### PR TITLE
Dino-A

### DIFF
--- a/dinosaur-A/README.md
+++ b/dinosaur-A/README.md
@@ -1,0 +1,37 @@
+# Dinosaur
+
+### Author
+[Opentrons](https://opentrons.com/)
+
+### Partner
+
+## Categories
+* Basic Pipetting
+	* Plate Pics
+
+## Description
+Draw a picture of a dinosaur on a 96 well plate using food coloring.
+
+### Time Estimate
+10 minutes
+
+### Robot
+* [OT PRO](https://opentrons.com/ot-one-pro)
+* [OT Standard](https://opentrons.com/ot-one-standard)  
+* [OT Hood](https://opentrons.com/ot-one-hood) 
+
+### Modules
+
+### Reagents
+* Blue Food Coloring
+* Green Food Coloring
+
+## Process
+1. Transfer blue food coloring to specific wells.
+2. Transfer green food coloring to specific wells.
+
+
+## Preview
+Learn how to use the robot by drawing a picture of a dinosaur in a 96 well plate!
+
+### Additional Notes

--- a/dinosaur-A/README.md
+++ b/dinosaur-A/README.md
@@ -1,4 +1,4 @@
-# Dinosaur
+# Dinosaur-A
 
 ### Author
 [Opentrons](https://opentrons.com/)
@@ -10,7 +10,7 @@
 	* Plate Pics
 
 ## Description
-Draw a picture of a dinosaur on a 96 well plate using food coloring.
+Draw a picture of a dinosaur on a 96 well plate using food coloring. This protocol is designed for the OT-One Standard model, which requires the pipette be on the "A" axis.
 
 ### Time Estimate
 10 minutes

--- a/dinosaur-A/dinosaur-A.py
+++ b/dinosaur-A/dinosaur-A.py
@@ -1,0 +1,46 @@
+from opentrons import containers, instruments
+
+
+# a 12 row trough for sources, and 96 well plate for output
+trough = containers.load('trough-12row', 'C1', 'trough')
+plate = containers.load('96-PCR-flat', 'D1', 'plate')
+
+# a tip rack for our pipette
+p200rack = containers.load('tiprack-200ul', 'B1', 'tiprack')
+
+# create a p200 pipette on robot axis B
+p200 = instruments.Pipette(
+    name="p200",
+    axis="a",
+    min_volume=20,
+    max_volume=200,
+    tip_racks=[p200rack]
+)
+
+# simple, atomic commands to control fine details
+p200.pick_up_tip()
+p200.aspirate(50, trough.wells('A1'))
+p200.dispense(plate.wells('D1'))
+
+# macro commands like .distribute() make writing long sequences easier
+p200.distribute(
+    50,
+    trough.wells('A1'),
+    plate.wells(
+        'E1', 'D2', 'E2', 'D3', 'E3', 'F3', 'G3', 'H3',
+        'C4', 'D4', 'E4', 'F4', 'G4', 'H4', 'C5', 'D5',
+        'E5', 'F5', 'G5', 'C6', 'D6', 'E6', 'F6', 'G6',
+        'C7', 'D7', 'E7', 'F7', 'G7', 'D8', 'E8', 'F8',
+        'G8', 'H8', 'E9', 'F9', 'G9', 'H9', 'F10', 'G11',
+        'H12'
+    )
+)
+
+p200.distribute(
+    50,
+    trough.wells('A2'),
+    plate.wells(
+        'C3', 'B4', 'A5', 'B5', 'B6', 'A7', 'B7',
+        'C8', 'C9', 'D9', 'E10', 'E11', 'F11', 'G12'
+    )
+)


### PR DESCRIPTION
Adds a 2nd version of the dinosaur protocol which simply uses axis A, so that anyone with an OT-One Standard can run dinosaur protocol without having to edit the protocol text.