### PR TITLE
update smoketest to run manually; fix 2 OT2 protocols

### DIFF
--- a/protocols/cDNA_synth/cDNA_synth.ot2.py
+++ b/protocols/cDNA_synth/cDNA_synth.ot2.py
@@ -1,3 +1,4 @@
+import os
 from opentrons import labware, instruments
 
 # tube rack holding reagents
@@ -70,7 +71,8 @@ p50multi.transfer(1, strip.cols(0), cdna_plate.cols(), new_tip='once')
 p50multi.transfer(1, samples.cols(), cdna_plate.cols(), new_tip='always')
 
 #  HOLD for 1.5hr for cDNA Synthesis
-p50single.delay(minutes=90)
+if not os.environ.get('OT_TESTING'):
+    p50single.delay(minutes=90)
 
 # Step7: Transfer 1 μl  of cDNA to another 96 well plate using multichannel
 # such well A1 to A1, B1 to B1. (QPCR Plate)

--- a/protocols/neut_dilution/neut_dilution.ot2.py
+++ b/protocols/neut_dilution/neut_dilution.ot2.py
@@ -22,9 +22,6 @@ tip200_rack = containers.load('tiprack-200ul', '1')
 tip200_rack2 = containers.load('tiprack-200ul', '4')
 tip200_rack3 = containers.load('tiprack-200ul', '7')
 
-# trash to dispose of tips
-trash = containers.load('fixed-trash', 12, 'trash')
-
 # p200 (20 - 200 uL) (single)
 p200single = instruments.P300_Single(
     mount='right',

--- a/protocols/plate_copying/plate_copying.ot2.py
+++ b/protocols/plate_copying/plate_copying.ot2.py
@@ -2,9 +2,11 @@ from opentrons import labware, instruments
 
 # Copy contents of one plate into another
 
+source_slot = '6'
+
 dest_slots = [
     '1',
-    '2', '3', '4', '5', '6',
+    '2', '3', '4', '5',
     '7', '8', '9']
 
 
@@ -50,7 +52,7 @@ def run_custom_protocol(
         labware.load(destination_container, slotName)
         for slotName in dest_slots]
 
-    source_plate = labware.load(source_container, 'C2')
+    source_plate = labware.load(source_container, source_slot)
 
     if ('384-plate' in [source_container, destination_container]
             and source_container != destination_container):

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1,21 +1,28 @@
 #!/usr/bin/env bash
 
-# Clean smoketest dir
-rm -rf smoketest/*.py
+# NOTE Ian 2018-04-25: this is meant to be run manually to check OT2 protocols.
+# For now, the user is responsible for installing the appropriate
+# python opentrons library for OT2 protocols.
+# 'otcustomizers' also must be installed.
 
-echo "Ignoring:"
-find . -name '*.ignore.py'
+# Clean smoketest dir
+echo "Clearing smoketest/ dir"
+rm -rf smoketest/
+mkdir smoketest
+
+python -c 'import opentrons; print("Smoke testing *.ot2.py protocols. Opentrons version:", opentrons.__version__)'
 
 echo "*****"
 
-# copy all non-ignored .py files to smoketest/
-find . -name '*.py' | grep -Ev '.*\.ignore\.py|.*/scripts/' | sort -f | while read filename; do
+# copy all *.ot2.py files to smoketest/
+find . -name '*.ot2.py' | sort -f | while read filename; do
     cp $filename smoketest/
 done
 
-find smoketest/ -name '*.py' | sort -f | while read pyfile; do
+
+find smoketest/ -name '*.ot2.py' | sort -f | while read pyfile; do
   if grep -Eq "^def run_custom_protocol\(" $pyfile; then
-    echo "Processing CUSTOMIZABLE protocol '$pyfile'"
+    echo "Processing CUSTOMIZABLE protocol '$pyfile' with default arguments"
     # add run_custom_protocol() call to end of all customizable protocols
     echo 'run_custom_protocol()' >> $pyfile
   else


### PR DESCRIPTION
# Overview

Amends `smoke-test.sh` to be used manually to check that OT2 protocols at least run under whatever version of `opentrons` python API you have installed.

I found 2 protocols that didn't run and attempted to fix them. And one had a long delay that would have made smoke testing take a long time. Please check my updates.

# To manually smoke-test OT2 protocols:

Install opentrons python API (eg `make dev` in opentrons monorepo), then:

```
pip install -e otcustomizers
./scripts/smoke-test.sh
```

# Known issues with `smoke-test.sh`

* Probably won't work on Windows?
* OT2 protocols using delay or time.sleep must only do it `if not os.environ.get('OT_TESTING'):`, or else that protocol will make the smoke tests delay/sleep for whatever interval
* `smoke-test.sh` does not ignore dirs with `.ignore` in them. To ignore a `*.ot2.py` file, rename it temporarily to something like `*ot2.py.ignore` or whatever -- just need to change the suffix so `smoke-test.sh` won't pick it up

Also, customizable protocols are only run with default arguments. There may easily be other arguments that cause it not to complete.