### PR TITLE
Removes ot2 parser until logic is in place to check protocol correctness

### DIFF
--- a/protolib/traverse.py
+++ b/protolib/traverse.py
@@ -110,10 +110,6 @@ def get_protocol_pyfile(protocol: dict):
     """
     pyfiles = protocol['detected-files'].get(OT_1_PROTOCOL)
 
-    if not pyfiles:
-
-        pyfiles = protocol['detected-files'].get(OT_2_PROTOCOL)
-
     pyfiles = filter(lambda f: not f.startswith('test_'), pyfiles)
     pyfiles = list(pyfiles)
     if not pyfiles:


### PR DESCRIPTION
## Overview

Traverse.py was attempting to parse through ot2 protocols wanting to be merged into develop. This caused errors as there is currently no logic to check OT 2 protocol API info

## Changelog
- Edits get_protocol_pyfile()