### PR TITLE
Add OT 2 version of cherry picking CSV

### DIFF
--- a/protocols/cherrypicking_csv/cherrypicking_csv.ot1.py
+++ b/protocols/cherrypicking_csv/cherrypicking_csv.ot1.py
@@ -18,7 +18,7 @@ def run_custom_protocol(
         pipette_axis: StringSelection(
             'B (left side)', 'A (right side)')='B (left side)',
         pipette_model: StringSelection(
-            'p200', 'p100', 'p50', 'p20', 'p10', 'p1000')='p200',
+            'p300', 'p50', 'p10', 'p1000')='p300',
         source_plate_type: StringSelection('96-flat', '384-plate')='96-flat',
         destination_plate_type: StringSelection(
             '96-flat', '384-plate')='96-flat',

--- a/protocols/cherrypicking_csv/cherrypicking_csv.ot2.py
+++ b/protocols/cherrypicking_csv/cherrypicking_csv.ot2.py
@@ -1,0 +1,64 @@
+from opentrons import containers, instruments
+from otcustomizers import FileInput, StringSelection
+
+example_csv = """
+A1, 20
+A3, 10
+B2, 15
+
+"""
+
+
+def run_custom_protocol(
+        volumes_csv: FileInput=example_csv,
+        pipette_axis: StringSelection(
+            'B (left side)', 'A (right side)')='B (left side)',
+        pipette_model: StringSelection(
+            'p1000', 'p300', 'p50', 'p10')='p300',
+        source_plate_type: StringSelection('96-flat', '384-plate')='96-flat',
+        destination_plate_type: StringSelection(
+            '96-flat', '384-plate')='96-flat',
+        tip_reuse: StringSelection(
+            'new tip each time', 'reuse tip')='new tip each time'
+        ):
+
+    pipette_max_vol = int(pipette_model[1:])
+    mount = 'left'
+    if pipette_axis[0] == 'B':
+        mount = 'right'
+
+    tiprack_slots = ['1', '4', '7', '10']
+
+    if pipette_max_vol == 300:
+        tipracks = [
+            containers.load('tiprack-200ul', slot) for slot in tiprack_slots]
+        pipette = instruments.P300_Single(mount=mount, tip_racks=[tipracks])
+    elif pipette_max_vol == 50:
+        tipracks = [
+            containers.load('tiprack-200ul', slot) for slot in tiprack_slots]
+        pipette = instruments.P50_Single(mount=mount, tip_racks=[tipracks])
+    elif pipette_max_vol == 10:
+        tipracks = [
+            containers.load('tiprack-200ul', slot) for slot in tiprack_slots]
+        pipette = instruments.P10_Single(mount=mount, tip_racks=[tipracks])
+    elif pipette_max_vol == 1000:
+        tipracks = [
+            containers.load('tiprack-200ul', slot) for slot in tiprack_slots]
+        pipette = instruments.P1000_Single(mount=mount, tip_racks=[tipracks])
+
+    data = [
+        [well, float(vol)]
+        for well, vol in
+        [row.split(',') for row in volumes_csv.strip().split('\n') if row]
+    ]
+
+    source_plate = containers.load(source_plate_type, '2')
+    dest_plate = containers.load(destination_plate_type, '3')
+
+    tip_strategy = 'always' if tip_reuse == 'new tip each time' else 'once'
+    for well_idx, (source_well, vol) in enumerate(data):
+        pipette.transfer(
+            vol,
+            source_plate.wells(source_well),
+            dest_plate.wells(well_idx),
+            new_tip=tip_strategy)


### PR DESCRIPTION
## Overview
This protocol was never converted to the OT 2 format since the custom field names will be taken directly from OT 1 version. Customer requested this protocol to be converted so some changes were required for this to be done.

## Changelog
- Adds OT 2 version
- Edits OT 1 version so that field names (temporarily) make sense.