### PR TITLE
Add module support in OT 2 parser

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ SHELL := /bin/bash
 
 MONOREPO_URI := https://github.com/Opentrons/opentrons.git
 OT1_VERSION := 2.5.2
-OT2_VERSION_TAG := v3.2.0-beta.1
+OT2_VERSION_TAG := v3.3.0
 OT2_MONOREPO_DIR := ot2monorepoClone
 
 OT1_FILE_SUFFIX := *.ot1.py


### PR DESCRIPTION
## Overview
PL parser did not support modules (or 3.3.0 software update). This caused some protocols to fail the parser in protocol-delivery branch.

## Changelog
- Adds load spy for modules
- Tracks all modules found in a given protocol

## TODO
- Add the modules found in the return statement for the parser so the deckmap knows where those modules are located.