### PR TITLE
Update all OT 2 protocols from containers -> labware

### DIFF
--- a/protocols/10X_serial_dilution/10x_serial_dilution.ot2.py
+++ b/protocols/10X_serial_dilution/10x_serial_dilution.ot2.py
@@ -1,9 +1,9 @@
-from opentrons import containers, instruments, robot
+from opentrons import labware, instruments, robot
 
-trough = containers.load('trough-12row', '5', 'trough')
-plate = containers.load('96-PCR-flat', '3', 'plate')
+trough = labware.load('trough-12row', '5', 'trough')
+plate = labware.load('96-PCR-flat', '3', 'plate')
 
-m300rack = containers.load('tiprack-200ul', '1', 'm300-rack')
+m300rack = labware.load('tiprack-200ul', '1', 'm300-rack')
 trash = robot.fixed_trash
 
 m300 = instruments.P300_Multi(

--- a/protocols/buffer_mix_dilute/buffer_mix_dilute.ot2.py
+++ b/protocols/buffer_mix_dilute/buffer_mix_dilute.ot2.py
@@ -1,11 +1,11 @@
-from opentrons import containers, instruments
+from opentrons import labware, instruments
 
-trough = containers.load('trough-12row', '3', 'trough')
-plate = containers.load('96-deep-well', '2', 'plate')
-tubes = containers.load('tube-rack-2ml', '8', 'tubes')
+trough = labware.load('trough-12row', '3', 'trough')
+plate = labware.load('96-deep-well', '2', 'plate')
+tubes = labware.load('tube-rack-2ml', '8', 'tubes')
 
-multirack = containers.load('tiprack-200ul', '1', 'p300rack')
-singlerack = containers.load('tiprack-200ul', '4', 'p300rack')
+multirack = labware.load('tiprack-200ul', '1', 'p300rack')
+singlerack = labware.load('tiprack-200ul', '4', 'p300rack')
 
 
 m300 = instruments.P300_Multi(

--- a/protocols/cherrypicking_csv/cherrypicking_csv.ot2.py
+++ b/protocols/cherrypicking_csv/cherrypicking_csv.ot2.py
@@ -1,4 +1,4 @@
-from opentrons import containers, instruments
+from opentrons import labware, instruments
 from otcustomizers import FileInput, StringSelection
 
 example_csv = """
@@ -31,19 +31,19 @@ def run_custom_protocol(
 
     if pipette_max_vol == 300:
         tipracks = [
-            containers.load('tiprack-200ul', slot) for slot in tiprack_slots]
+            labware.load('tiprack-200ul', slot) for slot in tiprack_slots]
         pipette = instruments.P300_Single(mount=mount, tip_racks=[tipracks])
     elif pipette_max_vol == 50:
         tipracks = [
-            containers.load('tiprack-200ul', slot) for slot in tiprack_slots]
+            labware.load('tiprack-200ul', slot) for slot in tiprack_slots]
         pipette = instruments.P50_Single(mount=mount, tip_racks=[tipracks])
     elif pipette_max_vol == 10:
         tipracks = [
-            containers.load('tiprack-200ul', slot) for slot in tiprack_slots]
+            labware.load('tiprack-200ul', slot) for slot in tiprack_slots]
         pipette = instruments.P10_Single(mount=mount, tip_racks=[tipracks])
     elif pipette_max_vol == 1000:
         tipracks = [
-            containers.load('tiprack-200ul', slot) for slot in tiprack_slots]
+            labware.load('tiprack-200ul', slot) for slot in tiprack_slots]
         pipette = instruments.P1000_Single(mount=mount, tip_racks=[tipracks])
 
     data = [
@@ -52,8 +52,8 @@ def run_custom_protocol(
         [row.split(',') for row in volumes_csv.strip().split('\n') if row]
     ]
 
-    source_plate = containers.load(source_plate_type, '2')
-    dest_plate = containers.load(destination_plate_type, '3')
+    source_plate = labware.load(source_plate_type, '2')
+    dest_plate = labware.load(destination_plate_type, '3')
 
     tip_strategy = 'always' if tip_reuse == 'new tip each time' else 'once'
     for well_idx, (source_well, vol) in enumerate(data):

--- a/protocols/dinosaur/dinosaur.ot2.py
+++ b/protocols/dinosaur/dinosaur.ot2.py
@@ -1,14 +1,14 @@
-from opentrons import containers, instruments
+from opentrons import labware, instruments
 from otcustomizers import StringSelection
 
 # a 12 row trough for sources
-trough = containers.load('trough-12row', 8)
+trough = labware.load('trough-12row', 8)
 
 # plate to create dinosaur in
-plate = containers.load('96-PCR-flat', 3)
+plate = labware.load('96-PCR-flat', 3)
 
 # a tip rack for our pipette
-p200rack = containers.load('tiprack-200ul', 6)
+p200rack = labware.load('tiprack-200ul', 6)
 
 # wells to dispense dinosaur body in green
 green_wells = [

--- a/protocols/media_exchange/Media_Exchange.ot2.py
+++ b/protocols/media_exchange/Media_Exchange.ot2.py
@@ -1,4 +1,4 @@
-from opentrons import containers, instruments
+from opentrons import labware, instruments
 
 """
 Workflow description: Step1: pick up tips from a 10 ul-tip rack
@@ -14,20 +14,20 @@ Step6: Repeat Steps1-5 for the remaining rows (second, third, fourth etc.)
 """
 A
 """
-output = containers.load('96-flat', '1')
+output = labware.load('96-flat', '1')
 
 
 """
 B
 """
-tiprack = containers.load('tiprack-10ul', '2')
+tiprack = labware.load('tiprack-10ul', '2')
 
 
 """
 C
 """
-plate_48 = containers.load('48-well-plate', '3', share=True)
-plate_96 = containers.load('96-flat', '3', share=True)
+plate_48 = labware.load('48-well-plate', '3', share=True)
+plate_96 = labware.load('96-flat', '3', share=True)
 
 
 p10single = instruments.P10_Single(

--- a/protocols/neut_dilution/neut_dilution.ot2.py
+++ b/protocols/neut_dilution/neut_dilution.ot2.py
@@ -5,22 +5,22 @@ neut_dilution
 OT-2
 """
 
-from opentrons import containers, instruments
+from opentrons import labware, instruments
 
 # solutions in trough
-trough = containers.load('trough-12row', '3')
+trough = labware.load('trough-12row', '3')
 
 # tube rack holding reagents
-reagents = containers.load('tube-rack-.75ml', '6')
+reagents = labware.load('tube-rack-.75ml', '6')
 
 # 96 well plates
-flat_plate = containers.load('96-PCR-flat', '2')
-deep_plate = containers.load('96-deep-well', '5')
+flat_plate = labware.load('96-PCR-flat', '2')
+deep_plate = labware.load('96-deep-well', '5')
 
 # tip rack for p10 and p50 pipette
-tip200_rack = containers.load('tiprack-200ul', '1')
-tip200_rack2 = containers.load('tiprack-200ul', '4')
-tip200_rack3 = containers.load('tiprack-200ul', '7')
+tip200_rack = labware.load('tiprack-200ul', '1')
+tip200_rack2 = labware.load('tiprack-200ul', '4')
+tip200_rack3 = labware.load('tiprack-200ul', '7')
 
 # p200 (20 - 200 uL) (single)
 p200single = instruments.P300_Single(

--- a/protocols/plate_copying/plate_copying.ot2.py
+++ b/protocols/plate_copying/plate_copying.ot2.py
@@ -43,7 +43,7 @@ def run_custom_protocol(
         destination_container: StringSelection(*container_choices)='96-flat',
         number_of_destination_plates: int=4):
 
-    # Load containers
+    # Load labware
     all_dest_plates = [
         labware.load(destination_container, slotName)
         for slotName in dest_slots]

--- a/protocols/tube_to_384/tube_to_384.ot2.py
+++ b/protocols/tube_to_384/tube_to_384.ot2.py
@@ -1,8 +1,8 @@
-from opentrons import containers, instruments
+from opentrons import labware, instruments
 
-p200rack = containers.load('tiprack-200ul', '10')
-sample_tubes = containers.load('tube-rack-2ml', '11')
-plate = containers.load('384-plate', '9')
+p200rack = labware.load('tiprack-200ul', '10')
+sample_tubes = labware.load('tube-rack-2ml', '11')
+plate = labware.load('384-plate', '9')
 
 p200 = instruments.P300_Single(
     mount="right",


### PR DESCRIPTION
## Overview
Labware was not showing up on certain OT 2 protocol deckmaps because the parser does not support the deprecated 'containers' value.

## Changelog
Replace all instances of `containers` found in the protocols directory.