### PR TITLE
try only 1 hash (#) in custom serial dilution README

### DIFF
--- a/protocols/customizable_serial_dilution/README.md
+++ b/protocols/customizable_serial_dilution/README.md
@@ -15,14 +15,14 @@ This protocol uses the inputs you define for ***dilution factor*** and ***diluti
 ***Example:*** For a 1 in 10 dilution series, if you define a ***dilution volume*** of 100uL and a ***dilution factor*** of 10, your OT-2 will first add 90uL of diluent to each well in your plate, then transfer 10uL between each well in the plate.
 ![serial dilution](https://s3.amazonaws.com/opentrons-protocol-library-website/custom-README-images/customizable-serial-dilution/Screen+Shot+2018-09-25+at+2.41.51+PM.png)
 
-### User-Defined Inputs
+# User-Defined Inputs
 * Pipette Type (defined for left mount only)
-* Dilution factor 
+* Dilution factor
 * Number of dilutions (max: 11)
 * Dilution volume (Sample + Diluent)
 * Tip Reuse Strategy (default: reuse one tip throughout dilution series)
 
-### Materials Needed
+# Materials Needed
 * [Opentrons OT-2](http://opentrons.com/ot-2)
 * [Opentrons OT-2 Run App (Version 3.1.2 or later)](http://opentrons.com/ot-app)
 * 200uL or 300 uL Tiprack - [Opentrons tips suggested](https://shop.opentrons.com/collections/opentrons-tips/products/opentrons-300ul-tips-racks-9-600-tips)
@@ -50,6 +50,6 @@ This protocol uses the inputs you define for ***dilution factor*** and ***diluti
 Customizable Serial Dilution, v1
 
 ### Additional Notes
-Please reference our [Technical Note](https://docs.google.com/document/d/1cwSAS52fSBOEI0Hb7U2paq5jS_G1LN2fB5TssJp-Au0/edit?usp=sharing) for more information about the expected output of this protocol, in addition to expanded sample data from the Opentrons lab. 
+Please reference our [Technical Note](https://docs.google.com/document/d/1cwSAS52fSBOEI0Hb7U2paq5jS_G1LN2fB5TssJp-Au0/edit?usp=sharing) for more information about the expected output of this protocol, in addition to expanded sample data from the Opentrons lab.
 
 We understand that there are limitations to the use of this protocol, and we plan to make improvements soon. In the meantime, if you'd like to request a more complex dilution workflow, please use our [Protocol Development Request Form](https://opentrons-protocol-dev.paperform.co/). You can also download this Python file and modify it using our [API Documentation](https://docs.opentrons.com/). For additional questions about this protocol, please email support@opentrons.com.


### PR DESCRIPTION
Addresses Opentrons/opentrons#2337 let's see what happens

Guessing that if we avoid double hashes, the `is_header = re.compile(r'^ *##+ *(.*)$')` in `get_header` won't pull out the header that we wanted to show.

One day we'll keep data in formats meant for data, and keep rich text in formats meant for rich text :face_with_head_bandage: 