### PR TITLE
Fix cherrypicking CSV

### DIFF
--- a/protocols/cherrypicking_csv/cherrypicking_csv.ot2.py
+++ b/protocols/cherrypicking_csv/cherrypicking_csv.ot2.py
@@ -32,19 +32,19 @@ def run_custom_protocol(
     if pipette_max_vol == 300:
         tipracks = [
             labware.load('tiprack-200ul', slot) for slot in tiprack_slots]
-        pipette = instruments.P300_Single(mount=mount, tip_racks=[tipracks])
+        pipette = instruments.P300_Single(mount=mount, tip_racks=tipracks)
     elif pipette_max_vol == 50:
         tipracks = [
             labware.load('tiprack-200ul', slot) for slot in tiprack_slots]
-        pipette = instruments.P50_Single(mount=mount, tip_racks=[tipracks])
+        pipette = instruments.P50_Single(mount=mount, tip_racks=tipracks)
     elif pipette_max_vol == 10:
         tipracks = [
             labware.load('tiprack-200ul', slot) for slot in tiprack_slots]
-        pipette = instruments.P10_Single(mount=mount, tip_racks=[tipracks])
+        pipette = instruments.P10_Single(mount=mount, tip_racks=tipracks)
     elif pipette_max_vol == 1000:
         tipracks = [
             labware.load('tiprack-200ul', slot) for slot in tiprack_slots]
-        pipette = instruments.P1000_Single(mount=mount, tip_racks=[tipracks])
+        pipette = instruments.P1000_Single(mount=mount, tip_racks=tipracks)
 
     data = [
         [well, float(vol)]


### PR DESCRIPTION
## Overview
A previous error that was found (in which tipracks were added to a pipette constructor as a double-nested list). This was fixed in another branch, but develop and master were not updated.