### PR TITLE
[Chore] Fix-1410-rick-tarletons-lab-university-of-georgia

### DIFF
--- a/protocols/1410-rick-tarletons-lab-university-of-georgia/cell_fixation.ot2.py
+++ b/protocols/1410-rick-tarletons-lab-university-of-georgia/cell_fixation.ot2.py
@@ -24,7 +24,7 @@ m300 = instruments.P300_Multi(
     tip_racks=[tiprack])
 
 
-def run_custom_protocols(
+def run_custom_protocol(
         number_of_384_well_plates: int=2):
 
     plates = [labware.load('384-plate', slot)


### PR DESCRIPTION
Customization field was not showing on the protocol library 
[Link](http://protocol-delivery.protocols.opentrons.com/protocol/1410-rick-tarletons-lab-university-of-georgia) 