### PR TITLE
[chore]fix-1327-van-andel-research-institute-2

### DIFF
--- a/protocols/1327-van-andel-research-institute/README.md
+++ b/protocols/1327-van-andel-research-institute/README.md
@@ -8,7 +8,7 @@
     * DNA
 
 ## Description
-With this protocol, your robot will be able to perform dilutions on 72 samples by diluting each sample from a 1.5 mL micro-centrifuge tube in a (0.5 mL screwcap tube)[https://us.vwr.com/store/product/4674084/vwr-screw-cap-microcentrifuge-tubes]. The volumes of each dilution will be provided in the form of a CSV file. Please see Additional Notes for the CSV formatting requirements.
+With this protocol, your robot will be able to perform dilutions on 72 samples by diluting each sample from a 2.0 mL eppendorf tube. The volumes of each dilution will be provided in the form of a CSV file. Please see Additional Notes for the CSV formatting requirements.
 
 ### Robot
 * [OT-2](https://opentrons.com/ot-2)
@@ -19,7 +19,7 @@ With this protocol, your robot will be able to perform dilutions on 72 samples b
 
 ## Process
 1. Upload your dilution CSV.
-2. Input the total volume of diluent in the 50 mL conical tube. (We recommend always having more than enough volume of diluent in the conical tube.)
+2. Input the total volume of diluent in the 15 mL conical tube. (We recommend always having more than enough volume of diluent in the conical tube.)
 3. Select whether or not you would like to mix the sample in after each transfer.
 4. Download your protocol.
 5. Upload your protocol into the [OT App](https://opentrons.com/ot-app).
@@ -35,7 +35,7 @@ Samples setup(1.5 mL Eppendorf tubes)
 2. Slot 2: Well A1-H12
 3. Slot 3: Well A1-H12
 
-Dilution Outputs setup(0.5 mL Screwcap tubes)
+Dilution Outputs setup
 1. Slot 4: Well A1-H12
 2. Slot 5: Well A1-H12
 3. Slot 6: Well A1-H12Â

--- a/protocols/1327-van-andel-research-institute/nucleic_acid_normalization.ot2.py
+++ b/protocols/1327-van-andel-research-institute/nucleic_acid_normalization.ot2.py
@@ -2,6 +2,12 @@ from opentrons import labware, instruments
 from otcustomizers import StringSelection, FileInput
 import math
 
+metadat = {
+    'protocolName': 'Nucleic Acid Normalization',
+    'author': 'Alise <protocols@opentrons.com>',
+    'source': 'Custom Protocol Request'
+    }
+
 # labware setup
 source_racks = [labware.load('opentrons-tuberack-2ml-eppendorf', slot)
                 for slot in ['1', '2', '3']]

--- a/protocols/1327-van-andel-research-institute/nucleic_acid_normalization.ot2.py
+++ b/protocols/1327-van-andel-research-institute/nucleic_acid_normalization.ot2.py
@@ -6,13 +6,10 @@ import math
 source_racks = [labware.load('opentrons-tuberack-2ml-eppendorf', slot)
                 for slot in ['1', '2', '3']]
 
-dest_racks = [labware.load('opentrons-tuberack-2ml-screwcap', slot)
+dest_racks = [labware.load('opentrons-tuberack-2ml-eppendorf', slot)
               for slot in ['4', '5', '6']]
-for rack in dest_racks:
-    for well in rack:
-        well.properties['height'] = 24
 
-diluent = labware.load('opentrons-tuberack-50ml', '7').wells('A1')
+diluent = labware.load('opentrons-tuberack-15ml', '7').wells('A1')
 
 tipracks_300 = [labware.load('opentrons-tiprack-300ul', slot)
                 for slot in ['8', '9']]
@@ -66,7 +63,7 @@ def run_custom_protocol(
 
     sample_volumes, diluent_volumes = csv_to_list(dilution_csv)
     diluent_height = 20 + \
-        (50-total_diluent_volume) * 1000 / (math.pi * (15 ** 2))
+        (50-total_diluent_volume) * 1000 / (math.pi * (8 ** 2))
 
     if mix_after_each_transfer == "True":
         mix_num = 3
@@ -77,7 +74,7 @@ def run_custom_protocol(
     dests = [well for rack in dest_racks for well in rack]
 
     for index, vol in enumerate(diluent_volumes):
-        diluent_height += vol / (math.pi * (15 ** 2))
+        diluent_height += vol / (math.pi * (8 ** 2))
         if vol >= 50:
             if not p300.tip_attached:
                 p300.pick_up_tip()


### PR DESCRIPTION
# Per user's request:

Line 8: 'opentrons-tuberack-2ml-eppendorf' instead of 'opentrons-tuberack-2ml-screwcap'

Lines 10-12: Remove custom rube height, default is fine

Line 14: 'opentrons-tuberack-15ml' instead of 'opentrons-tuberack-50ml'

Line 66: csv_to_list(dilution_csv) instead of csv_to_list(csv_example)

Lines 68 and 70: (math.pi * (8 ** 2)) instead of (math.pi * (15 ** 2))