### PR TITLE
ci(travis): remove sudo false

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 language: python
 python:
 - '3.5'


### PR DESCRIPTION
remove `sudo: false` b/c Travis deprecated container-based Linux
infrastructure
https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration