### PR TITLE
[chore] Update 384-plate filling on master

### DIFF
--- a/protocols/384_plate_filling/384_plate_filling.ot1.py
+++ b/protocols/384_plate_filling/384_plate_filling.ot1.py
@@ -6,18 +6,53 @@ trough = containers.load('trough-12row', 'E1', 'trough')
 plate = containers.load('384-plate', 'C1', 'plate')
 
 # 8-channel 10uL pipette, with tip rack and trash
-tiprack = containers.load('tiprack-200ul', 'A1', 'p200rack')
 trash = containers.load('trash-box', 'B2', 'trash')
 
 
-def run_custom_protocol(well_volume: float=1.0, pipette_type: StringSelection(
-    'p300-Single', 'p50-Single', 'p10-Single',
-        'p300-Multi', 'p50-Multi', 'p10-Multi')='p50-Multi'):
+def run_custom_protocol(
+        well_volume: float = 1.0,
+        reagent_well: StringSelection(
+            'A1', 'A2', 'A3', 'A4', 'A5', 'A6',
+            'A7', 'A8', 'A9', 'A10', 'A11', 'A12') = 'A1',
+        plate_starting_column: str = '1',
+        number_of_columns_to_fill: int = 24,
+        pipette_type: StringSelection('p300-Single', 'p50-Single',
+                                      'p10-Single', 'p300-Multi', 'p50-Multi',
+                                      'p10-Multi', 'p200-Single',
+                                      'p200-Multi') = 'p50-Multi',
+        mix_reagent_before_transfer: StringSelection(
+            'True', 'False') = 'True'):
+
+    if int(plate_starting_column) <= 0 or int(plate_starting_column) > 24:
+        raise Exception("Plate starting column number must be 1-24.")
+    if (int(plate_starting_column) + number_of_columns_to_fill) > 25:
+        raise Exception("Number of columns to fill exceeds plate's limit.")
+
+    if mix_reagent_before_transfer == 'False':
+        mix_times = 0
+    else:
+        mix_times = 5
+
     pip_name = pipette_type.split('-')  # Check which pipette type
-    chan = 1  # Number of channels
+
+    if pip_name[0] == 'p10':
+        tiprack = containers.load('tiprack-10ul', 'A1', 'p10rack')
+    else:
+        tiprack = containers.load('tiprack-200ul', 'A1', 'p300rack')
+
+    if pip_name[0] != 'p10' and well_volume < 5:
+        raise Exception("Cannot transfer volume this small without p10.")
+    if pip_name[0] == 'p20' and well_volume < 20:
+        raise Exception("Cannot transfer volume this small with p200.")
+    if pip_name[0] == 'p30' and well_volume < 30:
+        raise Exception("Cannot transfer volume this small with p300.")
+
+    # create pipette
+    if pip_name[1] == 'Single':
+        chan = 1  # Number of channels
     if pip_name[1] == 'Multi':
         chan = 8
-    vol = int(pip_name[0][1::])
+    vol = int(pip_name[0][1:])
     pipette = instruments.Pipette(
         axis='b',
         max_volume=vol,
@@ -36,6 +71,6 @@ def run_custom_protocol(well_volume: float=1.0, pipette_type: StringSelection(
 
     pipette.distribute(
         well_volume,
-        trough.wells('A1'),
+        trough.wells(reagent_well),
         alternating_wells,
-        mix_before=(5, pipette.max_volume))
+        mix_before=(mix_times, pipette.max_volume))

--- a/protocols/384_plate_filling/384_plate_filling.ot1.py
+++ b/protocols/384_plate_filling/384_plate_filling.ot1.py
@@ -10,7 +10,7 @@ trash = containers.load('trash-box', 'B2', 'trash')
 
 
 def run_custom_protocol(
-        well_volume: float = 1.0,
+        well_volume: float = 50.0,
         reagent_well: StringSelection(
             'A1', 'A2', 'A3', 'A4', 'A5', 'A6',
             'A7', 'A8', 'A9', 'A10', 'A11', 'A12') = 'A1',

--- a/protocols/384_plate_filling/384_plate_filling.ot1.py
+++ b/protocols/384_plate_filling/384_plate_filling.ot1.py
@@ -14,8 +14,8 @@ def run_custom_protocol(
         reagent_well: StringSelection(
             'A1', 'A2', 'A3', 'A4', 'A5', 'A6',
             'A7', 'A8', 'A9', 'A10', 'A11', 'A12') = 'A1',
-        plate_starting_column: str = '1',
-        number_of_columns_to_fill: int = 24,
+        plate_starting_row: str = '1',
+        number_of_rows_to_fill: int = 24,
         pipette_type: StringSelection('p300-Single', 'p50-Single',
                                       'p10-Single', 'p300-Multi', 'p50-Multi',
                                       'p10-Multi', 'p200-Single',
@@ -23,9 +23,9 @@ def run_custom_protocol(
         mix_reagent_before_transfer: StringSelection(
             'True', 'False') = 'True'):
 
-    if int(plate_starting_column) <= 0 or int(plate_starting_column) > 24:
+    if int(plate_starting_row) <= 0 or int(plate_starting_row) > 24:
         raise Exception("Plate starting column number must be 1-24.")
-    if (int(plate_starting_column) + number_of_columns_to_fill) > 25:
+    if (int(plate_starting_row) + number_of_rows_to_fill) > 25:
         raise Exception("Number of columns to fill exceeds plate's limit.")
 
     if mix_reagent_before_transfer == 'False':
@@ -60,17 +60,17 @@ def run_custom_protocol(
         channels=chan,
         trash_container=trash)
 
-    alternating_wells = []
-    for row in plate.rows():
-        if pip_name[1] == 'Multi':
+    if pip_name[1] == 'Multi':
+        alternating_wells = []
+        for row in plate.rows(plate_starting_row, to='24'):
             alternating_wells.append(row.wells('A'))
             alternating_wells.append(row.wells('B'))
-        else:
-            alternating_wells.append(row.wells('A', length=8, step=2))
-            alternating_wells.append(row.wells('B', length=8, step=2))
+        dests = alternating_wells[:number_of_rows_to_fill * 2]
+    else:
+        dests = plate.rows(plate_starting_row, length=number_of_rows_to_fill)
 
     pipette.distribute(
         well_volume,
         trough.wells(reagent_well),
-        alternating_wells,
+        dests,
         mix_before=(mix_times, pipette.max_volume))

--- a/protocols/384_plate_filling/384_plate_filling.ot2.py
+++ b/protocols/384_plate_filling/384_plate_filling.ot2.py
@@ -1,24 +1,45 @@
 from opentrons import instruments, labware
 from otcustomizers import StringSelection
 
-metadata = {
-    'protocolName': '384 Well Plate Filling',
-    'author': 'Opentrons <protocols@opentrons.com>',
-    'source': 'Protocol Library'
-    }
-
 # trough and 384-well plate
 trough = labware.load('trough-12row', '4', 'trough')
 plate = labware.load('384-plate', '2', 'plate')
 
-# 8-channel 10uL pipette, with tip rack and trash
-tiprack = labware.load('tiprack-200ul', '1', 'p200rack')
 
+def run_custom_protocol(
+        well_volume: float = 50.0,
+        reagent_well: StringSelection(
+            'A1', 'A2', 'A3', 'A4', 'A5', 'A6',
+            'A7', 'A8', 'A9', 'A10', 'A11', 'A12') = 'A1',
+        plate_starting_column: str = '1',
+        number_of_columns_to_fill: int = 24,
+        pipette_type: StringSelection(
+            'p300-Single', 'p50-Single', 'p10-Single',
+            'p300-Multi', 'p50-Multi', 'p10-Multi') = 'p50-Multi',
+        mix_reagent_before_transfer: StringSelection(
+            'True', 'False') = 'True'):
 
-def run_custom_protocol(well_volume: float=1.0, pipette_type: StringSelection(
-    'p300-Single', 'p50-Single', 'p10-Single',
-        'p300-Multi', 'p50-Multi', 'p10-Multi')='p300-Single'):
+    if int(plate_starting_column) <= 0 or int(plate_starting_column) > 24:
+        raise Exception("Plate starting column number must be 1-24.")
+    if (int(plate_starting_column) + number_of_columns_to_fill) > 25:
+        raise Exception("Number of columns to fill exceeds plate's limit.")
+
+    if mix_reagent_before_transfer == 'False':
+        mix_times = 0
+    else:
+        mix_times = 5
+
     pip_name = pipette_type.split('-')  # Check which pipette type
+
+    if pip_name[0] == 'p10':
+        tiprack = labware.load('tiprack-10ul', '1', 'p10rack')
+    else:
+        tiprack = labware.load('opentrons-tiprack-300ul', '1', 'p300rack')
+
+    if pip_name[0] != 'p10' and well_volume < 5:
+        raise Exception("Cannot transfer volume this small without p10.")
+    if pip_name[0] == 'p30' and well_volume < 30:
+        raise Exception("Cannot transfer volume this small with p300.")
 
     if pipette_type == 'p300-Single':
         pipette = instruments.P300_Single(
@@ -45,13 +66,18 @@ def run_custom_protocol(well_volume: float=1.0, pipette_type: StringSelection(
             mount='left',
             tip_racks=[tiprack])
 
-    alternating_wells = []
-    for column in plate.cols():
-        if pip_name[1] == 'Multi':
+    if pip_name[1] == 'Multi':
+        alternating_wells = []
+        for column in plate.cols(plate_starting_column, to='24'):
             alternating_wells.append(column.wells('A'))
             alternating_wells.append(column.wells('B'))
-        else:
-            alternating_wells.append(column.wells('A', length=8, step=2))
-            alternating_wells.append(column.wells('B', length=8, step=2))
+        dests = alternating_wells[:number_of_columns_to_fill * 2]
+    else:
+        dests = plate.cols(
+            plate_starting_column, length=number_of_columns_to_fill)
 
-    pipette.distribute(well_volume, trough.wells('A1'), alternating_wells)
+    pipette.distribute(
+        well_volume,
+        trough.wells(reagent_well),
+        dests,
+        mix_before=(mix_times, pipette.max_volume))

--- a/protocols/384_plate_filling/README.md
+++ b/protocols/384_plate_filling/README.md
@@ -7,37 +7,35 @@
 
 ## Categories
 * Basic Pipetting
-	* Plate Filling
+		* Plate Filling
 
 ## Description
-With this protocol, your robot can fill each well of a 384 well plate from a source 12-row trough using any sized pipette from
+With this protocol, your robot can fill each well of a 384-well plate from a source 12-row trough using any sized pipette from
 p10-p300 (without tip changes). This can be particularly useful for cell culture seeding, PCR master mix distribution, and more!
 Use the field labeled "well volume" below to define your preferred volume. You can input any volume from 1-300uL.
 
-### Time Estimate
+---
+
+You will need:
+* [Opentrons electronic pipette](https://shop.opentrons.com/collections/ot-2-pipettes)
+* [10µl or 300µl Opentrons pipette tips](https://shop.opentrons.com/collections/opentrons-tips)
+* 384-well plate
+* [12-row trough](https://www.usascientific.com/12-channel-automation-reservoir.aspx)
 
 ### Robot
-* [OT PRO](https://opentrons.com/ot-one-pro)
-* [OT Standard](https://opentrons.com/ot-one-standard)  
-* [OT Hood](https://opentrons.com/ot-one-hood)
-
-### Modules
-
-### Reagents
+* [OT-2 or OT-One S](https://shop.opentrons.com/)
 
 ## Process
-1. Input your desired volume into the "well volume" field above.
+1. Input your desired well volume, reagent well, plate starting column, number of columns to fill, pipette type, and whether to mix reagent before pipetting into the corresponding fields above.
 2. Download your protocol.
 3. Upload your protocol into the [OT App](http://opentrons.com/ot-app).
 4. Set up your deck according to the deck map.
 5. Calibrate your tiprack, pipette, and labware using the OT app. For calibration tips, check out our [support articles](https://support.opentrons.com/getting-started/software-setup/calibrating-the-pipettes).
 6. Hit "run".
-7. The robot will pick up one row of tips and dispense your defined volume into each well of the 384 well plate, until it is completely filled.
+7. The robot will pick up one row of tips and dispense your defined volume into each well of the 384-well plate, until it is completely filled.
 
 ### Additional Notes
 * You can get a preview of the action in this [video](https://www.youtube.com/watch?v=AWKfpK9rmuo).
 * One row of tips is used throughout the entire run. If you want to implement tip changes or modify your pipette size, see our [API documentation](https://docs.opentrons.com) for tips on how to modify your Python script.
-
-
 
 ###### Internal


### PR DESCRIPTION
<!--
  To ensure your code is reviewed quickly and thoroughly, please fill out the
  sections below to the best of your ability!
-->

## overview

changes to 384 protocols and README on master
<!--
  Use this section to describe your pull-request at a high level. If the PR
  addresses any open issues, please tag the issues here.
-->

## changelog

#### 3/8/19
in both ot1 and ot2 scripts:
- fixed 'mix' if/else logic
- threw exceptions for impossible volume+pipette combos
- changed type for default 'column start' argument to string
- checked for plate starting column <= 0 instead of < 0

in README:
- adhered to new template

#### 3/11/19
fixed filling in OT1 to include parameter for number of rows to fill

<!--
  List out the changes to the code in this PR. Please try your best to
  categorize your changes and describe what has changed and why.

  Example changelog:
  - Fixed app crash when trying to calibrate an illegal pipette
  - Added state to API to track pipette usage
  - Updated API docs to mention only two pipettes are supported

  IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

## review requests

Alise
<!--
  Describe any requests for your reviewers here.
-->
