### PR TITLE
fix-1288-biofire-diagnostics

### DIFF
--- a/protocols/1288-biofire-diagnostics/biofire_diagnostics.ot2.py
+++ b/protocols/1288-biofire-diagnostics/biofire_diagnostics.ot2.py
@@ -33,7 +33,7 @@ p2 = instruments.P300_Multi(
 def run_custom_protocol(
         reagent_volume: float=1000):
 
-    tip_loc = [col for plate in plates for col in plate.cols()]
+    tip_loc = [col for tiprack in tipracks for col in tiprack.cols()]
     plate_loc = [col for plate in plates for col in plate.cols()]
 
     for index, (col_1, col_2) in enumerate(zip(


### PR DESCRIPTION
<!--
  To ensure your code is reviewed quickly and thoroughly, please fill out the
  sections below to the best of your ability!
-->

## overview
User observed that the tip racks are not showing up in the App during calibration. Pipettes were not picking up tips at the correct location.
<!--
  Use this section to describe your pull-request at a high level. If the PR
  addresses any open issues, please tag the issues here.
-->

## changelog
- rather than picking tips from the plates, pick up tips from tip racks
<!--
  List out the changes to the code in this PR. Please try your best to
  categorize your changes and describe what has changed and why.

  Example changelog:
  - Fixed app crash when trying to calibrate an illegal pipette
  - Added state to API to track pipette usage
  - Updated API docs to mention only two pipettes are supported

  IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

## review requests
standard
<!--
  Describe any requests for your reviewers here.
-->
