### PR TITLE
fix PCR Prep on Develop

### DIFF
--- a/protocols/pcr_prep_part_2/pcr_prep-part2.ot2.py
+++ b/protocols/pcr_prep_part_2/pcr_prep-part2.ot2.py
@@ -12,36 +12,33 @@ metadata = {
 def run_custom_protocol(
         number_of_samples: int=96,
         left_pipette: StringSelection(
-            'p10-multi', 'P50-multi', 'p300-multi')='p50-multi',
+            'p10-multi', 'P50-multi', 'p300-multi', 'none')='p50-multi',
         right_pipette: StringSelection(
-            'p10-multi', 'P50-multi', 'p300-multi')='p300-multi',
+            'p10-multi', 'P50-multi', 'p300-multi', 'none')='p300-multi',
         mastermix_volume: float=18,
         DNA_volume: float=2
         ):
 
+    if left_pipette == right_pipette and left_pipette == 'none':
+        raise Exception('You have to select at least 1 pipette.')
+
     def mount_pipette(pipette_type, mount, tiprack_slot):
-        if pipette_type == 'p10-single':
+        if pipette_type == 'p10-multi':
             tip_rack = [labware.load('tiprack-10ul', slot)
                         for slot in tiprack_slot]
-            pipette = instruments.P10_Single(
+            pipette = instruments.P10_Multi(
                 mount=mount,
                 tip_racks=tip_rack)
-        elif pipette_type == 'p50-single':
+        elif pipette_type == 'p50-multi':
             tip_rack = [labware.load('opentrons-tiprack-300ul', slot)
                         for slot in tiprack_slot]
-            pipette = instruments.P50_Single(
-                mount=mount,
-                tip_racks=tip_rack)
-        elif pipette_type == 'p300-single':
-            tip_rack = [labware.load('opentrons-tiprack-300ul', slot)
-                        for slot in tiprack_slot]
-            pipette = instruments.P300_Single(
+            pipette = instruments.P50_Multi(
                 mount=mount,
                 tip_racks=tip_rack)
         else:
-            tip_rack = [labware.load('tiprack-1000ul', slot)
+            tip_rack = [labware.load('opentrons-tiprack-300ul', slot)
                         for slot in tiprack_slot]
-            pipette = instruments.P1000_Single(
+            pipette = instruments.P300_Multi(
                 mount=mount,
                 tip_racks=tip_rack)
         return pipette
@@ -53,9 +50,24 @@ def run_custom_protocol(
 
     # instrument setup
     pipette_l = mount_pipette(
-        left_pipette, 'left', ['4', '5'])
+        left_pipette, 'left', ['4', '5']
+        ) if 'none' not in left_pipette else None
     pipette_r = mount_pipette(
-        right_pipette, 'right', ['6', '7'])
+        right_pipette, 'right', ['6', '7']
+        ) if 'none' not in right_pipette else None
+
+    # determine which pipette has the smaller volume range
+    if pipette_l and pipette_r:
+        if left_pipette == right_pipette:
+            pip_s = pipette_l
+            pip_l = pipette_r
+        else:
+            if pipette_l.max_volume < pipette_r.max_volume:
+                pip_s, pip_l = pipette_l, pipette_r
+            else:
+                pip_s, pip_l = pipette_r, pipette_l
+    else:
+        pipette = pipette_l if pipette_l else pipette_r
 
     # reagent setup
     mastermix = trough.wells('A1')
@@ -63,20 +75,21 @@ def run_custom_protocol(
     col_num = math.ceil(number_of_samples / 8)
 
     # distribute mastermix
-    if mastermix_volume < pipette_r.min_volume and \
-            mastermix_volume > pipette_l.min_volume:
-        pipette = pipette_l
-    else:
-        pipette = pipette_r
+    if pipette_l and pipette_r:
+        if mastermix_volume <= pip_s.max_volume:
+            pipette = pip_s
+        else:
+            pipette = pip_l
     pipette.distribute(
         mastermix_volume, mastermix, dest_plate.cols('1', length=col_num),
         blow_out=mastermix)
 
     # transfer DNA
-    if DNA_volume < pipette_r.min_volume and DNA_volume > pipette_l.min_volume:
-        pipette = pipette_l
-    else:
-        pipette = pipette_r
+    if pipette_l and pipette_r:
+        if DNA_volume <= pip_s.max_volume:
+            pipette = pip_s
+        else:
+            pipette = pip_l
     for source, dest in zip(dna_plate.cols('1', length=col_num),
                             dest_plate.cols('1', length=col_num)):
         pipette.transfer(DNA_volume, source, dest)


### PR DESCRIPTION
## overview
The protocol currently requires user to attach a pipette on both mounts. Users that have only 1 single-channel pipette or 1 multi-channel pipette cannot effectively run the protocol. 

## changelog
- add `none` as an option
- update logic to pick which pipette to use based on transfer volumes

## review requests
Make sure code looks sane and concise