### PR TITLE
fix logic errors in CSV dilution per user report

### DIFF
--- a/protocols/1610/dna_dilution.ot2.py
+++ b/protocols/1610/dna_dilution.ot2.py
@@ -124,9 +124,9 @@ pipettes.')
                     vol,
                     water,
                     dest,
-                    blow_out=True,
                     new_tip='never'
                 )
+                pipette.blow_out()
     if p10.tip_attached:
         p10.drop_tip()
     if p50.tip_attached:
@@ -140,12 +140,16 @@ pipettes.')
                 source = elution_plate.wells(line[0])
                 dest = oa_dilution_plate.wells(line[3])
                 pipette = p10 if vol <= 10 else p50
+                pipette.pick_up_tip()
                 pipette.transfer(
                     vol,
                     source,
                     dest,
-                    blow_out=True
+                    new_tip='never'
                 )
+                pipette.mix(5, 9, dest)
+                pipette.blow_out()
+                pipette.drop_tip()
 
     # water to CNV transfer
     p10.pick_up_tip()
@@ -162,9 +166,10 @@ pipettes.')
                     vol,
                     water,
                     dest,
-                    blow_out=True,
                     new_tip='never'
                 )
+                pipette.blow_out()
+                pipette.drop_tip()
     if p10.tip_attached:
         p10.drop_tip()
     if p50.tip_attached:
@@ -176,14 +181,17 @@ pipettes.')
             vol = float(line[7])
             if vol != 0:
                 source = oa_dilution_plate.wells(line[3])
-                dest = oa_dilution_plate.wells(line[6])
+                dest = cnv_dilution_plate.wells(line[6])
                 pipette = p10 if vol <= 10 else p50
+                pipette.pick_up_tip()
                 pipette.transfer(
                     vol,
                     source,
                     dest,
-                    blow_out=True
+                    new_tip='never'
                 )
+                pipette.blow_out()
+                pipette.drop_tip()
 
     if magnet_setup == 'Opentrons magnetic module':
         magdeck.disengage()


### PR DESCRIPTION
## overview

fixes plate dilution from CSV protocol for 1610

## changelog

#### 9/16/2019
- fixes protocol per following user report:

> Issues:
> 1) During the Open Array dilution step, well G6 pulled up the proper volume of DNA from extraction plate and moved to the correct position on the OA dilution plate, but it did not dispense the liquid. It discarded the sample in the trash instead. Not sure if this was a glitch with this run or something that needed to be addressed. We will keep an eye on it and see if it happens again but any suggestions or comments would be appreciated. 
> 
> 2) We had lots of issues with the CNV dilution steps. Is it possible to separate the 2 steps into 2 separate protocols? I think this will help us troubleshoot better and we need to mix the OA dilutions before starting the CNV dilutions, which is not currently happening. 
> 
> 3) There was no water addition step in CNV dilution step. It went straight to the OA plate to grab the DNA mixture. 
> 
> 4) During CNV dilution step, it grabbed DNA from OA dilution plate properly, but then dispensed back into the same OA dilution plate, instead of moving it to the CNV dilution plate. 
> 
> 5) During CNV dilution step, it missed picking up tips a lot of the time. I noticed when I went through the calibration steps it never had me align the pipette with that back tray, just tray 7. If we separate the 2 protocols, I think this should help with the alignment/calibration too. 
> 