### PR TITLE
fix-4a0be6-2

### DIFF
--- a/protocols/4a0be6/tube_filling.ot2.py
+++ b/protocols/4a0be6/tube_filling.ot2.py
@@ -1,5 +1,5 @@
 import math
-from opentrons import labware, instruments, robot
+from opentrons import labware, instruments
 from otcustomizers import StringSelection
 
 metadata = {


### PR DESCRIPTION

## overview
More troubleshooting edits to the 4a0be6 protocol.

## changelog
- make sure the number getting passed into `yield_group()` is an int
- remove the pauses between every two tuberacks
