### PR TITLE
fix ELISA dispense depth and distribution volume for 77032e and 6e8459

### DIFF
--- a/protocols/1464-natrix-separations-inc-milliporesigma-part1/ELISA_protocol_part1.ot2.py
+++ b/protocols/1464-natrix-separations-inc-milliporesigma-part1/ELISA_protocol_part1.ot2.py
@@ -112,7 +112,7 @@ def run_custom_protocol(
             p1000.transfer(
                 volume,
                 source,
-                dest.top(-10),
+                dest.top(-20),
                 new_tip='never')
             p1000.blow_out(dest.top())
     p1000.drop_tip()

--- a/protocols/1464-natrix-separations-inc-milliporesigma-part3/ELISA_protocol_part3.ot2.py
+++ b/protocols/1464-natrix-separations-inc-milliporesigma-part3/ELISA_protocol_part3.ot2.py
@@ -55,5 +55,4 @@ def run_custom_protocol(
     for col in plate.cols[:number_of_columns]:
         m300.pick_up_tip()
         m300.transfer(100, stop_solution, col, new_tip='never')
-        m300.mix(3, 100, col)
         m300.drop_tip()

--- a/protocols/1556-part1/proA_ELISA-part1.ot2.py
+++ b/protocols/1556-part1/proA_ELISA-part1.ot2.py
@@ -117,7 +117,7 @@ def run_custom_protocol(
                 p1000.transfer(
                     volume,
                     source,
-                    dest.top(-10),
+                    dest.top(-20),
                     new_tip='never')
                 p1000.blow_out(dest.top())
     p1000.drop_tip()
@@ -177,7 +177,7 @@ def run_custom_protocol(
     # transfer samples
     for sample in samples:
         p300.pick_up_tip()
-        p300.aspirate(200, sample)
+        p300.aspirate(230, sample)
         for dest in dests[0]:
             p300.dispense(100, dest)
         p300.drop_tip()


### PR DESCRIPTION
## overview

fixes ELISA protocols for 77032e and 6e8459. closes #1191. closes #1192 

## changelog

#### 10/15
- lowers dilution distribution depth in deepwell plate in 1464 part 1 and 1556 part 1
- removes mix after transfer in 1464 part 3
- aspirates 30ul additional in distribution from deepwell to STP plate at the end of 1556 part 1