### PR TITLE
5c6979 ensure tempdeck displays

### DIFF
--- a/protocols/5c6979/nuc_acid_pur.ot2.py
+++ b/protocols/5c6979/nuc_acid_pur.ot2.py
@@ -129,6 +129,7 @@ resuming.')
 
     # HB distributions
     pick_up(m50, 'single')
+    m50.aspirate(0, temp_plate.wells(0).top(5))
     # HB
     hb_distribute(10, hb[0], ['2', '5'])
     hb_distribute(20, hb[0], ['8'])


### PR DESCRIPTION
## overview

fix nucleic acid purification protocol for 5c6979

## changelog

#### 10/22/2019
- adds ghost aspiration at temp_plate to ensure tempdeck displays during calibration