### PR TITLE
feat: Add support for P1000 to logo example

### DIFF
--- a/protocols/Opentrons_Logo/Opentrons_Logo.ot2.py
+++ b/protocols/Opentrons_Logo/Opentrons_Logo.ot2.py
@@ -4,7 +4,6 @@
 @version 1.3
 """
 from opentrons import labware, instruments
-from otcustomizers import StringSelection
 
 metadata = {
     'protocolName': 'Opentrons Logo',
@@ -13,24 +12,27 @@ metadata = {
     }
 
 
-def run_custom_protocol(pipette_type: StringSelection(
-    'p300-Single', 'p50-Single', 'p10-Single')='p300-Single',
-    dye_labware_type: StringSelection(
-        'trough-12row', 'tube-rack-2ml')='trough-12row'):
+def run_custom_protocol(pipette_type: 'StringSelection...'='p300-Single',
+    dye_labware_type: 'StringSelection...'='trough-12row', mount: 'StringSelection...'='right'):
+    if pipette_type == 'p1000-Single':
+        tiprack = labware.load('tiprack-1000ul', '1')
+        pipette = instruments.P1000_Single(
+            mount=mount,
+            tip_racks=[tiprack])
     if pipette_type == 'p300-Single':
         tiprack = labware.load('tiprack-200ul', '1')
         pipette = instruments.P300_Single(
-            mount='right',
+            mount=mount,
             tip_racks=[tiprack])
     elif pipette_type == 'p50-Single':
         tiprack = labware.load('tiprack-200ul', '1')
         pipette = instruments.P50_Single(
-            mount='right',
+            mount=mount,
             tip_racks=[tiprack])
     elif pipette_type == 'p10-Single':
         tiprack = labware.load('tiprack-10ul', '1')
         pipette = instruments.P10_Single(
-            mount='right',
+            mount=mount,
             tip_racks=[tiprack])
 
     if dye_labware_type == 'trough-12row':

--- a/protocols/Opentrons_Logo/Opentrons_Logo.ot2.py
+++ b/protocols/Opentrons_Logo/Opentrons_Logo.ot2.py
@@ -25,7 +25,7 @@ def run_custom_protocol(pipette_type: StringSelection(
         pipette = instruments.P1000_Single(
             mount=pipette_is_on,
             tip_racks=[tiprack])
-    if pipette_type == 'p300-Single':
+    elif pipette_type == 'p300-Single':
         tiprack = labware.load('tiprack-200ul', '1')
         pipette = instruments.P300_Single(
             mount=pipette_is_on,

--- a/protocols/Opentrons_Logo/Opentrons_Logo.ot2.py
+++ b/protocols/Opentrons_Logo/Opentrons_Logo.ot2.py
@@ -17,7 +17,7 @@ metadata = {
 def run_custom_protocol(pipette_type: StringSelection(
     'p1000-Single', 'p300-Single', 'p50-Single', 'p10-Single')='p300-Single',
     dye_labware_type: StringSelection(
-        'trough-12row', 'tube-rack-2ml')='trough-12row'),
+        'trough-12row', 'tube-rack-2ml')='trough-12row',
     pipette_is_on: StringSelection(
         'left', 'right')='right'):
     if pipette_type == 'p1000-Single':

--- a/protocols/Opentrons_Logo/Opentrons_Logo.ot2.py
+++ b/protocols/Opentrons_Logo/Opentrons_Logo.ot2.py
@@ -4,6 +4,8 @@
 @version 1.3
 """
 from opentrons import labware, instruments
+from otcustomizers import StringSelection
+
 
 metadata = {
     'protocolName': 'Opentrons Logo',
@@ -12,27 +14,31 @@ metadata = {
     }
 
 
-def run_custom_protocol(pipette_type: 'StringSelection...'='p300-Single',
-    dye_labware_type: 'StringSelection...'='trough-12row', mount: 'StringSelection...'='right'):
+def run_custom_protocol(pipette_type: StringSelection(
+    'p1000-Single', 'p300-Single', 'p50-Single', 'p10-Single')='p300-Single',
+    dye_labware_type: StringSelection(
+        'trough-12row', 'tube-rack-2ml')='trough-12row'),
+    pipette_is_on: StringSelection(
+        'left', 'right')='right'):
     if pipette_type == 'p1000-Single':
         tiprack = labware.load('tiprack-1000ul', '1')
         pipette = instruments.P1000_Single(
-            mount=mount,
+            mount=pipette_is_on,
             tip_racks=[tiprack])
     if pipette_type == 'p300-Single':
         tiprack = labware.load('tiprack-200ul', '1')
         pipette = instruments.P300_Single(
-            mount=mount,
+            mount=pipette_is_on,
             tip_racks=[tiprack])
     elif pipette_type == 'p50-Single':
         tiprack = labware.load('tiprack-200ul', '1')
         pipette = instruments.P50_Single(
-            mount=mount,
+            mount=pipette_is_on,
             tip_racks=[tiprack])
     elif pipette_type == 'p10-Single':
         tiprack = labware.load('tiprack-10ul', '1')
         pipette = instruments.P10_Single(
-            mount=mount,
+            mount=pipette_is_on,
             tip_racks=[tiprack])
 
     if dye_labware_type == 'trough-12row':


### PR DESCRIPTION
## overview

Adds support for P1000 and pipettes mounted on either side.


## review requests

I tested a version of this when using my new bot for the first time as I lacked a P300/P50 but I haven't tested this exact version of the code as I'm not familiar with the customizer. Feel free to reject this PR as a result, my aim was just to make it more user friendly for anyone who starts with only a P1000 or who may have it mounted on the "wrong" side.
