### PR TITLE
feat(protolib): do not create categories for hidden protocols

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.gitattributes
+
 .DS_Store
 *.DS_Store
 *.swp


### PR DESCRIPTION
## overview

Should hide categories from the site list when they don't have non-hidden protocols

## review requests

Inspect `releases/output.json` for top-level `"categories"` key:

```js
// OLD!
{
    "Sample Prep": [
        "Sequencing",
        "Mass Spec",
        "PCR"
    ],
    "NGS Library Prep": [
        "Illumina"
    ],
    "Basic Pipetting": [
        "Plate Consoidation",
        "Dilution",
        "Plate Filling",
        "Plate Consolidation"
    ],
    "Getting Started": [
        "Opentrons Logo"
    ],
    "Molecular Biology": [
        "Nucleic Acid Purification"
    ]
}

// NEW
{
    "Sample Prep": [
        "PCR",
        "Sequencing"
    ],
    "NGS Library Prep": [
        "Illumina"
    ],
    "Basic Pipetting": [
        "Dilution"
    ],
    "Getting Started": [
        "Opentrons Logo"
    ],
    "Molecular Biology": [
        "Nucleic Acid Purification"
    ]
}
```