### PR TITLE
hide-pcr-test-plan

### DIFF
--- a/protoBuilds/pcr_test_plan/metadata.json
+++ b/protoBuilds/pcr_test_plan/metadata.json
@@ -11,7 +11,7 @@
     "flags": {
         "embedded-app": false,
         "feature": false,
-        "hide-from-search": false,
+        "hide-from-search": true,
         "skip-tests": false
     },
     "path": "protocols/pcr_test_plan",


### PR DESCRIPTION
## overview

hides PCR test plan protocol template from front-facing Protocol Library

## changelog

#### 1/7/2019
- adds dotfile `.hide-from-search` to protocol folder