### PR TITLE
expand-cherrypicking

### DIFF
--- a/protoBuilds/cherrypicking/cherrypicking.ot2.apiv2.py.json
+++ b/protoBuilds/cherrypicking/cherrypicking.ot2.apiv2.py.json
@@ -1,5 +1,5 @@
 {
-    "content": "metadata = {\n    'protocolName': 'Cherrypicking',\n    'author': 'Opentrons <protocols@opentrons.com>',\n    'source': 'Protocol Library',\n    'apiLevel': '2.0'\n    }\n\n\ndef run(protocol):\n    [volumes_csv, pip_model, pip_mount, sp_type,\n     dp_type, filter_tip, tip_reuse] = get_values(  # noqa: F821\n        'volumes_csv', 'pip_model', 'pip_mount', 'sp_type',\n         'dp_type', 'filter_tip', 'tip_reuse')\n\n    # create pipette and volume max\n    pip_max = pip_model.split('_')[0][1:]\n\n    pip_max = '300' if pip_max == '50' else pip_max\n    tip_name = 'opentrons_96_tiprack_'+pip_max+'ul'\n    if filter_tip == 'yes':\n        pip_max = '200' if pip_max == '300' else pip_max\n        tip_name = 'opentrons_96_filtertippack_'+pip_max+'ul'\n\n    tiprack_slots = ['1', '4', '7', '10']\n    tips = [protocol.load_labware(tip_name, slot)\n            for slot in tiprack_slots]\n\n    pipette = protocol.load_instrument(pip_model, pip_mount, tip_racks=tips)\n\n    # create labware\n    dest_plate = protocol.load_labware(dp_type, '3', 'Destination Plate')\n\n    data = [row.split(',') for row in volumes_csv.strip().splitlines() if row]\n\n    if len(data[1]) == 2:\n        source_plate = protocol.load_labware(sp_type, '2', 'Source Plate')\n        if tip_reuse == 'never':\n            pipette.pick_up_tip()\n        for well_idx, (source_well, vol) in enumerate(data[1:]):\n            if source_well and vol:\n                vol = float(vol)\n                pipette.transfer(\n                    vol,\n                    source_plate.wells(source_well),\n                    dest_plate.wells(well_idx),\n                    new_tip=tip_reuse)\n        if tip_reuse == 'never':\n            pipette.drop_tip()\n    else:\n        source_plates = []\n        plateno = 0\n        for d in data[1:]:\n            z = int(d[2])\n            if z > plateno:\n                plateno = z\n        for i in range(plateno):\n            nomenclature = 'Source Plate ' + str(i+1)\n            numeral = str(i*3+2)\n            source_plates.append(protocol.load_labware(\n                sp_type,\n                numeral,\n                nomenclature\n            ))\n        if tip_reuse == 'never':\n            pipette.pick_up_tip()\n        for well_idx, (source_well, vol, plate) in enumerate(data[1:]):\n            if source_well and vol and plate:\n                vol = float(vol)\n                source_p = source_plates[int(plate)-1]\n                pipette.transfer(\n                    vol,\n                    source_p.wells(source_well),\n                    dest_plate.wells(well_idx),\n                    new_tip=tip_reuse)\n        if tip_reuse == 'never':\n            pipette.drop_tip()\n",
+    "content": "metadata = {\n    'protocolName': 'Cherrypicking',\n    'author': 'Opentrons <protocols@opentrons.com>',\n    'source': 'Protocol Library',\n    'apiLevel': '2.0'\n    }\n\n\ndef run(protocol):\n    [volumes_csv, pip_model, pip_mount, sp_type,\n     dp_type, filter_tip, tip_reuse] = get_values(  # noqa: F821\n        'volumes_csv', 'pip_model', 'pip_mount', 'sp_type',\n         'dp_type', 'filter_tip', 'tip_reuse')\n\n    # create pipette and volume max\n    pip_max = pip_model.split('_')[0][1:]\n\n    pip_max = '300' if pip_max == '50' else pip_max\n    tip_name = 'opentrons_96_tiprack_'+pip_max+'ul'\n    if filter_tip == 'yes':\n        pip_max = '200' if pip_max == '300' else pip_max\n        tip_name = 'opentrons_96_filtertippack_'+pip_max+'ul'\n\n    tiprack_slots = ['1', '4', '7', '10']\n    tips = [protocol.load_labware(tip_name, slot)\n            for slot in tiprack_slots]\n\n    pipette = protocol.load_instrument(pip_model, pip_mount, tip_racks=tips)\n\n    # create labware\n    dest_plate = protocol.load_labware(dp_type, '3', 'Destination Plate/Rack')\n\n    data = [row.split(',') for row in volumes_csv.strip().splitlines() if row]\n\n    if len(data[1]) == 2:\n        source_plate = protocol.load_labware(sp_type, '2', 'Source Plate')\n        if tip_reuse == 'never':\n            pipette.pick_up_tip()\n        for well_idx, (source_well, vol) in enumerate(data[1:]):\n            if source_well and vol:\n                vol = float(vol)\n                pipette.transfer(\n                    vol,\n                    source_plate.wells(source_well),\n                    dest_plate.wells(well_idx),\n                    new_tip=tip_reuse)\n        if tip_reuse == 'never':\n            pipette.drop_tip()\n    else:\n        source_plates = []\n        plateno = 0\n        for d in data[1:]:\n            z = int(d[2])\n            if z > plateno:\n                plateno = z\n        for i in range(plateno):\n            nomenclature = 'Source Plate ' + str(i+1)\n            numeral = str(i*3+2)\n            source_plates.append(protocol.load_labware(\n                sp_type,\n                numeral,\n                nomenclature\n            ))\n        if tip_reuse == 'never':\n            pipette.pick_up_tip()\n        for well_idx, (source_well, vol, plate) in enumerate(data[1:]):\n            if source_well and vol and plate:\n                vol = float(vol)\n                source_p = source_plates[int(plate)-1]\n                pipette.transfer(\n                    vol,\n                    source_p.wells(source_well),\n                    dest_plate.wells(well_idx),\n                    new_tip=tip_reuse)\n        if tip_reuse == 'never':\n            pipette.drop_tip()\n",
     "custom_labware_defs": [],
     "fields": [
         {
@@ -85,6 +85,10 @@
                 {
                     "label": "USA Scientific 96-Deepwell, 2.4mL",
                     "value": "usascientific_96_wellplate_2.4ml_deep"
+                },
+                {
+                    "label": "Opentrons 24 Tube Rack with Eppendorf 2 mL Safe-Lock Snapcap",
+                    "value": "opentrons_24_tuberack_eppendorf_2ml_safelock_snapcap"
                 }
             ],
             "type": "dropDown"
@@ -116,6 +120,10 @@
                 {
                     "label": "USA Scientific 96-Deepwell, 2.4mL",
                     "value": "usascientific_96_wellplate_2.4ml_deep"
+                },
+                {
+                    "label": "Opentrons 24 Tube Rack with Eppendorf 2 mL Safe-Lock Snapcap",
+                    "value": "opentrons_24_tuberack_eppendorf_2ml_safelock_snapcap"
                 }
             ],
             "type": "dropDown"
@@ -171,7 +179,7 @@
             "type": "nest_96_wellplate_200ul_flat"
         },
         {
-            "name": "Destination Plate on 3",
+            "name": "Destination Plate/Rack on 3",
             "share": false,
             "slot": "3",
             "type": "nest_96_wellplate_200ul_flat"

--- a/protocols/cherrypicking/cherrypicking.ot2.apiv2.py
+++ b/protocols/cherrypicking/cherrypicking.ot2.apiv2.py
@@ -28,7 +28,7 @@ def run(protocol):
     pipette = protocol.load_instrument(pip_model, pip_mount, tip_racks=tips)
 
     # create labware
-    dest_plate = protocol.load_labware(dp_type, '3', 'Destination Plate')
+    dest_plate = protocol.load_labware(dp_type, '3', 'Destination Plate/Rack')
 
     data = [row.split(',') for row in volumes_csv.strip().splitlines() if row]
 

--- a/protocols/cherrypicking/fields.json
+++ b/protocols/cherrypicking/fields.json
@@ -38,7 +38,8 @@
       {"label": "BioRad 96-Well, 200µL PCR", "value": "biorad_96_wellplate_200ul_pcr"},
       {"label": "Corning 96-Well, 360µL Flat", "value": "corning_96_wellplate_360ul_flat"},
       {"label": "Corning 384-Well, 112µL Flat", "value": "corning_384_wellplate_112ul_flat"},
-      {"label": "USA Scientific 96-Deepwell, 2.4mL", "value": "usascientific_96_wellplate_2.4ml_deep"}
+      {"label": "USA Scientific 96-Deepwell, 2.4mL", "value": "usascientific_96_wellplate_2.4ml_deep"},
+      {"label": "Opentrons 24 Tube Rack with Eppendorf 2 mL Safe-Lock Snapcap", "value": "opentrons_24_tuberack_eppendorf_2ml_safelock_snapcap"}
     ]
   },
   {
@@ -51,7 +52,8 @@
       {"label": "BioRad 96-Well, 200µL PCR", "value": "biorad_96_wellplate_200ul_pcr"},
       {"label": "Corning 96-Well, 360µL Flat", "value": "corning_96_wellplate_360ul_flat"},
       {"label": "Corning 384-Well, 112µL Flat", "value": "corning_384_wellplate_112ul_flat"},
-      {"label": "USA Scientific 96-Deepwell, 2.4mL", "value": "usascientific_96_wellplate_2.4ml_deep"}
+      {"label": "USA Scientific 96-Deepwell, 2.4mL", "value": "usascientific_96_wellplate_2.4ml_deep"},
+      {"label": "Opentrons 24 Tube Rack with Eppendorf 2 mL Safe-Lock Snapcap", "value": "opentrons_24_tuberack_eppendorf_2ml_safelock_snapcap"}
     ]
   },
   {


### PR DESCRIPTION
## overview

expands public cherrypicking protocol on library to include 4x6 2ml Eppendorf tuberack for source and destination labware. closes #1421 

## changelog

#### 1/17/2020
- adds 4x6 2ml Eppendorf tuberack for source and destination labware