### PR TITLE
feat(protolib): update monorepo to v3.16.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SHELL := /bin/bash
 
 MONOREPO_URI := https://github.com/Opentrons/opentrons.git
-OT2_VERSION_TAG := v3.15.2
+OT2_VERSION_TAG := v3.16.1
 OT2_MONOREPO_DIR := ot2monorepoClone
 
 # Parsers output to here


### PR DESCRIPTION
## overview

- updates monorepo clone version `OT2_VERSION_TAG` to v3.16.1 (previously v3.15.2)

## changelog

#### 3/4/2020
changes `Makefile` `OT2_VERSION_TAG` to v3.16.1 (previously v3.15.2)

## to do

- pull from `develop`
- run `make teardown setup`