### PR TITLE
update-131de0-duplicate-sample

### DIFF
--- a/protoBuilds/131de0/cnv.ot2.apiv2.py.json
+++ b/protoBuilds/131de0/cnv.ot2.apiv2.py.json
@@ -1,5 +1,5 @@
 {
-    "content": "import math\n\n# metadata\nmetadata = {\n    'protocolName': 'Copy Number Variant (CNV) Plating',\n    'author': 'Nick <protocols@opentrons.com>',\n    'source': 'Custom Protocol Request',\n    'apiLevel': '2.0'\n}\n\n\ndef run(ctx):\n\n    p10_multi_mount, num_samples, num_reps = get_values(  # noqa: F821\n        'p10_multi_mount', 'num_samples', 'num_reps')\n\n    # load labware\n    mm_plate = ctx.load_labware(\n        'microampoptical_384_wellplate_30ul', '1', 'mastermix plate')\n    plate384 = ctx.load_labware(\n        'microampoptical_384_wellplate_30ul', '2', '384-well plate')\n    dilution_plate = ctx.load_labware(\n        'usascientific_96_wellplate_100ul', '3', 'CNV dilution plate')\n    tipracks = [\n        ctx.load_labware('opentrons_96_tiprack_10ul', str(slot))\n        for slot in range(4, 7)\n    ]\n\n    # load pipette\n    m10 = ctx.load_instrument('p10_multi', p10_multi_mount, tip_racks=tipracks)\n\n    # transfer mastermix to all 384 wells\n    num_cols = math.ceil(num_samples/8)\n    mm_sources = mm_plate.rows()[0][:num_reps]\n    mm_dest_sets = [\n        [\n            [well\n             for set in [row[i*2:i*2+2] for row in plate384.rows()[:2]]\n             for well in set[:num_reps]][n]\n            for i in range(12)\n        ][:num_cols]\n        for n in range(num_reps)\n    ]\n    for s, d_set in zip(mm_sources, mm_dest_sets):\n        m10.pick_up_tip()\n        for d in d_set:\n            m10.air_gap(2)\n            m10.aspirate(8, s)\n            m10.dispense(10, d)\n            m10.blow_out(d.bottom(3))\n        m10.drop_tip()\n\n    # setup DNA sources and destinations\n    dna_source_sets = dilution_plate.rows()[0]\n    dna_dest_sets = [\n        [well\n         for set in [row[i*2:i*2+2] for row in plate384.rows()[:2]]\n         for well in set[:num_reps]]\n        for i in range(12)\n    ][:num_cols]\n\n    # transfer DNA in triplicate\n    for s, d_set in zip(dna_source_sets, dna_dest_sets):\n        m10.pick_up_tip()\n        for d in d_set:\n            m10.air_gap(3)\n            m10.aspirate(2, s)\n            m10.air_gap(2)\n            m10.dispense(2, d.top(-2))\n            m10.aspirate(5)\n            m10.dispense(7, d)\n            m10.dispense(3, d.bottom(3))\n            m10.blow_out(d.bottom(3))\n        m10.drop_tip()\n",
+    "content": "import math\n\n# metadata\nmetadata = {\n    'protocolName': 'Copy Number Variant (CNV) Plating',\n    'author': 'Nick <protocols@opentrons.com>',\n    'source': 'Custom Protocol Request',\n    'apiLevel': '2.0'\n}\n\n\ndef run(ctx):\n\n    p10_multi_mount, num_samples, num_reps, num_mm = get_values(  # noqa: F821\n        'p10_multi_mount', 'num_samples', 'num_reps', 'num_mm')\n    # p10_multi_mount, num_samples, num_reps, num_mm = [\n    #     'left', 24, 'duplicate', 8]\n\n    # load labware\n    plate384 = ctx.load_labware(\n        'microampoptical_384_wellplate_30ul', '2', '384-well plate')\n    dilution_plate = ctx.load_labware(\n        'usascientific_96_wellplate_100ul', '3', 'CNV dilution plate')\n    tipracks = [\n        ctx.load_labware('opentrons_96_tiprack_10ul', str(slot))\n        for slot in range(5, 8)\n    ]\n\n    # load pipette\n    m10 = ctx.load_instrument('p10_multi', p10_multi_mount, tip_racks=tipracks)\n\n    # transfer mastermix to all 384 wells\n    num_cols = math.ceil(num_samples/8)\n\n    if num_reps == 'quadruplicate':\n        mm_source = ctx.load_labware('generic_1_reservoir_25000ul', '4')\n        mm_dest_sets = [\n            [\n                [well\n                 for set in [row[i*2:i*2+2] for row in plate384.rows()[:2]]\n                 for well in set[:num_reps]][n]\n                for i in range(12)\n            ][:num_cols]\n            for n in range(num_reps)\n        ]\n        for d_set in mm_dest_sets:\n            m10.pick_up_tip()\n            for d in d_set:\n                m10.air_gap(2)\n                m10.aspirate(8, mm_source)\n                m10.dispense(10, d)\n                m10.blow_out(d.bottom(3))\n            m10.drop_tip()\n\n        # setup DNA sources and destinations\n        dna_source_sets = dilution_plate.rows()[0][:num_cols]\n        dna_dest_sets = [\n            [well\n             for set in [row[i*2:i*2+2] for row in plate384.rows()[:2]]\n             for well in set[:num_reps]]\n            for i in range(12)\n        ][:num_cols]\n\n        # transfer DNA in quadruplicate\n        for s, d_set in zip(dna_source_sets, dna_dest_sets):\n            for d in d_set:\n                m10.pick_up_tip()\n                m10.air_gap(3)\n                m10.aspirate(2, s)\n                m10.air_gap(2)\n                m10.dispense(2, d.top(-2))\n                m10.aspirate(5)\n                m10.dispense(7, d)\n                m10.dispense(3, d.bottom(3))\n                m10.blow_out(d.bottom(3))\n                m10.drop_tip()\n\n    else:\n        if num_mm > 12 or num_samples*num_mm > 192 or num_samples > 96:\n            raise Exception('Invalid combination of number of samples\\\n/mastermixes.')\n        mm_plate = ctx.load_labware(\n            'microampoptical_384_wellplate_30ul', '1', 'mastermix plate')\n        mm_sources = mm_plate.rows()[0][:num_mm]\n        mm_dest_sets = [\n            [well for col in plate384.columns()[n*num_cols:(n+1)*num_cols]\n             for well in col[:2]]\n            for n in range(num_mm)\n        ][:num_mm]\n        for s, d_set in zip(mm_sources, mm_dest_sets):\n            m10.pick_up_tip()\n            for d in d_set:\n                m10.air_gap(2)\n                m10.aspirate(8, s)\n                m10.dispense(10, d)\n                m10.blow_out(d.bottom(3))\n            m10.drop_tip()\n\n        # setup DNA sources and destinations\n        dna_source_sets = dilution_plate.rows()[0][:num_cols]\n        dna_dest_sets = [\n            [set[i*2:i*2+2] for set in mm_dest_sets]\n            for i in range(num_cols)\n        ]\n\n        # transfer DNA in duplicate\n        for s, d_sets in zip(dna_source_sets, dna_dest_sets):\n            for dupe in d_sets:\n                m10.pick_up_tip()\n                for d in dupe:\n                    m10.air_gap(3)\n                    m10.aspirate(2, s)\n                    m10.air_gap(2)\n                    m10.dispense(2, d.top(-2))\n                    m10.aspirate(5)\n                    m10.dispense(7, d)\n                    m10.dispense(3, d.bottom(3))\n                    m10.blow_out(d.bottom(3))\n                m10.drop_tip()\n",
     "custom_labware_defs": [
         {
             "brand": {
@@ -5538,14 +5538,29 @@
         },
         {
             "default": 96,
-            "label": "number of samples (1-96)",
+            "label": "number of samples (1-96, processed in columns of 8)",
             "name": "num_samples",
             "type": "int"
         },
         {
-            "default": 4,
-            "label": "number of replicates (1-4)",
+            "label": "replicate factor",
             "name": "num_reps",
+            "options": [
+                {
+                    "label": "duplicate",
+                    "value": "duplicate"
+                },
+                {
+                    "label": "quadruplicate",
+                    "value": "quadruplicate"
+                }
+            ],
+            "type": "dropDown"
+        },
+        {
+            "default": 2,
+            "label": "number of mastermixes (if processing duplicates)",
+            "name": "num_mm",
             "type": "int"
         }
     ],
@@ -5575,12 +5590,6 @@
             "type": "usascientific_96_wellplate_100ul"
         },
         {
-            "name": "Opentrons 96 Tip Rack 10 \u00b5L on 4",
-            "share": false,
-            "slot": "4",
-            "type": "opentrons_96_tiprack_10ul"
-        },
-        {
             "name": "Opentrons 96 Tip Rack 10 \u00b5L on 5",
             "share": false,
             "slot": "5",
@@ -5590,6 +5599,12 @@
             "name": "Opentrons 96 Tip Rack 10 \u00b5L on 6",
             "share": false,
             "slot": "6",
+            "type": "opentrons_96_tiprack_10ul"
+        },
+        {
+            "name": "Opentrons 96 Tip Rack 10 \u00b5L on 7",
+            "share": false,
+            "slot": "7",
             "type": "opentrons_96_tiprack_10ul"
         },
         {

--- a/protocols/131de0/cnv.ot2.apiv2.py
+++ b/protocols/131de0/cnv.ot2.apiv2.py
@@ -11,19 +11,19 @@ metadata = {
 
 def run(ctx):
 
-    p10_multi_mount, num_samples, num_reps = get_values(  # noqa: F821
-        'p10_multi_mount', 'num_samples', 'num_reps')
+    p10_multi_mount, num_samples, num_reps, num_mm = get_values(  # noqa: F821
+        'p10_multi_mount', 'num_samples', 'num_reps', 'num_mm')
+    # p10_multi_mount, num_samples, num_reps, num_mm = [
+    #     'left', 24, 'duplicate', 8]
 
     # load labware
-    mm_plate = ctx.load_labware(
-        'microampoptical_384_wellplate_30ul', '1', 'mastermix plate')
     plate384 = ctx.load_labware(
         'microampoptical_384_wellplate_30ul', '2', '384-well plate')
     dilution_plate = ctx.load_labware(
         'usascientific_96_wellplate_100ul', '3', 'CNV dilution plate')
     tipracks = [
         ctx.load_labware('opentrons_96_tiprack_10ul', str(slot))
-        for slot in range(4, 7)
+        for slot in range(5, 8)
     ]
 
     # load pipette
@@ -31,44 +31,89 @@ def run(ctx):
 
     # transfer mastermix to all 384 wells
     num_cols = math.ceil(num_samples/8)
-    mm_sources = mm_plate.rows()[0][:num_reps]
-    mm_dest_sets = [
-        [
+
+    if num_reps == 'quadruplicate':
+        mm_source = ctx.load_labware('generic_1_reservoir_25000ul', '4')
+        mm_dest_sets = [
+            [
+                [well
+                 for set in [row[i*2:i*2+2] for row in plate384.rows()[:2]]
+                 for well in set[:num_reps]][n]
+                for i in range(12)
+            ][:num_cols]
+            for n in range(num_reps)
+        ]
+        for d_set in mm_dest_sets:
+            m10.pick_up_tip()
+            for d in d_set:
+                m10.air_gap(2)
+                m10.aspirate(8, mm_source)
+                m10.dispense(10, d)
+                m10.blow_out(d.bottom(3))
+            m10.drop_tip()
+
+        # setup DNA sources and destinations
+        dna_source_sets = dilution_plate.rows()[0][:num_cols]
+        dna_dest_sets = [
             [well
              for set in [row[i*2:i*2+2] for row in plate384.rows()[:2]]
-             for well in set[:num_reps]][n]
+             for well in set[:num_reps]]
             for i in range(12)
         ][:num_cols]
-        for n in range(num_reps)
-    ]
-    for s, d_set in zip(mm_sources, mm_dest_sets):
-        m10.pick_up_tip()
-        for d in d_set:
-            m10.air_gap(2)
-            m10.aspirate(8, s)
-            m10.dispense(10, d)
-            m10.blow_out(d.bottom(3))
-        m10.drop_tip()
 
-    # setup DNA sources and destinations
-    dna_source_sets = dilution_plate.rows()[0]
-    dna_dest_sets = [
-        [well
-         for set in [row[i*2:i*2+2] for row in plate384.rows()[:2]]
-         for well in set[:num_reps]]
-        for i in range(12)
-    ][:num_cols]
+        # transfer DNA in quadruplicate
+        for s, d_set in zip(dna_source_sets, dna_dest_sets):
+            for d in d_set:
+                m10.pick_up_tip()
+                m10.air_gap(3)
+                m10.aspirate(2, s)
+                m10.air_gap(2)
+                m10.dispense(2, d.top(-2))
+                m10.aspirate(5)
+                m10.dispense(7, d)
+                m10.dispense(3, d.bottom(3))
+                m10.blow_out(d.bottom(3))
+                m10.drop_tip()
 
-    # transfer DNA in triplicate
-    for s, d_set in zip(dna_source_sets, dna_dest_sets):
-        for d in d_set:
+    else:
+        if num_mm > 12 or num_samples*num_mm > 192 or num_samples > 96:
+            raise Exception('Invalid combination of number of samples\
+/mastermixes.')
+        mm_plate = ctx.load_labware(
+            'microampoptical_384_wellplate_30ul', '1', 'mastermix plate')
+        mm_sources = mm_plate.rows()[0][:num_mm]
+        mm_dest_sets = [
+            [well for col in plate384.columns()[n*num_cols:(n+1)*num_cols]
+             for well in col[:2]]
+            for n in range(num_mm)
+        ][:num_mm]
+        for s, d_set in zip(mm_sources, mm_dest_sets):
             m10.pick_up_tip()
-            m10.air_gap(3)
-            m10.aspirate(2, s)
-            m10.air_gap(2)
-            m10.dispense(2, d.top(-2))
-            m10.aspirate(5)
-            m10.dispense(7, d)
-            m10.dispense(3, d.bottom(3))
-            m10.blow_out(d.bottom(3))
+            for d in d_set:
+                m10.air_gap(2)
+                m10.aspirate(8, s)
+                m10.dispense(10, d)
+                m10.blow_out(d.bottom(3))
             m10.drop_tip()
+
+        # setup DNA sources and destinations
+        dna_source_sets = dilution_plate.rows()[0][:num_cols]
+        dna_dest_sets = [
+            [set[i*2:i*2+2] for set in mm_dest_sets]
+            for i in range(num_cols)
+        ]
+
+        # transfer DNA in duplicate
+        for s, d_sets in zip(dna_source_sets, dna_dest_sets):
+            for dupe in d_sets:
+                m10.pick_up_tip()
+                for d in dupe:
+                    m10.air_gap(3)
+                    m10.aspirate(2, s)
+                    m10.air_gap(2)
+                    m10.dispense(2, d.top(-2))
+                    m10.aspirate(5)
+                    m10.dispense(7, d)
+                    m10.dispense(3, d.bottom(3))
+                    m10.blow_out(d.bottom(3))
+                m10.drop_tip()

--- a/protocols/131de0/fields.json
+++ b/protocols/131de0/fields.json
@@ -10,14 +10,23 @@
   },
   {
     "type": "int",
-    "label": "number of samples (1-96)",
+    "label": "number of samples (1-96, processed in columns of 8)",
     "name": "num_samples",
     "default": 96
   },
   {
-    "type": "int",
-    "label": "number of replicates (1-4)",
+    "type": "dropDown",
+    "label": "replicate factor",
     "name": "num_reps",
-    "default": 4
+    "options": [
+      { "label": "duplicate", "value": "duplicate"},
+      { "label": "quadruplicate", "value": "quadruplicate"}
+    ]
+  },
+  {
+    "type": "int",
+    "label": "number of mastermixes (if processing duplicates)",
+    "name": "num_mm",
+    "default": 2
   }
 ]


### PR DESCRIPTION
## overview

updates PCR prep protocol bundle for 131de0 to accommodate 2 different transfer schemes

## changelog

#### 3/9/2020
- allows for dropdown selection of sample replicate type (`duplicate` or `quadruplicate`)
- processes samples accordingly