### PR TITLE
update API to 3.17.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SHELL := /bin/bash
 
 MONOREPO_URI := https://github.com/Opentrons/opentrons.git
-OT2_VERSION_TAG := v3.16.1
+OT2_VERSION_TAG := v3.17.1
 OT2_MONOREPO_DIR := ot2monorepoClone
 
 # Parsers output to here

--- a/protoBuilds/06ab09/06ab09.ot2.apiv2.py.json
+++ b/protoBuilds/06ab09/06ab09.ot2.apiv2.py.json
@@ -3,1137 +3,6 @@
     "custom_labware_defs": [
         {
             "brand": {
-                "brand": "Axygen",
-                "brandId": []
-            },
-            "cornerOffsetFromSlot": {
-                "x": 0,
-                "y": 0,
-                "z": 0
-            },
-            "dimensions": {
-                "xDimension": 127.8,
-                "yDimension": 85.4,
-                "zDimension": 15.75
-            },
-            "groups": [
-                {
-                    "brand": {
-                        "brand": "Axygen",
-                        "brandId": []
-                    },
-                    "metadata": {
-                        "displayCategory": "wellPlate",
-                        "displayName": "Axygen 96 Well Plate",
-                        "wellBottomShape": "u"
-                    },
-                    "wells": [
-                        "A1",
-                        "B1",
-                        "C1",
-                        "D1",
-                        "E1",
-                        "F1",
-                        "G1",
-                        "H1",
-                        "A2",
-                        "B2",
-                        "C2",
-                        "D2",
-                        "E2",
-                        "F2",
-                        "G2",
-                        "H2",
-                        "A3",
-                        "B3",
-                        "C3",
-                        "D3",
-                        "E3",
-                        "F3",
-                        "G3",
-                        "H3",
-                        "A4",
-                        "B4",
-                        "C4",
-                        "D4",
-                        "E4",
-                        "F4",
-                        "G4",
-                        "H4",
-                        "A5",
-                        "B5",
-                        "C5",
-                        "D5",
-                        "E5",
-                        "F5",
-                        "G5",
-                        "H5",
-                        "A6",
-                        "B6",
-                        "C6",
-                        "D6",
-                        "E6",
-                        "F6",
-                        "G6",
-                        "H6",
-                        "A7",
-                        "B7",
-                        "C7",
-                        "D7",
-                        "E7",
-                        "F7",
-                        "G7",
-                        "H7",
-                        "A8",
-                        "B8",
-                        "C8",
-                        "D8",
-                        "E8",
-                        "F8",
-                        "G8",
-                        "H8",
-                        "A9",
-                        "B9",
-                        "C9",
-                        "D9",
-                        "E9",
-                        "F9",
-                        "G9",
-                        "H9",
-                        "A10",
-                        "B10",
-                        "C10",
-                        "D10",
-                        "E10",
-                        "F10",
-                        "G10",
-                        "H10",
-                        "A11",
-                        "B11",
-                        "C11",
-                        "D11",
-                        "E11",
-                        "F11",
-                        "G11",
-                        "H11",
-                        "A12",
-                        "B12",
-                        "C12",
-                        "D12",
-                        "E12",
-                        "F12",
-                        "G12",
-                        "H12"
-                    ]
-                }
-            ],
-            "metadata": {
-                "displayCategory": "wellPlate",
-                "displayName": "Axygen 96 Well Plate",
-                "displayVolumeUnits": "\u00b5L",
-                "tags": []
-            },
-            "namespace": "custom_beta",
-            "ordering": [
-                [
-                    "A1",
-                    "B1",
-                    "C1",
-                    "D1",
-                    "E1",
-                    "F1",
-                    "G1",
-                    "H1"
-                ],
-                [
-                    "A2",
-                    "B2",
-                    "C2",
-                    "D2",
-                    "E2",
-                    "F2",
-                    "G2",
-                    "H2"
-                ],
-                [
-                    "A3",
-                    "B3",
-                    "C3",
-                    "D3",
-                    "E3",
-                    "F3",
-                    "G3",
-                    "H3"
-                ],
-                [
-                    "A4",
-                    "B4",
-                    "C4",
-                    "D4",
-                    "E4",
-                    "F4",
-                    "G4",
-                    "H4"
-                ],
-                [
-                    "A5",
-                    "B5",
-                    "C5",
-                    "D5",
-                    "E5",
-                    "F5",
-                    "G5",
-                    "H5"
-                ],
-                [
-                    "A6",
-                    "B6",
-                    "C6",
-                    "D6",
-                    "E6",
-                    "F6",
-                    "G6",
-                    "H6"
-                ],
-                [
-                    "A7",
-                    "B7",
-                    "C7",
-                    "D7",
-                    "E7",
-                    "F7",
-                    "G7",
-                    "H7"
-                ],
-                [
-                    "A8",
-                    "B8",
-                    "C8",
-                    "D8",
-                    "E8",
-                    "F8",
-                    "G8",
-                    "H8"
-                ],
-                [
-                    "A9",
-                    "B9",
-                    "C9",
-                    "D9",
-                    "E9",
-                    "F9",
-                    "G9",
-                    "H9"
-                ],
-                [
-                    "A10",
-                    "B10",
-                    "C10",
-                    "D10",
-                    "E10",
-                    "F10",
-                    "G10",
-                    "H10"
-                ],
-                [
-                    "A11",
-                    "B11",
-                    "C11",
-                    "D11",
-                    "E11",
-                    "F11",
-                    "G11",
-                    "H11"
-                ],
-                [
-                    "A12",
-                    "B12",
-                    "C12",
-                    "D12",
-                    "E12",
-                    "F12",
-                    "G12",
-                    "H12"
-                ]
-            ],
-            "parameters": {
-                "format": "irregular",
-                "isMagneticModuleCompatible": false,
-                "isTiprack": false,
-                "loadName": "axygen_96_wellplate",
-                "quirks": []
-            },
-            "schemaVersion": 2,
-            "version": 1,
-            "wells": {
-                "A1": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 14.38,
-                    "y": 74.22,
-                    "z": 1.75
-                },
-                "A10": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 95.38,
-                    "y": 74.22,
-                    "z": 1.75
-                },
-                "A11": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 104.38,
-                    "y": 74.22,
-                    "z": 1.75
-                },
-                "A12": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 113.38,
-                    "y": 74.22,
-                    "z": 1.75
-                },
-                "A2": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 23.38,
-                    "y": 74.22,
-                    "z": 1.75
-                },
-                "A3": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 32.38,
-                    "y": 74.22,
-                    "z": 1.75
-                },
-                "A4": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 41.38,
-                    "y": 74.22,
-                    "z": 1.75
-                },
-                "A5": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 50.38,
-                    "y": 74.22,
-                    "z": 1.75
-                },
-                "A6": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 59.38,
-                    "y": 74.22,
-                    "z": 1.75
-                },
-                "A7": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 68.38,
-                    "y": 74.22,
-                    "z": 1.75
-                },
-                "A8": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 77.38,
-                    "y": 74.22,
-                    "z": 1.75
-                },
-                "A9": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 86.38,
-                    "y": 74.22,
-                    "z": 1.75
-                },
-                "B1": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 14.38,
-                    "y": 65.22,
-                    "z": 1.75
-                },
-                "B10": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 95.38,
-                    "y": 65.22,
-                    "z": 1.75
-                },
-                "B11": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 104.38,
-                    "y": 65.22,
-                    "z": 1.75
-                },
-                "B12": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 113.38,
-                    "y": 65.22,
-                    "z": 1.75
-                },
-                "B2": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 23.38,
-                    "y": 65.22,
-                    "z": 1.75
-                },
-                "B3": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 32.38,
-                    "y": 65.22,
-                    "z": 1.75
-                },
-                "B4": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 41.38,
-                    "y": 65.22,
-                    "z": 1.75
-                },
-                "B5": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 50.38,
-                    "y": 65.22,
-                    "z": 1.75
-                },
-                "B6": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 59.38,
-                    "y": 65.22,
-                    "z": 1.75
-                },
-                "B7": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 68.38,
-                    "y": 65.22,
-                    "z": 1.75
-                },
-                "B8": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 77.38,
-                    "y": 65.22,
-                    "z": 1.75
-                },
-                "B9": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 86.38,
-                    "y": 65.22,
-                    "z": 1.75
-                },
-                "C1": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 14.38,
-                    "y": 56.22,
-                    "z": 1.75
-                },
-                "C10": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 95.38,
-                    "y": 56.22,
-                    "z": 1.75
-                },
-                "C11": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 104.38,
-                    "y": 56.22,
-                    "z": 1.75
-                },
-                "C12": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 113.38,
-                    "y": 56.22,
-                    "z": 1.75
-                },
-                "C2": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 23.38,
-                    "y": 56.22,
-                    "z": 1.75
-                },
-                "C3": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 32.38,
-                    "y": 56.22,
-                    "z": 1.75
-                },
-                "C4": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 41.38,
-                    "y": 56.22,
-                    "z": 1.75
-                },
-                "C5": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 50.38,
-                    "y": 56.22,
-                    "z": 1.75
-                },
-                "C6": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 59.38,
-                    "y": 56.22,
-                    "z": 1.75
-                },
-                "C7": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 68.38,
-                    "y": 56.22,
-                    "z": 1.75
-                },
-                "C8": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 77.38,
-                    "y": 56.22,
-                    "z": 1.75
-                },
-                "C9": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 86.38,
-                    "y": 56.22,
-                    "z": 1.75
-                },
-                "D1": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 14.38,
-                    "y": 47.22,
-                    "z": 1.75
-                },
-                "D10": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 95.38,
-                    "y": 47.22,
-                    "z": 1.75
-                },
-                "D11": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 104.38,
-                    "y": 47.22,
-                    "z": 1.75
-                },
-                "D12": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 113.38,
-                    "y": 47.22,
-                    "z": 1.75
-                },
-                "D2": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 23.38,
-                    "y": 47.22,
-                    "z": 1.75
-                },
-                "D3": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 32.38,
-                    "y": 47.22,
-                    "z": 1.75
-                },
-                "D4": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 41.38,
-                    "y": 47.22,
-                    "z": 1.75
-                },
-                "D5": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 50.38,
-                    "y": 47.22,
-                    "z": 1.75
-                },
-                "D6": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 59.38,
-                    "y": 47.22,
-                    "z": 1.75
-                },
-                "D7": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 68.38,
-                    "y": 47.22,
-                    "z": 1.75
-                },
-                "D8": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 77.38,
-                    "y": 47.22,
-                    "z": 1.75
-                },
-                "D9": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 86.38,
-                    "y": 47.22,
-                    "z": 1.75
-                },
-                "E1": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 14.38,
-                    "y": 38.22,
-                    "z": 1.75
-                },
-                "E10": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 95.38,
-                    "y": 38.22,
-                    "z": 1.75
-                },
-                "E11": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 104.38,
-                    "y": 38.22,
-                    "z": 1.75
-                },
-                "E12": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 113.38,
-                    "y": 38.22,
-                    "z": 1.75
-                },
-                "E2": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 23.38,
-                    "y": 38.22,
-                    "z": 1.75
-                },
-                "E3": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 32.38,
-                    "y": 38.22,
-                    "z": 1.75
-                },
-                "E4": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 41.38,
-                    "y": 38.22,
-                    "z": 1.75
-                },
-                "E5": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 50.38,
-                    "y": 38.22,
-                    "z": 1.75
-                },
-                "E6": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 59.38,
-                    "y": 38.22,
-                    "z": 1.75
-                },
-                "E7": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 68.38,
-                    "y": 38.22,
-                    "z": 1.75
-                },
-                "E8": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 77.38,
-                    "y": 38.22,
-                    "z": 1.75
-                },
-                "E9": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 86.38,
-                    "y": 38.22,
-                    "z": 1.75
-                },
-                "F1": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 14.38,
-                    "y": 29.22,
-                    "z": 1.75
-                },
-                "F10": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 95.38,
-                    "y": 29.22,
-                    "z": 1.75
-                },
-                "F11": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 104.38,
-                    "y": 29.22,
-                    "z": 1.75
-                },
-                "F12": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 113.38,
-                    "y": 29.22,
-                    "z": 1.75
-                },
-                "F2": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 23.38,
-                    "y": 29.22,
-                    "z": 1.75
-                },
-                "F3": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 32.38,
-                    "y": 29.22,
-                    "z": 1.75
-                },
-                "F4": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 41.38,
-                    "y": 29.22,
-                    "z": 1.75
-                },
-                "F5": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 50.38,
-                    "y": 29.22,
-                    "z": 1.75
-                },
-                "F6": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 59.38,
-                    "y": 29.22,
-                    "z": 1.75
-                },
-                "F7": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 68.38,
-                    "y": 29.22,
-                    "z": 1.75
-                },
-                "F8": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 77.38,
-                    "y": 29.22,
-                    "z": 1.75
-                },
-                "F9": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 86.38,
-                    "y": 29.22,
-                    "z": 1.75
-                },
-                "G1": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 14.38,
-                    "y": 20.22,
-                    "z": 1.75
-                },
-                "G10": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 95.38,
-                    "y": 20.22,
-                    "z": 1.75
-                },
-                "G11": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 104.38,
-                    "y": 20.22,
-                    "z": 1.75
-                },
-                "G12": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 113.38,
-                    "y": 20.22,
-                    "z": 1.75
-                },
-                "G2": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 23.38,
-                    "y": 20.22,
-                    "z": 1.75
-                },
-                "G3": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 32.38,
-                    "y": 20.22,
-                    "z": 1.75
-                },
-                "G4": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 41.38,
-                    "y": 20.22,
-                    "z": 1.75
-                },
-                "G5": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 50.38,
-                    "y": 20.22,
-                    "z": 1.75
-                },
-                "G6": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 59.38,
-                    "y": 20.22,
-                    "z": 1.75
-                },
-                "G7": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 68.38,
-                    "y": 20.22,
-                    "z": 1.75
-                },
-                "G8": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 77.38,
-                    "y": 20.22,
-                    "z": 1.75
-                },
-                "G9": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 86.38,
-                    "y": 20.22,
-                    "z": 1.75
-                },
-                "H1": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 14.38,
-                    "y": 11.22,
-                    "z": 1.75
-                },
-                "H10": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 95.38,
-                    "y": 11.22,
-                    "z": 1.75
-                },
-                "H11": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 104.38,
-                    "y": 11.22,
-                    "z": 1.75
-                },
-                "H12": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 113.38,
-                    "y": 11.22,
-                    "z": 1.75
-                },
-                "H2": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 23.38,
-                    "y": 11.22,
-                    "z": 1.75
-                },
-                "H3": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 32.38,
-                    "y": 11.22,
-                    "z": 1.75
-                },
-                "H4": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 41.38,
-                    "y": 11.22,
-                    "z": 1.75
-                },
-                "H5": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 50.38,
-                    "y": 11.22,
-                    "z": 1.75
-                },
-                "H6": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 59.38,
-                    "y": 11.22,
-                    "z": 1.75
-                },
-                "H7": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 68.38,
-                    "y": 11.22,
-                    "z": 1.75
-                },
-                "H8": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 77.38,
-                    "y": 11.22,
-                    "z": 1.75
-                },
-                "H9": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 86.38,
-                    "y": 11.22,
-                    "z": 1.75
-                }
-            }
-        },
-        {
-            "brand": {
                 "brand": "Micronics",
                 "brandId": []
             },
@@ -2260,6 +1129,1137 @@
                     "x": 86.38,
                     "y": 11.26,
                     "z": 7.5
+                }
+            }
+        },
+        {
+            "brand": {
+                "brand": "Axygen",
+                "brandId": []
+            },
+            "cornerOffsetFromSlot": {
+                "x": 0,
+                "y": 0,
+                "z": 0
+            },
+            "dimensions": {
+                "xDimension": 127.8,
+                "yDimension": 85.4,
+                "zDimension": 15.75
+            },
+            "groups": [
+                {
+                    "brand": {
+                        "brand": "Axygen",
+                        "brandId": []
+                    },
+                    "metadata": {
+                        "displayCategory": "wellPlate",
+                        "displayName": "Axygen 96 Well Plate",
+                        "wellBottomShape": "u"
+                    },
+                    "wells": [
+                        "A1",
+                        "B1",
+                        "C1",
+                        "D1",
+                        "E1",
+                        "F1",
+                        "G1",
+                        "H1",
+                        "A2",
+                        "B2",
+                        "C2",
+                        "D2",
+                        "E2",
+                        "F2",
+                        "G2",
+                        "H2",
+                        "A3",
+                        "B3",
+                        "C3",
+                        "D3",
+                        "E3",
+                        "F3",
+                        "G3",
+                        "H3",
+                        "A4",
+                        "B4",
+                        "C4",
+                        "D4",
+                        "E4",
+                        "F4",
+                        "G4",
+                        "H4",
+                        "A5",
+                        "B5",
+                        "C5",
+                        "D5",
+                        "E5",
+                        "F5",
+                        "G5",
+                        "H5",
+                        "A6",
+                        "B6",
+                        "C6",
+                        "D6",
+                        "E6",
+                        "F6",
+                        "G6",
+                        "H6",
+                        "A7",
+                        "B7",
+                        "C7",
+                        "D7",
+                        "E7",
+                        "F7",
+                        "G7",
+                        "H7",
+                        "A8",
+                        "B8",
+                        "C8",
+                        "D8",
+                        "E8",
+                        "F8",
+                        "G8",
+                        "H8",
+                        "A9",
+                        "B9",
+                        "C9",
+                        "D9",
+                        "E9",
+                        "F9",
+                        "G9",
+                        "H9",
+                        "A10",
+                        "B10",
+                        "C10",
+                        "D10",
+                        "E10",
+                        "F10",
+                        "G10",
+                        "H10",
+                        "A11",
+                        "B11",
+                        "C11",
+                        "D11",
+                        "E11",
+                        "F11",
+                        "G11",
+                        "H11",
+                        "A12",
+                        "B12",
+                        "C12",
+                        "D12",
+                        "E12",
+                        "F12",
+                        "G12",
+                        "H12"
+                    ]
+                }
+            ],
+            "metadata": {
+                "displayCategory": "wellPlate",
+                "displayName": "Axygen 96 Well Plate",
+                "displayVolumeUnits": "\u00b5L",
+                "tags": []
+            },
+            "namespace": "custom_beta",
+            "ordering": [
+                [
+                    "A1",
+                    "B1",
+                    "C1",
+                    "D1",
+                    "E1",
+                    "F1",
+                    "G1",
+                    "H1"
+                ],
+                [
+                    "A2",
+                    "B2",
+                    "C2",
+                    "D2",
+                    "E2",
+                    "F2",
+                    "G2",
+                    "H2"
+                ],
+                [
+                    "A3",
+                    "B3",
+                    "C3",
+                    "D3",
+                    "E3",
+                    "F3",
+                    "G3",
+                    "H3"
+                ],
+                [
+                    "A4",
+                    "B4",
+                    "C4",
+                    "D4",
+                    "E4",
+                    "F4",
+                    "G4",
+                    "H4"
+                ],
+                [
+                    "A5",
+                    "B5",
+                    "C5",
+                    "D5",
+                    "E5",
+                    "F5",
+                    "G5",
+                    "H5"
+                ],
+                [
+                    "A6",
+                    "B6",
+                    "C6",
+                    "D6",
+                    "E6",
+                    "F6",
+                    "G6",
+                    "H6"
+                ],
+                [
+                    "A7",
+                    "B7",
+                    "C7",
+                    "D7",
+                    "E7",
+                    "F7",
+                    "G7",
+                    "H7"
+                ],
+                [
+                    "A8",
+                    "B8",
+                    "C8",
+                    "D8",
+                    "E8",
+                    "F8",
+                    "G8",
+                    "H8"
+                ],
+                [
+                    "A9",
+                    "B9",
+                    "C9",
+                    "D9",
+                    "E9",
+                    "F9",
+                    "G9",
+                    "H9"
+                ],
+                [
+                    "A10",
+                    "B10",
+                    "C10",
+                    "D10",
+                    "E10",
+                    "F10",
+                    "G10",
+                    "H10"
+                ],
+                [
+                    "A11",
+                    "B11",
+                    "C11",
+                    "D11",
+                    "E11",
+                    "F11",
+                    "G11",
+                    "H11"
+                ],
+                [
+                    "A12",
+                    "B12",
+                    "C12",
+                    "D12",
+                    "E12",
+                    "F12",
+                    "G12",
+                    "H12"
+                ]
+            ],
+            "parameters": {
+                "format": "irregular",
+                "isMagneticModuleCompatible": false,
+                "isTiprack": false,
+                "loadName": "axygen_96_wellplate",
+                "quirks": []
+            },
+            "schemaVersion": 2,
+            "version": 1,
+            "wells": {
+                "A1": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 14.38,
+                    "y": 74.22,
+                    "z": 1.75
+                },
+                "A10": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 95.38,
+                    "y": 74.22,
+                    "z": 1.75
+                },
+                "A11": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 104.38,
+                    "y": 74.22,
+                    "z": 1.75
+                },
+                "A12": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 113.38,
+                    "y": 74.22,
+                    "z": 1.75
+                },
+                "A2": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 23.38,
+                    "y": 74.22,
+                    "z": 1.75
+                },
+                "A3": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 32.38,
+                    "y": 74.22,
+                    "z": 1.75
+                },
+                "A4": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 41.38,
+                    "y": 74.22,
+                    "z": 1.75
+                },
+                "A5": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 50.38,
+                    "y": 74.22,
+                    "z": 1.75
+                },
+                "A6": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 59.38,
+                    "y": 74.22,
+                    "z": 1.75
+                },
+                "A7": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 68.38,
+                    "y": 74.22,
+                    "z": 1.75
+                },
+                "A8": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 77.38,
+                    "y": 74.22,
+                    "z": 1.75
+                },
+                "A9": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 86.38,
+                    "y": 74.22,
+                    "z": 1.75
+                },
+                "B1": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 14.38,
+                    "y": 65.22,
+                    "z": 1.75
+                },
+                "B10": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 95.38,
+                    "y": 65.22,
+                    "z": 1.75
+                },
+                "B11": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 104.38,
+                    "y": 65.22,
+                    "z": 1.75
+                },
+                "B12": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 113.38,
+                    "y": 65.22,
+                    "z": 1.75
+                },
+                "B2": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 23.38,
+                    "y": 65.22,
+                    "z": 1.75
+                },
+                "B3": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 32.38,
+                    "y": 65.22,
+                    "z": 1.75
+                },
+                "B4": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 41.38,
+                    "y": 65.22,
+                    "z": 1.75
+                },
+                "B5": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 50.38,
+                    "y": 65.22,
+                    "z": 1.75
+                },
+                "B6": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 59.38,
+                    "y": 65.22,
+                    "z": 1.75
+                },
+                "B7": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 68.38,
+                    "y": 65.22,
+                    "z": 1.75
+                },
+                "B8": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 77.38,
+                    "y": 65.22,
+                    "z": 1.75
+                },
+                "B9": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 86.38,
+                    "y": 65.22,
+                    "z": 1.75
+                },
+                "C1": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 14.38,
+                    "y": 56.22,
+                    "z": 1.75
+                },
+                "C10": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 95.38,
+                    "y": 56.22,
+                    "z": 1.75
+                },
+                "C11": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 104.38,
+                    "y": 56.22,
+                    "z": 1.75
+                },
+                "C12": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 113.38,
+                    "y": 56.22,
+                    "z": 1.75
+                },
+                "C2": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 23.38,
+                    "y": 56.22,
+                    "z": 1.75
+                },
+                "C3": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 32.38,
+                    "y": 56.22,
+                    "z": 1.75
+                },
+                "C4": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 41.38,
+                    "y": 56.22,
+                    "z": 1.75
+                },
+                "C5": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 50.38,
+                    "y": 56.22,
+                    "z": 1.75
+                },
+                "C6": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 59.38,
+                    "y": 56.22,
+                    "z": 1.75
+                },
+                "C7": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 68.38,
+                    "y": 56.22,
+                    "z": 1.75
+                },
+                "C8": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 77.38,
+                    "y": 56.22,
+                    "z": 1.75
+                },
+                "C9": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 86.38,
+                    "y": 56.22,
+                    "z": 1.75
+                },
+                "D1": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 14.38,
+                    "y": 47.22,
+                    "z": 1.75
+                },
+                "D10": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 95.38,
+                    "y": 47.22,
+                    "z": 1.75
+                },
+                "D11": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 104.38,
+                    "y": 47.22,
+                    "z": 1.75
+                },
+                "D12": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 113.38,
+                    "y": 47.22,
+                    "z": 1.75
+                },
+                "D2": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 23.38,
+                    "y": 47.22,
+                    "z": 1.75
+                },
+                "D3": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 32.38,
+                    "y": 47.22,
+                    "z": 1.75
+                },
+                "D4": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 41.38,
+                    "y": 47.22,
+                    "z": 1.75
+                },
+                "D5": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 50.38,
+                    "y": 47.22,
+                    "z": 1.75
+                },
+                "D6": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 59.38,
+                    "y": 47.22,
+                    "z": 1.75
+                },
+                "D7": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 68.38,
+                    "y": 47.22,
+                    "z": 1.75
+                },
+                "D8": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 77.38,
+                    "y": 47.22,
+                    "z": 1.75
+                },
+                "D9": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 86.38,
+                    "y": 47.22,
+                    "z": 1.75
+                },
+                "E1": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 14.38,
+                    "y": 38.22,
+                    "z": 1.75
+                },
+                "E10": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 95.38,
+                    "y": 38.22,
+                    "z": 1.75
+                },
+                "E11": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 104.38,
+                    "y": 38.22,
+                    "z": 1.75
+                },
+                "E12": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 113.38,
+                    "y": 38.22,
+                    "z": 1.75
+                },
+                "E2": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 23.38,
+                    "y": 38.22,
+                    "z": 1.75
+                },
+                "E3": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 32.38,
+                    "y": 38.22,
+                    "z": 1.75
+                },
+                "E4": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 41.38,
+                    "y": 38.22,
+                    "z": 1.75
+                },
+                "E5": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 50.38,
+                    "y": 38.22,
+                    "z": 1.75
+                },
+                "E6": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 59.38,
+                    "y": 38.22,
+                    "z": 1.75
+                },
+                "E7": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 68.38,
+                    "y": 38.22,
+                    "z": 1.75
+                },
+                "E8": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 77.38,
+                    "y": 38.22,
+                    "z": 1.75
+                },
+                "E9": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 86.38,
+                    "y": 38.22,
+                    "z": 1.75
+                },
+                "F1": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 14.38,
+                    "y": 29.22,
+                    "z": 1.75
+                },
+                "F10": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 95.38,
+                    "y": 29.22,
+                    "z": 1.75
+                },
+                "F11": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 104.38,
+                    "y": 29.22,
+                    "z": 1.75
+                },
+                "F12": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 113.38,
+                    "y": 29.22,
+                    "z": 1.75
+                },
+                "F2": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 23.38,
+                    "y": 29.22,
+                    "z": 1.75
+                },
+                "F3": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 32.38,
+                    "y": 29.22,
+                    "z": 1.75
+                },
+                "F4": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 41.38,
+                    "y": 29.22,
+                    "z": 1.75
+                },
+                "F5": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 50.38,
+                    "y": 29.22,
+                    "z": 1.75
+                },
+                "F6": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 59.38,
+                    "y": 29.22,
+                    "z": 1.75
+                },
+                "F7": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 68.38,
+                    "y": 29.22,
+                    "z": 1.75
+                },
+                "F8": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 77.38,
+                    "y": 29.22,
+                    "z": 1.75
+                },
+                "F9": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 86.38,
+                    "y": 29.22,
+                    "z": 1.75
+                },
+                "G1": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 14.38,
+                    "y": 20.22,
+                    "z": 1.75
+                },
+                "G10": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 95.38,
+                    "y": 20.22,
+                    "z": 1.75
+                },
+                "G11": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 104.38,
+                    "y": 20.22,
+                    "z": 1.75
+                },
+                "G12": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 113.38,
+                    "y": 20.22,
+                    "z": 1.75
+                },
+                "G2": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 23.38,
+                    "y": 20.22,
+                    "z": 1.75
+                },
+                "G3": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 32.38,
+                    "y": 20.22,
+                    "z": 1.75
+                },
+                "G4": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 41.38,
+                    "y": 20.22,
+                    "z": 1.75
+                },
+                "G5": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 50.38,
+                    "y": 20.22,
+                    "z": 1.75
+                },
+                "G6": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 59.38,
+                    "y": 20.22,
+                    "z": 1.75
+                },
+                "G7": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 68.38,
+                    "y": 20.22,
+                    "z": 1.75
+                },
+                "G8": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 77.38,
+                    "y": 20.22,
+                    "z": 1.75
+                },
+                "G9": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 86.38,
+                    "y": 20.22,
+                    "z": 1.75
+                },
+                "H1": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 14.38,
+                    "y": 11.22,
+                    "z": 1.75
+                },
+                "H10": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 95.38,
+                    "y": 11.22,
+                    "z": 1.75
+                },
+                "H11": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 104.38,
+                    "y": 11.22,
+                    "z": 1.75
+                },
+                "H12": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 113.38,
+                    "y": 11.22,
+                    "z": 1.75
+                },
+                "H2": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 23.38,
+                    "y": 11.22,
+                    "z": 1.75
+                },
+                "H3": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 32.38,
+                    "y": 11.22,
+                    "z": 1.75
+                },
+                "H4": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 41.38,
+                    "y": 11.22,
+                    "z": 1.75
+                },
+                "H5": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 50.38,
+                    "y": 11.22,
+                    "z": 1.75
+                },
+                "H6": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 59.38,
+                    "y": 11.22,
+                    "z": 1.75
+                },
+                "H7": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 68.38,
+                    "y": 11.22,
+                    "z": 1.75
+                },
+                "H8": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 77.38,
+                    "y": 11.22,
+                    "z": 1.75
+                },
+                "H9": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 86.38,
+                    "y": 11.22,
+                    "z": 1.75
                 }
             }
         }

--- a/protoBuilds/08878b/08878b.ot2.apiv2.py.json
+++ b/protoBuilds/08878b/08878b.ot2.apiv2.py.json
@@ -51,7 +51,7 @@
     ],
     "labware": [
         {
-            "name": "Bio-Rad 96 Well Plate 200 \u00b5L PCR on Temperature Module on 4",
+            "name": "Bio-Rad 96 Well Plate 200 \u00b5L PCR on Temperature Module GEN1 on 4",
             "share": false,
             "slot": "4",
             "type": "biorad_96_wellplate_200ul_pcr"

--- a/protoBuilds/0944e4/ngs_cleanup.ot2.apiv2.py.json
+++ b/protoBuilds/0944e4/ngs_cleanup.ot2.apiv2.py.json
@@ -1213,7 +1213,7 @@
     ],
     "labware": [
         {
-            "name": "magnetic plate on Magnetic Module on 1",
+            "name": "magnetic plate on Magnetic Module GEN1 on 1",
             "share": false,
             "slot": "1",
             "type": "twintec_pcr_plate"

--- a/protoBuilds/09cdbe/cherrypick.ot2.apiv2.py.json
+++ b/protoBuilds/09cdbe/cherrypick.ot2.apiv2.py.json
@@ -3,6 +3,236 @@
     "custom_labware_defs": [
         {
             "brand": {
+                "brand": "VWR",
+                "brandId": [
+                    "10002-731"
+                ]
+            },
+            "cornerOffsetFromSlot": {
+                "x": 0,
+                "y": 0,
+                "z": 0
+            },
+            "dimensions": {
+                "xDimension": 127.76,
+                "yDimension": 85.48,
+                "zDimension": 81
+            },
+            "groups": [
+                {
+                    "brand": {
+                        "brand": "VWR",
+                        "brandId": [
+                            "10002-731"
+                        ]
+                    },
+                    "metadata": {
+                        "displayCategory": "tubeRack",
+                        "displayName": "VWR 15 Tube Rack 5000 \u00b5L",
+                        "wellBottomShape": "v"
+                    },
+                    "wells": [
+                        "A1",
+                        "B1",
+                        "C1",
+                        "A2",
+                        "B2",
+                        "C2",
+                        "A3",
+                        "B3",
+                        "C3",
+                        "A4",
+                        "B4",
+                        "C4",
+                        "A5",
+                        "B5",
+                        "C5"
+                    ]
+                }
+            ],
+            "metadata": {
+                "displayCategory": "tubeRack",
+                "displayName": "VWR 15 Tube Rack 5000 \u00b5L",
+                "displayVolumeUnits": "\u00b5L",
+                "tags": []
+            },
+            "namespace": "custom_beta",
+            "ordering": [
+                [
+                    "A1",
+                    "B1",
+                    "C1"
+                ],
+                [
+                    "A2",
+                    "B2",
+                    "C2"
+                ],
+                [
+                    "A3",
+                    "B3",
+                    "C3"
+                ],
+                [
+                    "A4",
+                    "B4",
+                    "C4"
+                ],
+                [
+                    "A5",
+                    "B5",
+                    "C5"
+                ]
+            ],
+            "parameters": {
+                "format": "irregular",
+                "isMagneticModuleCompatible": false,
+                "isTiprack": false,
+                "loadName": "vwr_15_tuberack_5000ul",
+                "quirks": []
+            },
+            "schemaVersion": 2,
+            "version": 1,
+            "wells": {
+                "A1": {
+                    "depth": 56,
+                    "diameter": 16,
+                    "shape": "circular",
+                    "totalLiquidVolume": 5000,
+                    "x": 13.88,
+                    "y": 67.74,
+                    "z": 25
+                },
+                "A2": {
+                    "depth": 56,
+                    "diameter": 16,
+                    "shape": "circular",
+                    "totalLiquidVolume": 5000,
+                    "x": 38.88,
+                    "y": 67.74,
+                    "z": 25
+                },
+                "A3": {
+                    "depth": 56,
+                    "diameter": 16,
+                    "shape": "circular",
+                    "totalLiquidVolume": 5000,
+                    "x": 63.88,
+                    "y": 67.74,
+                    "z": 25
+                },
+                "A4": {
+                    "depth": 56,
+                    "diameter": 16,
+                    "shape": "circular",
+                    "totalLiquidVolume": 5000,
+                    "x": 88.88,
+                    "y": 67.74,
+                    "z": 25
+                },
+                "A5": {
+                    "depth": 56,
+                    "diameter": 16,
+                    "shape": "circular",
+                    "totalLiquidVolume": 5000,
+                    "x": 113.88,
+                    "y": 67.74,
+                    "z": 25
+                },
+                "B1": {
+                    "depth": 56,
+                    "diameter": 16,
+                    "shape": "circular",
+                    "totalLiquidVolume": 5000,
+                    "x": 13.88,
+                    "y": 42.74,
+                    "z": 25
+                },
+                "B2": {
+                    "depth": 56,
+                    "diameter": 16,
+                    "shape": "circular",
+                    "totalLiquidVolume": 5000,
+                    "x": 38.88,
+                    "y": 42.74,
+                    "z": 25
+                },
+                "B3": {
+                    "depth": 56,
+                    "diameter": 16,
+                    "shape": "circular",
+                    "totalLiquidVolume": 5000,
+                    "x": 63.88,
+                    "y": 42.74,
+                    "z": 25
+                },
+                "B4": {
+                    "depth": 56,
+                    "diameter": 16,
+                    "shape": "circular",
+                    "totalLiquidVolume": 5000,
+                    "x": 88.88,
+                    "y": 42.74,
+                    "z": 25
+                },
+                "B5": {
+                    "depth": 56,
+                    "diameter": 16,
+                    "shape": "circular",
+                    "totalLiquidVolume": 5000,
+                    "x": 113.88,
+                    "y": 42.74,
+                    "z": 25
+                },
+                "C1": {
+                    "depth": 56,
+                    "diameter": 16,
+                    "shape": "circular",
+                    "totalLiquidVolume": 5000,
+                    "x": 13.88,
+                    "y": 17.74,
+                    "z": 25
+                },
+                "C2": {
+                    "depth": 56,
+                    "diameter": 16,
+                    "shape": "circular",
+                    "totalLiquidVolume": 5000,
+                    "x": 38.88,
+                    "y": 17.74,
+                    "z": 25
+                },
+                "C3": {
+                    "depth": 56,
+                    "diameter": 16,
+                    "shape": "circular",
+                    "totalLiquidVolume": 5000,
+                    "x": 63.88,
+                    "y": 17.74,
+                    "z": 25
+                },
+                "C4": {
+                    "depth": 56,
+                    "diameter": 16,
+                    "shape": "circular",
+                    "totalLiquidVolume": 5000,
+                    "x": 88.88,
+                    "y": 17.74,
+                    "z": 25
+                },
+                "C5": {
+                    "depth": 56,
+                    "diameter": 16,
+                    "shape": "circular",
+                    "totalLiquidVolume": 5000,
+                    "x": 113.88,
+                    "y": 17.74,
+                    "z": 25
+                }
+            }
+        },
+        {
+            "brand": {
                 "brand": "Axygen",
                 "brandId": [
                     "14-222-327"
@@ -1133,236 +1363,6 @@
                     "x": 86.38,
                     "y": 11.24,
                     "z": 1.1
-                }
-            }
-        },
-        {
-            "brand": {
-                "brand": "VWR",
-                "brandId": [
-                    "10002-731"
-                ]
-            },
-            "cornerOffsetFromSlot": {
-                "x": 0,
-                "y": 0,
-                "z": 0
-            },
-            "dimensions": {
-                "xDimension": 127.76,
-                "yDimension": 85.48,
-                "zDimension": 81
-            },
-            "groups": [
-                {
-                    "brand": {
-                        "brand": "VWR",
-                        "brandId": [
-                            "10002-731"
-                        ]
-                    },
-                    "metadata": {
-                        "displayCategory": "tubeRack",
-                        "displayName": "VWR 15 Tube Rack 5000 \u00b5L",
-                        "wellBottomShape": "v"
-                    },
-                    "wells": [
-                        "A1",
-                        "B1",
-                        "C1",
-                        "A2",
-                        "B2",
-                        "C2",
-                        "A3",
-                        "B3",
-                        "C3",
-                        "A4",
-                        "B4",
-                        "C4",
-                        "A5",
-                        "B5",
-                        "C5"
-                    ]
-                }
-            ],
-            "metadata": {
-                "displayCategory": "tubeRack",
-                "displayName": "VWR 15 Tube Rack 5000 \u00b5L",
-                "displayVolumeUnits": "\u00b5L",
-                "tags": []
-            },
-            "namespace": "custom_beta",
-            "ordering": [
-                [
-                    "A1",
-                    "B1",
-                    "C1"
-                ],
-                [
-                    "A2",
-                    "B2",
-                    "C2"
-                ],
-                [
-                    "A3",
-                    "B3",
-                    "C3"
-                ],
-                [
-                    "A4",
-                    "B4",
-                    "C4"
-                ],
-                [
-                    "A5",
-                    "B5",
-                    "C5"
-                ]
-            ],
-            "parameters": {
-                "format": "irregular",
-                "isMagneticModuleCompatible": false,
-                "isTiprack": false,
-                "loadName": "vwr_15_tuberack_5000ul",
-                "quirks": []
-            },
-            "schemaVersion": 2,
-            "version": 1,
-            "wells": {
-                "A1": {
-                    "depth": 56,
-                    "diameter": 16,
-                    "shape": "circular",
-                    "totalLiquidVolume": 5000,
-                    "x": 13.88,
-                    "y": 67.74,
-                    "z": 25
-                },
-                "A2": {
-                    "depth": 56,
-                    "diameter": 16,
-                    "shape": "circular",
-                    "totalLiquidVolume": 5000,
-                    "x": 38.88,
-                    "y": 67.74,
-                    "z": 25
-                },
-                "A3": {
-                    "depth": 56,
-                    "diameter": 16,
-                    "shape": "circular",
-                    "totalLiquidVolume": 5000,
-                    "x": 63.88,
-                    "y": 67.74,
-                    "z": 25
-                },
-                "A4": {
-                    "depth": 56,
-                    "diameter": 16,
-                    "shape": "circular",
-                    "totalLiquidVolume": 5000,
-                    "x": 88.88,
-                    "y": 67.74,
-                    "z": 25
-                },
-                "A5": {
-                    "depth": 56,
-                    "diameter": 16,
-                    "shape": "circular",
-                    "totalLiquidVolume": 5000,
-                    "x": 113.88,
-                    "y": 67.74,
-                    "z": 25
-                },
-                "B1": {
-                    "depth": 56,
-                    "diameter": 16,
-                    "shape": "circular",
-                    "totalLiquidVolume": 5000,
-                    "x": 13.88,
-                    "y": 42.74,
-                    "z": 25
-                },
-                "B2": {
-                    "depth": 56,
-                    "diameter": 16,
-                    "shape": "circular",
-                    "totalLiquidVolume": 5000,
-                    "x": 38.88,
-                    "y": 42.74,
-                    "z": 25
-                },
-                "B3": {
-                    "depth": 56,
-                    "diameter": 16,
-                    "shape": "circular",
-                    "totalLiquidVolume": 5000,
-                    "x": 63.88,
-                    "y": 42.74,
-                    "z": 25
-                },
-                "B4": {
-                    "depth": 56,
-                    "diameter": 16,
-                    "shape": "circular",
-                    "totalLiquidVolume": 5000,
-                    "x": 88.88,
-                    "y": 42.74,
-                    "z": 25
-                },
-                "B5": {
-                    "depth": 56,
-                    "diameter": 16,
-                    "shape": "circular",
-                    "totalLiquidVolume": 5000,
-                    "x": 113.88,
-                    "y": 42.74,
-                    "z": 25
-                },
-                "C1": {
-                    "depth": 56,
-                    "diameter": 16,
-                    "shape": "circular",
-                    "totalLiquidVolume": 5000,
-                    "x": 13.88,
-                    "y": 17.74,
-                    "z": 25
-                },
-                "C2": {
-                    "depth": 56,
-                    "diameter": 16,
-                    "shape": "circular",
-                    "totalLiquidVolume": 5000,
-                    "x": 38.88,
-                    "y": 17.74,
-                    "z": 25
-                },
-                "C3": {
-                    "depth": 56,
-                    "diameter": 16,
-                    "shape": "circular",
-                    "totalLiquidVolume": 5000,
-                    "x": 63.88,
-                    "y": 17.74,
-                    "z": 25
-                },
-                "C4": {
-                    "depth": 56,
-                    "diameter": 16,
-                    "shape": "circular",
-                    "totalLiquidVolume": 5000,
-                    "x": 88.88,
-                    "y": 17.74,
-                    "z": 25
-                },
-                "C5": {
-                    "depth": 56,
-                    "diameter": 16,
-                    "shape": "circular",
-                    "totalLiquidVolume": 5000,
-                    "x": 113.88,
-                    "y": 17.74,
-                    "z": 25
                 }
             }
         },

--- a/protoBuilds/131de0/cnv.ot2.apiv2.py.json
+++ b/protoBuilds/131de0/cnv.ot2.apiv2.py.json
@@ -3,1201 +3,6 @@
     "custom_labware_defs": [
         {
             "brand": {
-                "brand": "USA Scientific",
-                "brandId": []
-            },
-            "cornerOffsetFromSlot": {
-                "x": 0,
-                "y": 0,
-                "z": 0
-            },
-            "dimensions": {
-                "xDimension": 127.76,
-                "yDimension": 85.47,
-                "zDimension": 15.5
-            },
-            "groups": [
-                {
-                    "brand": {
-                        "brand": "USA Scientific",
-                        "brandId": []
-                    },
-                    "metadata": {
-                        "displayCategory": "wellPlate",
-                        "displayName": "USA Scientific 96 Well Plate 100 \u00b5L",
-                        "wellBottomShape": "v"
-                    },
-                    "wells": [
-                        "A1",
-                        "B1",
-                        "C1",
-                        "D1",
-                        "E1",
-                        "F1",
-                        "G1",
-                        "H1",
-                        "A2",
-                        "B2",
-                        "C2",
-                        "D2",
-                        "E2",
-                        "F2",
-                        "G2",
-                        "H2",
-                        "A3",
-                        "B3",
-                        "C3",
-                        "D3",
-                        "E3",
-                        "F3",
-                        "G3",
-                        "H3",
-                        "A4",
-                        "B4",
-                        "C4",
-                        "D4",
-                        "E4",
-                        "F4",
-                        "G4",
-                        "H4",
-                        "A5",
-                        "B5",
-                        "C5",
-                        "D5",
-                        "E5",
-                        "F5",
-                        "G5",
-                        "H5",
-                        "A6",
-                        "B6",
-                        "C6",
-                        "D6",
-                        "E6",
-                        "F6",
-                        "G6",
-                        "H6",
-                        "A7",
-                        "B7",
-                        "C7",
-                        "D7",
-                        "E7",
-                        "F7",
-                        "G7",
-                        "H7",
-                        "A8",
-                        "B8",
-                        "C8",
-                        "D8",
-                        "E8",
-                        "F8",
-                        "G8",
-                        "H8",
-                        "A9",
-                        "B9",
-                        "C9",
-                        "D9",
-                        "E9",
-                        "F9",
-                        "G9",
-                        "H9",
-                        "A10",
-                        "B10",
-                        "C10",
-                        "D10",
-                        "E10",
-                        "F10",
-                        "G10",
-                        "H10",
-                        "A11",
-                        "B11",
-                        "C11",
-                        "D11",
-                        "E11",
-                        "F11",
-                        "G11",
-                        "H11",
-                        "A12",
-                        "B12",
-                        "C12",
-                        "D12",
-                        "E12",
-                        "F12",
-                        "G12",
-                        "H12"
-                    ]
-                }
-            ],
-            "metadata": {
-                "displayCategory": "wellPlate",
-                "displayName": "USA Scientific 96 Well Plate 100 \u00b5L",
-                "displayVolumeUnits": "\u00b5L",
-                "tags": []
-            },
-            "namespace": "custom_beta",
-            "ordering": [
-                [
-                    "A1",
-                    "B1",
-                    "C1",
-                    "D1",
-                    "E1",
-                    "F1",
-                    "G1",
-                    "H1"
-                ],
-                [
-                    "A2",
-                    "B2",
-                    "C2",
-                    "D2",
-                    "E2",
-                    "F2",
-                    "G2",
-                    "H2"
-                ],
-                [
-                    "A3",
-                    "B3",
-                    "C3",
-                    "D3",
-                    "E3",
-                    "F3",
-                    "G3",
-                    "H3"
-                ],
-                [
-                    "A4",
-                    "B4",
-                    "C4",
-                    "D4",
-                    "E4",
-                    "F4",
-                    "G4",
-                    "H4"
-                ],
-                [
-                    "A5",
-                    "B5",
-                    "C5",
-                    "D5",
-                    "E5",
-                    "F5",
-                    "G5",
-                    "H5"
-                ],
-                [
-                    "A6",
-                    "B6",
-                    "C6",
-                    "D6",
-                    "E6",
-                    "F6",
-                    "G6",
-                    "H6"
-                ],
-                [
-                    "A7",
-                    "B7",
-                    "C7",
-                    "D7",
-                    "E7",
-                    "F7",
-                    "G7",
-                    "H7"
-                ],
-                [
-                    "A8",
-                    "B8",
-                    "C8",
-                    "D8",
-                    "E8",
-                    "F8",
-                    "G8",
-                    "H8"
-                ],
-                [
-                    "A9",
-                    "B9",
-                    "C9",
-                    "D9",
-                    "E9",
-                    "F9",
-                    "G9",
-                    "H9"
-                ],
-                [
-                    "A10",
-                    "B10",
-                    "C10",
-                    "D10",
-                    "E10",
-                    "F10",
-                    "G10",
-                    "H10"
-                ],
-                [
-                    "A11",
-                    "B11",
-                    "C11",
-                    "D11",
-                    "E11",
-                    "F11",
-                    "G11",
-                    "H11"
-                ],
-                [
-                    "A12",
-                    "B12",
-                    "C12",
-                    "D12",
-                    "E12",
-                    "F12",
-                    "G12",
-                    "H12"
-                ]
-            ],
-            "parameters": {
-                "format": "irregular",
-                "isMagneticModuleCompatible": false,
-                "isTiprack": false,
-                "loadName": "usascientific_96_wellplate_100ul",
-                "quirks": []
-            },
-            "schemaVersion": 2,
-            "version": 1,
-            "wells": {
-                "A1": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 15,
-                    "y": 75.47,
-                    "z": 0
-                },
-                "A10": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 95.91,
-                    "y": 75.47,
-                    "z": 0
-                },
-                "A11": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 104.9,
-                    "y": 75.47,
-                    "z": 0
-                },
-                "A12": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 113.89,
-                    "y": 75.47,
-                    "z": 0
-                },
-                "A2": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 23.99,
-                    "y": 75.47,
-                    "z": 0
-                },
-                "A3": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 32.98,
-                    "y": 75.47,
-                    "z": 0
-                },
-                "A4": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 41.97,
-                    "y": 75.47,
-                    "z": 0
-                },
-                "A5": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 50.96,
-                    "y": 75.47,
-                    "z": 0
-                },
-                "A6": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 59.95,
-                    "y": 75.47,
-                    "z": 0
-                },
-                "A7": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 68.94,
-                    "y": 75.47,
-                    "z": 0
-                },
-                "A8": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 77.93,
-                    "y": 75.47,
-                    "z": 0
-                },
-                "A9": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 86.92,
-                    "y": 75.47,
-                    "z": 0
-                },
-                "B1": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 15,
-                    "y": 66.48,
-                    "z": 0
-                },
-                "B10": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 95.91,
-                    "y": 66.48,
-                    "z": 0
-                },
-                "B11": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 104.9,
-                    "y": 66.48,
-                    "z": 0
-                },
-                "B12": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 113.89,
-                    "y": 66.48,
-                    "z": 0
-                },
-                "B2": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 23.99,
-                    "y": 66.48,
-                    "z": 0
-                },
-                "B3": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 32.98,
-                    "y": 66.48,
-                    "z": 0
-                },
-                "B4": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 41.97,
-                    "y": 66.48,
-                    "z": 0
-                },
-                "B5": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 50.96,
-                    "y": 66.48,
-                    "z": 0
-                },
-                "B6": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 59.95,
-                    "y": 66.48,
-                    "z": 0
-                },
-                "B7": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 68.94,
-                    "y": 66.48,
-                    "z": 0
-                },
-                "B8": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 77.93,
-                    "y": 66.48,
-                    "z": 0
-                },
-                "B9": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 86.92,
-                    "y": 66.48,
-                    "z": 0
-                },
-                "C1": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 15,
-                    "y": 57.49,
-                    "z": 0
-                },
-                "C10": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 95.91,
-                    "y": 57.49,
-                    "z": 0
-                },
-                "C11": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 104.9,
-                    "y": 57.49,
-                    "z": 0
-                },
-                "C12": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 113.89,
-                    "y": 57.49,
-                    "z": 0
-                },
-                "C2": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 23.99,
-                    "y": 57.49,
-                    "z": 0
-                },
-                "C3": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 32.98,
-                    "y": 57.49,
-                    "z": 0
-                },
-                "C4": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 41.97,
-                    "y": 57.49,
-                    "z": 0
-                },
-                "C5": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 50.96,
-                    "y": 57.49,
-                    "z": 0
-                },
-                "C6": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 59.95,
-                    "y": 57.49,
-                    "z": 0
-                },
-                "C7": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 68.94,
-                    "y": 57.49,
-                    "z": 0
-                },
-                "C8": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 77.93,
-                    "y": 57.49,
-                    "z": 0
-                },
-                "C9": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 86.92,
-                    "y": 57.49,
-                    "z": 0
-                },
-                "D1": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 15,
-                    "y": 48.5,
-                    "z": 0
-                },
-                "D10": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 95.91,
-                    "y": 48.5,
-                    "z": 0
-                },
-                "D11": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 104.9,
-                    "y": 48.5,
-                    "z": 0
-                },
-                "D12": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 113.89,
-                    "y": 48.5,
-                    "z": 0
-                },
-                "D2": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 23.99,
-                    "y": 48.5,
-                    "z": 0
-                },
-                "D3": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 32.98,
-                    "y": 48.5,
-                    "z": 0
-                },
-                "D4": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 41.97,
-                    "y": 48.5,
-                    "z": 0
-                },
-                "D5": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 50.96,
-                    "y": 48.5,
-                    "z": 0
-                },
-                "D6": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 59.95,
-                    "y": 48.5,
-                    "z": 0
-                },
-                "D7": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 68.94,
-                    "y": 48.5,
-                    "z": 0
-                },
-                "D8": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 77.93,
-                    "y": 48.5,
-                    "z": 0
-                },
-                "D9": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 86.92,
-                    "y": 48.5,
-                    "z": 0
-                },
-                "E1": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 15,
-                    "y": 39.51,
-                    "z": 0
-                },
-                "E10": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 95.91,
-                    "y": 39.51,
-                    "z": 0
-                },
-                "E11": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 104.9,
-                    "y": 39.51,
-                    "z": 0
-                },
-                "E12": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 113.89,
-                    "y": 39.51,
-                    "z": 0
-                },
-                "E2": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 23.99,
-                    "y": 39.51,
-                    "z": 0
-                },
-                "E3": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 32.98,
-                    "y": 39.51,
-                    "z": 0
-                },
-                "E4": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 41.97,
-                    "y": 39.51,
-                    "z": 0
-                },
-                "E5": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 50.96,
-                    "y": 39.51,
-                    "z": 0
-                },
-                "E6": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 59.95,
-                    "y": 39.51,
-                    "z": 0
-                },
-                "E7": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 68.94,
-                    "y": 39.51,
-                    "z": 0
-                },
-                "E8": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 77.93,
-                    "y": 39.51,
-                    "z": 0
-                },
-                "E9": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 86.92,
-                    "y": 39.51,
-                    "z": 0
-                },
-                "F1": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 15,
-                    "y": 30.52,
-                    "z": 0
-                },
-                "F10": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 95.91,
-                    "y": 30.52,
-                    "z": 0
-                },
-                "F11": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 104.9,
-                    "y": 30.52,
-                    "z": 0
-                },
-                "F12": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 113.89,
-                    "y": 30.52,
-                    "z": 0
-                },
-                "F2": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 23.99,
-                    "y": 30.52,
-                    "z": 0
-                },
-                "F3": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 32.98,
-                    "y": 30.52,
-                    "z": 0
-                },
-                "F4": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 41.97,
-                    "y": 30.52,
-                    "z": 0
-                },
-                "F5": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 50.96,
-                    "y": 30.52,
-                    "z": 0
-                },
-                "F6": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 59.95,
-                    "y": 30.52,
-                    "z": 0
-                },
-                "F7": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 68.94,
-                    "y": 30.52,
-                    "z": 0
-                },
-                "F8": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 77.93,
-                    "y": 30.52,
-                    "z": 0
-                },
-                "F9": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 86.92,
-                    "y": 30.52,
-                    "z": 0
-                },
-                "G1": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 15,
-                    "y": 21.53,
-                    "z": 0
-                },
-                "G10": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 95.91,
-                    "y": 21.53,
-                    "z": 0
-                },
-                "G11": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 104.9,
-                    "y": 21.53,
-                    "z": 0
-                },
-                "G12": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 113.89,
-                    "y": 21.53,
-                    "z": 0
-                },
-                "G2": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 23.99,
-                    "y": 21.53,
-                    "z": 0
-                },
-                "G3": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 32.98,
-                    "y": 21.53,
-                    "z": 0
-                },
-                "G4": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 41.97,
-                    "y": 21.53,
-                    "z": 0
-                },
-                "G5": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 50.96,
-                    "y": 21.53,
-                    "z": 0
-                },
-                "G6": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 59.95,
-                    "y": 21.53,
-                    "z": 0
-                },
-                "G7": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 68.94,
-                    "y": 21.53,
-                    "z": 0
-                },
-                "G8": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 77.93,
-                    "y": 21.53,
-                    "z": 0
-                },
-                "G9": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 86.92,
-                    "y": 21.53,
-                    "z": 0
-                },
-                "H1": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 15,
-                    "y": 12.54,
-                    "z": 0
-                },
-                "H10": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 95.91,
-                    "y": 12.54,
-                    "z": 0
-                },
-                "H11": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 104.9,
-                    "y": 12.54,
-                    "z": 0
-                },
-                "H12": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 113.89,
-                    "y": 12.54,
-                    "z": 0
-                },
-                "H2": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 23.99,
-                    "y": 12.54,
-                    "z": 0
-                },
-                "H3": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 32.98,
-                    "y": 12.54,
-                    "z": 0
-                },
-                "H4": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 41.97,
-                    "y": 12.54,
-                    "z": 0
-                },
-                "H5": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 50.96,
-                    "y": 12.54,
-                    "z": 0
-                },
-                "H6": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 59.95,
-                    "y": 12.54,
-                    "z": 0
-                },
-                "H7": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 68.94,
-                    "y": 12.54,
-                    "z": 0
-                },
-                "H8": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 77.93,
-                    "y": 12.54,
-                    "z": 0
-                },
-                "H9": {
-                    "depth": 15.5,
-                    "diameter": 5.6,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 86.92,
-                    "y": 12.54,
-                    "z": 0
-                }
-            }
-        },
-        {
-            "brand": {
-                "brand": "Generic",
-                "brandId": []
-            },
-            "cornerOffsetFromSlot": {
-                "x": 0,
-                "y": 0,
-                "z": 0
-            },
-            "dimensions": {
-                "xDimension": 127.8,
-                "yDimension": 85.5,
-                "zDimension": 27
-            },
-            "groups": [
-                {
-                    "brand": {
-                        "brand": "Generic",
-                        "brandId": []
-                    },
-                    "metadata": {
-                        "displayCategory": "reservoir",
-                        "displayName": "Generic 1 Reservoir 25000 \u00b5L",
-                        "wellBottomShape": "v"
-                    },
-                    "wells": [
-                        "A1"
-                    ]
-                }
-            ],
-            "metadata": {
-                "displayCategory": "reservoir",
-                "displayName": "Generic 1 Reservoir 25000 \u00b5L",
-                "displayVolumeUnits": "\u00b5L",
-                "tags": []
-            },
-            "namespace": "custom_beta",
-            "ordering": [
-                [
-                    "A1"
-                ]
-            ],
-            "parameters": {
-                "format": "irregular",
-                "isMagneticModuleCompatible": false,
-                "isTiprack": false,
-                "loadName": "generic_1_reservoir_25000ul",
-                "quirks": []
-            },
-            "schemaVersion": 2,
-            "version": 1,
-            "wells": {
-                "A1": {
-                    "depth": 21.5,
-                    "diameter": 30,
-                    "shape": "circular",
-                    "totalLiquidVolume": 25000,
-                    "x": 25,
-                    "y": 65.5,
-                    "z": 5.5
-                }
-            }
-        },
-        {
-            "brand": {
                 "brand": "MicroAmp Optical",
                 "brandId": []
             },
@@ -5516,6 +4321,1201 @@
                     "x": 48.15,
                     "y": 9,
                     "z": 0.61
+                }
+            }
+        },
+        {
+            "brand": {
+                "brand": "Generic",
+                "brandId": []
+            },
+            "cornerOffsetFromSlot": {
+                "x": 0,
+                "y": 0,
+                "z": 0
+            },
+            "dimensions": {
+                "xDimension": 127.8,
+                "yDimension": 85.5,
+                "zDimension": 27
+            },
+            "groups": [
+                {
+                    "brand": {
+                        "brand": "Generic",
+                        "brandId": []
+                    },
+                    "metadata": {
+                        "displayCategory": "reservoir",
+                        "displayName": "Generic 1 Reservoir 25000 \u00b5L",
+                        "wellBottomShape": "v"
+                    },
+                    "wells": [
+                        "A1"
+                    ]
+                }
+            ],
+            "metadata": {
+                "displayCategory": "reservoir",
+                "displayName": "Generic 1 Reservoir 25000 \u00b5L",
+                "displayVolumeUnits": "\u00b5L",
+                "tags": []
+            },
+            "namespace": "custom_beta",
+            "ordering": [
+                [
+                    "A1"
+                ]
+            ],
+            "parameters": {
+                "format": "irregular",
+                "isMagneticModuleCompatible": false,
+                "isTiprack": false,
+                "loadName": "generic_1_reservoir_25000ul",
+                "quirks": []
+            },
+            "schemaVersion": 2,
+            "version": 1,
+            "wells": {
+                "A1": {
+                    "depth": 21.5,
+                    "diameter": 30,
+                    "shape": "circular",
+                    "totalLiquidVolume": 25000,
+                    "x": 25,
+                    "y": 65.5,
+                    "z": 5.5
+                }
+            }
+        },
+        {
+            "brand": {
+                "brand": "USA Scientific",
+                "brandId": []
+            },
+            "cornerOffsetFromSlot": {
+                "x": 0,
+                "y": 0,
+                "z": 0
+            },
+            "dimensions": {
+                "xDimension": 127.76,
+                "yDimension": 85.47,
+                "zDimension": 15.5
+            },
+            "groups": [
+                {
+                    "brand": {
+                        "brand": "USA Scientific",
+                        "brandId": []
+                    },
+                    "metadata": {
+                        "displayCategory": "wellPlate",
+                        "displayName": "USA Scientific 96 Well Plate 100 \u00b5L",
+                        "wellBottomShape": "v"
+                    },
+                    "wells": [
+                        "A1",
+                        "B1",
+                        "C1",
+                        "D1",
+                        "E1",
+                        "F1",
+                        "G1",
+                        "H1",
+                        "A2",
+                        "B2",
+                        "C2",
+                        "D2",
+                        "E2",
+                        "F2",
+                        "G2",
+                        "H2",
+                        "A3",
+                        "B3",
+                        "C3",
+                        "D3",
+                        "E3",
+                        "F3",
+                        "G3",
+                        "H3",
+                        "A4",
+                        "B4",
+                        "C4",
+                        "D4",
+                        "E4",
+                        "F4",
+                        "G4",
+                        "H4",
+                        "A5",
+                        "B5",
+                        "C5",
+                        "D5",
+                        "E5",
+                        "F5",
+                        "G5",
+                        "H5",
+                        "A6",
+                        "B6",
+                        "C6",
+                        "D6",
+                        "E6",
+                        "F6",
+                        "G6",
+                        "H6",
+                        "A7",
+                        "B7",
+                        "C7",
+                        "D7",
+                        "E7",
+                        "F7",
+                        "G7",
+                        "H7",
+                        "A8",
+                        "B8",
+                        "C8",
+                        "D8",
+                        "E8",
+                        "F8",
+                        "G8",
+                        "H8",
+                        "A9",
+                        "B9",
+                        "C9",
+                        "D9",
+                        "E9",
+                        "F9",
+                        "G9",
+                        "H9",
+                        "A10",
+                        "B10",
+                        "C10",
+                        "D10",
+                        "E10",
+                        "F10",
+                        "G10",
+                        "H10",
+                        "A11",
+                        "B11",
+                        "C11",
+                        "D11",
+                        "E11",
+                        "F11",
+                        "G11",
+                        "H11",
+                        "A12",
+                        "B12",
+                        "C12",
+                        "D12",
+                        "E12",
+                        "F12",
+                        "G12",
+                        "H12"
+                    ]
+                }
+            ],
+            "metadata": {
+                "displayCategory": "wellPlate",
+                "displayName": "USA Scientific 96 Well Plate 100 \u00b5L",
+                "displayVolumeUnits": "\u00b5L",
+                "tags": []
+            },
+            "namespace": "custom_beta",
+            "ordering": [
+                [
+                    "A1",
+                    "B1",
+                    "C1",
+                    "D1",
+                    "E1",
+                    "F1",
+                    "G1",
+                    "H1"
+                ],
+                [
+                    "A2",
+                    "B2",
+                    "C2",
+                    "D2",
+                    "E2",
+                    "F2",
+                    "G2",
+                    "H2"
+                ],
+                [
+                    "A3",
+                    "B3",
+                    "C3",
+                    "D3",
+                    "E3",
+                    "F3",
+                    "G3",
+                    "H3"
+                ],
+                [
+                    "A4",
+                    "B4",
+                    "C4",
+                    "D4",
+                    "E4",
+                    "F4",
+                    "G4",
+                    "H4"
+                ],
+                [
+                    "A5",
+                    "B5",
+                    "C5",
+                    "D5",
+                    "E5",
+                    "F5",
+                    "G5",
+                    "H5"
+                ],
+                [
+                    "A6",
+                    "B6",
+                    "C6",
+                    "D6",
+                    "E6",
+                    "F6",
+                    "G6",
+                    "H6"
+                ],
+                [
+                    "A7",
+                    "B7",
+                    "C7",
+                    "D7",
+                    "E7",
+                    "F7",
+                    "G7",
+                    "H7"
+                ],
+                [
+                    "A8",
+                    "B8",
+                    "C8",
+                    "D8",
+                    "E8",
+                    "F8",
+                    "G8",
+                    "H8"
+                ],
+                [
+                    "A9",
+                    "B9",
+                    "C9",
+                    "D9",
+                    "E9",
+                    "F9",
+                    "G9",
+                    "H9"
+                ],
+                [
+                    "A10",
+                    "B10",
+                    "C10",
+                    "D10",
+                    "E10",
+                    "F10",
+                    "G10",
+                    "H10"
+                ],
+                [
+                    "A11",
+                    "B11",
+                    "C11",
+                    "D11",
+                    "E11",
+                    "F11",
+                    "G11",
+                    "H11"
+                ],
+                [
+                    "A12",
+                    "B12",
+                    "C12",
+                    "D12",
+                    "E12",
+                    "F12",
+                    "G12",
+                    "H12"
+                ]
+            ],
+            "parameters": {
+                "format": "irregular",
+                "isMagneticModuleCompatible": false,
+                "isTiprack": false,
+                "loadName": "usascientific_96_wellplate_100ul",
+                "quirks": []
+            },
+            "schemaVersion": 2,
+            "version": 1,
+            "wells": {
+                "A1": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 15,
+                    "y": 75.47,
+                    "z": 0
+                },
+                "A10": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 95.91,
+                    "y": 75.47,
+                    "z": 0
+                },
+                "A11": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 104.9,
+                    "y": 75.47,
+                    "z": 0
+                },
+                "A12": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 113.89,
+                    "y": 75.47,
+                    "z": 0
+                },
+                "A2": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 23.99,
+                    "y": 75.47,
+                    "z": 0
+                },
+                "A3": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 32.98,
+                    "y": 75.47,
+                    "z": 0
+                },
+                "A4": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 41.97,
+                    "y": 75.47,
+                    "z": 0
+                },
+                "A5": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 50.96,
+                    "y": 75.47,
+                    "z": 0
+                },
+                "A6": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 59.95,
+                    "y": 75.47,
+                    "z": 0
+                },
+                "A7": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 68.94,
+                    "y": 75.47,
+                    "z": 0
+                },
+                "A8": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 77.93,
+                    "y": 75.47,
+                    "z": 0
+                },
+                "A9": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 86.92,
+                    "y": 75.47,
+                    "z": 0
+                },
+                "B1": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 15,
+                    "y": 66.48,
+                    "z": 0
+                },
+                "B10": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 95.91,
+                    "y": 66.48,
+                    "z": 0
+                },
+                "B11": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 104.9,
+                    "y": 66.48,
+                    "z": 0
+                },
+                "B12": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 113.89,
+                    "y": 66.48,
+                    "z": 0
+                },
+                "B2": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 23.99,
+                    "y": 66.48,
+                    "z": 0
+                },
+                "B3": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 32.98,
+                    "y": 66.48,
+                    "z": 0
+                },
+                "B4": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 41.97,
+                    "y": 66.48,
+                    "z": 0
+                },
+                "B5": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 50.96,
+                    "y": 66.48,
+                    "z": 0
+                },
+                "B6": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 59.95,
+                    "y": 66.48,
+                    "z": 0
+                },
+                "B7": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 68.94,
+                    "y": 66.48,
+                    "z": 0
+                },
+                "B8": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 77.93,
+                    "y": 66.48,
+                    "z": 0
+                },
+                "B9": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 86.92,
+                    "y": 66.48,
+                    "z": 0
+                },
+                "C1": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 15,
+                    "y": 57.49,
+                    "z": 0
+                },
+                "C10": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 95.91,
+                    "y": 57.49,
+                    "z": 0
+                },
+                "C11": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 104.9,
+                    "y": 57.49,
+                    "z": 0
+                },
+                "C12": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 113.89,
+                    "y": 57.49,
+                    "z": 0
+                },
+                "C2": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 23.99,
+                    "y": 57.49,
+                    "z": 0
+                },
+                "C3": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 32.98,
+                    "y": 57.49,
+                    "z": 0
+                },
+                "C4": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 41.97,
+                    "y": 57.49,
+                    "z": 0
+                },
+                "C5": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 50.96,
+                    "y": 57.49,
+                    "z": 0
+                },
+                "C6": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 59.95,
+                    "y": 57.49,
+                    "z": 0
+                },
+                "C7": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 68.94,
+                    "y": 57.49,
+                    "z": 0
+                },
+                "C8": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 77.93,
+                    "y": 57.49,
+                    "z": 0
+                },
+                "C9": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 86.92,
+                    "y": 57.49,
+                    "z": 0
+                },
+                "D1": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 15,
+                    "y": 48.5,
+                    "z": 0
+                },
+                "D10": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 95.91,
+                    "y": 48.5,
+                    "z": 0
+                },
+                "D11": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 104.9,
+                    "y": 48.5,
+                    "z": 0
+                },
+                "D12": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 113.89,
+                    "y": 48.5,
+                    "z": 0
+                },
+                "D2": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 23.99,
+                    "y": 48.5,
+                    "z": 0
+                },
+                "D3": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 32.98,
+                    "y": 48.5,
+                    "z": 0
+                },
+                "D4": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 41.97,
+                    "y": 48.5,
+                    "z": 0
+                },
+                "D5": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 50.96,
+                    "y": 48.5,
+                    "z": 0
+                },
+                "D6": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 59.95,
+                    "y": 48.5,
+                    "z": 0
+                },
+                "D7": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 68.94,
+                    "y": 48.5,
+                    "z": 0
+                },
+                "D8": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 77.93,
+                    "y": 48.5,
+                    "z": 0
+                },
+                "D9": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 86.92,
+                    "y": 48.5,
+                    "z": 0
+                },
+                "E1": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 15,
+                    "y": 39.51,
+                    "z": 0
+                },
+                "E10": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 95.91,
+                    "y": 39.51,
+                    "z": 0
+                },
+                "E11": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 104.9,
+                    "y": 39.51,
+                    "z": 0
+                },
+                "E12": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 113.89,
+                    "y": 39.51,
+                    "z": 0
+                },
+                "E2": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 23.99,
+                    "y": 39.51,
+                    "z": 0
+                },
+                "E3": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 32.98,
+                    "y": 39.51,
+                    "z": 0
+                },
+                "E4": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 41.97,
+                    "y": 39.51,
+                    "z": 0
+                },
+                "E5": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 50.96,
+                    "y": 39.51,
+                    "z": 0
+                },
+                "E6": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 59.95,
+                    "y": 39.51,
+                    "z": 0
+                },
+                "E7": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 68.94,
+                    "y": 39.51,
+                    "z": 0
+                },
+                "E8": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 77.93,
+                    "y": 39.51,
+                    "z": 0
+                },
+                "E9": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 86.92,
+                    "y": 39.51,
+                    "z": 0
+                },
+                "F1": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 15,
+                    "y": 30.52,
+                    "z": 0
+                },
+                "F10": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 95.91,
+                    "y": 30.52,
+                    "z": 0
+                },
+                "F11": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 104.9,
+                    "y": 30.52,
+                    "z": 0
+                },
+                "F12": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 113.89,
+                    "y": 30.52,
+                    "z": 0
+                },
+                "F2": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 23.99,
+                    "y": 30.52,
+                    "z": 0
+                },
+                "F3": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 32.98,
+                    "y": 30.52,
+                    "z": 0
+                },
+                "F4": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 41.97,
+                    "y": 30.52,
+                    "z": 0
+                },
+                "F5": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 50.96,
+                    "y": 30.52,
+                    "z": 0
+                },
+                "F6": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 59.95,
+                    "y": 30.52,
+                    "z": 0
+                },
+                "F7": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 68.94,
+                    "y": 30.52,
+                    "z": 0
+                },
+                "F8": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 77.93,
+                    "y": 30.52,
+                    "z": 0
+                },
+                "F9": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 86.92,
+                    "y": 30.52,
+                    "z": 0
+                },
+                "G1": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 15,
+                    "y": 21.53,
+                    "z": 0
+                },
+                "G10": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 95.91,
+                    "y": 21.53,
+                    "z": 0
+                },
+                "G11": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 104.9,
+                    "y": 21.53,
+                    "z": 0
+                },
+                "G12": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 113.89,
+                    "y": 21.53,
+                    "z": 0
+                },
+                "G2": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 23.99,
+                    "y": 21.53,
+                    "z": 0
+                },
+                "G3": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 32.98,
+                    "y": 21.53,
+                    "z": 0
+                },
+                "G4": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 41.97,
+                    "y": 21.53,
+                    "z": 0
+                },
+                "G5": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 50.96,
+                    "y": 21.53,
+                    "z": 0
+                },
+                "G6": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 59.95,
+                    "y": 21.53,
+                    "z": 0
+                },
+                "G7": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 68.94,
+                    "y": 21.53,
+                    "z": 0
+                },
+                "G8": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 77.93,
+                    "y": 21.53,
+                    "z": 0
+                },
+                "G9": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 86.92,
+                    "y": 21.53,
+                    "z": 0
+                },
+                "H1": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 15,
+                    "y": 12.54,
+                    "z": 0
+                },
+                "H10": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 95.91,
+                    "y": 12.54,
+                    "z": 0
+                },
+                "H11": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 104.9,
+                    "y": 12.54,
+                    "z": 0
+                },
+                "H12": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 113.89,
+                    "y": 12.54,
+                    "z": 0
+                },
+                "H2": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 23.99,
+                    "y": 12.54,
+                    "z": 0
+                },
+                "H3": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 32.98,
+                    "y": 12.54,
+                    "z": 0
+                },
+                "H4": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 41.97,
+                    "y": 12.54,
+                    "z": 0
+                },
+                "H5": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 50.96,
+                    "y": 12.54,
+                    "z": 0
+                },
+                "H6": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 59.95,
+                    "y": 12.54,
+                    "z": 0
+                },
+                "H7": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 68.94,
+                    "y": 12.54,
+                    "z": 0
+                },
+                "H8": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 77.93,
+                    "y": 12.54,
+                    "z": 0
+                },
+                "H9": {
+                    "depth": 15.5,
+                    "diameter": 5.6,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 86.92,
+                    "y": 12.54,
+                    "z": 0
                 }
             }
         }

--- a/protoBuilds/13c0b8/13c0b8.ot2.apiv2.py.json
+++ b/protoBuilds/13c0b8/13c0b8.ot2.apiv2.py.json
@@ -1146,7 +1146,7 @@
     ],
     "labware": [
         {
-            "name": "96-well BRANDplate with V-bottom on Temperature Module on 1",
+            "name": "96-well BRANDplate with V-bottom on Temperature Module GEN1 on 1",
             "share": false,
             "slot": "1",
             "type": "brandplates_96_wellplate_360ul"

--- a/protoBuilds/1577-v2/custom_chip_PCR_prep.ot2.apiv2.py.json
+++ b/protoBuilds/1577-v2/custom_chip_PCR_prep.ot2.apiv2.py.json
@@ -1523,7 +1523,7 @@
             "type": "opentrons_96_tiprack_300ul"
         },
         {
-            "name": "2ml Eppendorf snapcap reagent tubes on Temperature Module on 6",
+            "name": "2ml Eppendorf snapcap reagent tubes on Temperature Module GEN1 on 6",
             "share": false,
             "slot": "6",
             "type": "opentrons_24_aluminumblock_nest_2ml_snapcap"

--- a/protoBuilds/19fc32/19fc32.ot2.apiv2.py.json
+++ b/protoBuilds/19fc32/19fc32.ot2.apiv2.py.json
@@ -44,7 +44,7 @@
             "type": "corning_384_wellplate_112ul_flat"
         },
         {
-            "name": "Mag Plate on Magnetic Module on 4",
+            "name": "Mag Plate on Magnetic Module GEN1 on 4",
             "share": false,
             "slot": "4",
             "type": "biorad_96_wellplate_200ul_pcr"

--- a/protoBuilds/1a2343/pcr_prep.ot2.apiv2.py.json
+++ b/protoBuilds/1a2343/pcr_prep.ot2.apiv2.py.json
@@ -63,7 +63,7 @@
             "type": "opentrons_96_tiprack_20ul"
         },
         {
-            "name": "reagent plate on Temperature Module on 4",
+            "name": "reagent plate on Temperature Module GEN1 on 4",
             "share": false,
             "slot": "4",
             "type": "usascientific_96_wellplate_2.4ml_deep"

--- a/protoBuilds/1ce6aa/1ce6aa.ot2.apiv2.py.json
+++ b/protoBuilds/1ce6aa/1ce6aa.ot2.apiv2.py.json
@@ -3,6 +3,1128 @@
     "custom_labware_defs": [
         {
             "brand": {
+                "brand": "generic"
+            },
+            "cornerOffsetFromSlot": {
+                "x": 0,
+                "y": 0,
+                "z": 0
+            },
+            "dimensions": {
+                "xDimension": 127.76,
+                "yDimension": 85.48,
+                "zDimension": 70
+            },
+            "groups": [
+                {
+                    "metadata": {},
+                    "wells": [
+                        "A1",
+                        "B1",
+                        "C1",
+                        "D1",
+                        "E1",
+                        "F1",
+                        "G1",
+                        "H1",
+                        "A2",
+                        "B2",
+                        "C2",
+                        "D2",
+                        "E2",
+                        "F2",
+                        "G2",
+                        "H2",
+                        "A3",
+                        "B3",
+                        "C3",
+                        "D3",
+                        "E3",
+                        "F3",
+                        "G3",
+                        "H3",
+                        "A4",
+                        "B4",
+                        "C4",
+                        "D4",
+                        "E4",
+                        "F4",
+                        "G4",
+                        "H4",
+                        "A5",
+                        "B5",
+                        "C5",
+                        "D5",
+                        "E5",
+                        "F5",
+                        "G5",
+                        "H5",
+                        "A6",
+                        "B6",
+                        "C6",
+                        "D6",
+                        "E6",
+                        "F6",
+                        "G6",
+                        "H6",
+                        "A7",
+                        "B7",
+                        "C7",
+                        "D7",
+                        "E7",
+                        "F7",
+                        "G7",
+                        "H7",
+                        "A8",
+                        "B8",
+                        "C8",
+                        "D8",
+                        "E8",
+                        "F8",
+                        "G8",
+                        "H8",
+                        "A9",
+                        "B9",
+                        "C9",
+                        "D9",
+                        "E9",
+                        "F9",
+                        "G9",
+                        "H9",
+                        "A10",
+                        "B10",
+                        "C10",
+                        "D10",
+                        "E10",
+                        "F10",
+                        "G10",
+                        "H10",
+                        "A11",
+                        "B11",
+                        "C11",
+                        "D11",
+                        "E11",
+                        "F11",
+                        "G11",
+                        "H11",
+                        "A12",
+                        "B12",
+                        "C12",
+                        "D12",
+                        "E12",
+                        "F12",
+                        "G12",
+                        "H12"
+                    ]
+                }
+            ],
+            "metadata": {
+                "displayCategory": "tipRack",
+                "displayName": "Custom 200\u00b5L Tiprack",
+                "displayVolumeUnits": "\u00b5L",
+                "tags": []
+            },
+            "namespace": "custom_beta",
+            "ordering": [
+                [
+                    "A1",
+                    "B1",
+                    "C1",
+                    "D1",
+                    "E1",
+                    "F1",
+                    "G1",
+                    "H1"
+                ],
+                [
+                    "A2",
+                    "B2",
+                    "C2",
+                    "D2",
+                    "E2",
+                    "F2",
+                    "G2",
+                    "H2"
+                ],
+                [
+                    "A3",
+                    "B3",
+                    "C3",
+                    "D3",
+                    "E3",
+                    "F3",
+                    "G3",
+                    "H3"
+                ],
+                [
+                    "A4",
+                    "B4",
+                    "C4",
+                    "D4",
+                    "E4",
+                    "F4",
+                    "G4",
+                    "H4"
+                ],
+                [
+                    "A5",
+                    "B5",
+                    "C5",
+                    "D5",
+                    "E5",
+                    "F5",
+                    "G5",
+                    "H5"
+                ],
+                [
+                    "A6",
+                    "B6",
+                    "C6",
+                    "D6",
+                    "E6",
+                    "F6",
+                    "G6",
+                    "H6"
+                ],
+                [
+                    "A7",
+                    "B7",
+                    "C7",
+                    "D7",
+                    "E7",
+                    "F7",
+                    "G7",
+                    "H7"
+                ],
+                [
+                    "A8",
+                    "B8",
+                    "C8",
+                    "D8",
+                    "E8",
+                    "F8",
+                    "G8",
+                    "H8"
+                ],
+                [
+                    "A9",
+                    "B9",
+                    "C9",
+                    "D9",
+                    "E9",
+                    "F9",
+                    "G9",
+                    "H9"
+                ],
+                [
+                    "A10",
+                    "B10",
+                    "C10",
+                    "D10",
+                    "E10",
+                    "F10",
+                    "G10",
+                    "H10"
+                ],
+                [
+                    "A11",
+                    "B11",
+                    "C11",
+                    "D11",
+                    "E11",
+                    "F11",
+                    "G11",
+                    "H11"
+                ],
+                [
+                    "A12",
+                    "B12",
+                    "C12",
+                    "D12",
+                    "E12",
+                    "F12",
+                    "G12",
+                    "H12"
+                ]
+            ],
+            "parameters": {
+                "format": "96Standard",
+                "isMagneticModuleCompatible": false,
+                "isTiprack": true,
+                "loadName": "generic_96_tiprack_20ul",
+                "tipLength": 32
+            },
+            "schemaVersion": 2,
+            "version": 1,
+            "wells": {
+                "A1": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 14.38,
+                    "y": 74.24,
+                    "z": 38
+                },
+                "A10": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 95.38,
+                    "y": 74.24,
+                    "z": 38
+                },
+                "A11": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 104.38,
+                    "y": 74.24,
+                    "z": 38
+                },
+                "A12": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 113.38,
+                    "y": 74.24,
+                    "z": 38
+                },
+                "A2": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 23.38,
+                    "y": 74.24,
+                    "z": 38
+                },
+                "A3": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 32.38,
+                    "y": 74.24,
+                    "z": 38
+                },
+                "A4": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 41.38,
+                    "y": 74.24,
+                    "z": 38
+                },
+                "A5": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 50.38,
+                    "y": 74.24,
+                    "z": 38
+                },
+                "A6": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 59.38,
+                    "y": 74.24,
+                    "z": 38
+                },
+                "A7": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 68.38,
+                    "y": 74.24,
+                    "z": 38
+                },
+                "A8": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 77.38,
+                    "y": 74.24,
+                    "z": 38
+                },
+                "A9": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 86.38,
+                    "y": 74.24,
+                    "z": 38
+                },
+                "B1": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 14.38,
+                    "y": 65.24,
+                    "z": 38
+                },
+                "B10": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 95.38,
+                    "y": 65.24,
+                    "z": 38
+                },
+                "B11": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 104.38,
+                    "y": 65.24,
+                    "z": 38
+                },
+                "B12": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 113.38,
+                    "y": 65.24,
+                    "z": 38
+                },
+                "B2": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 23.38,
+                    "y": 65.24,
+                    "z": 38
+                },
+                "B3": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 32.38,
+                    "y": 65.24,
+                    "z": 38
+                },
+                "B4": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 41.38,
+                    "y": 65.24,
+                    "z": 38
+                },
+                "B5": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 50.38,
+                    "y": 65.24,
+                    "z": 38
+                },
+                "B6": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 59.38,
+                    "y": 65.24,
+                    "z": 38
+                },
+                "B7": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 68.38,
+                    "y": 65.24,
+                    "z": 38
+                },
+                "B8": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 77.38,
+                    "y": 65.24,
+                    "z": 38
+                },
+                "B9": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 86.38,
+                    "y": 65.24,
+                    "z": 38
+                },
+                "C1": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 14.38,
+                    "y": 56.24,
+                    "z": 38
+                },
+                "C10": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 95.38,
+                    "y": 56.24,
+                    "z": 38
+                },
+                "C11": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 104.38,
+                    "y": 56.24,
+                    "z": 38
+                },
+                "C12": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 113.38,
+                    "y": 56.24,
+                    "z": 38
+                },
+                "C2": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 23.38,
+                    "y": 56.24,
+                    "z": 38
+                },
+                "C3": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 32.38,
+                    "y": 56.24,
+                    "z": 38
+                },
+                "C4": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 41.38,
+                    "y": 56.24,
+                    "z": 38
+                },
+                "C5": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 50.38,
+                    "y": 56.24,
+                    "z": 38
+                },
+                "C6": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 59.38,
+                    "y": 56.24,
+                    "z": 38
+                },
+                "C7": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 68.38,
+                    "y": 56.24,
+                    "z": 38
+                },
+                "C8": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 77.38,
+                    "y": 56.24,
+                    "z": 38
+                },
+                "C9": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 86.38,
+                    "y": 56.24,
+                    "z": 38
+                },
+                "D1": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 14.38,
+                    "y": 47.24,
+                    "z": 38
+                },
+                "D10": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 95.38,
+                    "y": 47.24,
+                    "z": 38
+                },
+                "D11": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 104.38,
+                    "y": 47.24,
+                    "z": 38
+                },
+                "D12": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 113.38,
+                    "y": 47.24,
+                    "z": 38
+                },
+                "D2": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 23.38,
+                    "y": 47.24,
+                    "z": 38
+                },
+                "D3": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 32.38,
+                    "y": 47.24,
+                    "z": 38
+                },
+                "D4": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 41.38,
+                    "y": 47.24,
+                    "z": 38
+                },
+                "D5": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 50.38,
+                    "y": 47.24,
+                    "z": 38
+                },
+                "D6": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 59.38,
+                    "y": 47.24,
+                    "z": 38
+                },
+                "D7": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 68.38,
+                    "y": 47.24,
+                    "z": 38
+                },
+                "D8": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 77.38,
+                    "y": 47.24,
+                    "z": 38
+                },
+                "D9": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 86.38,
+                    "y": 47.24,
+                    "z": 38
+                },
+                "E1": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 14.38,
+                    "y": 38.24,
+                    "z": 38
+                },
+                "E10": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 95.38,
+                    "y": 38.24,
+                    "z": 38
+                },
+                "E11": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 104.38,
+                    "y": 38.24,
+                    "z": 38
+                },
+                "E12": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 113.38,
+                    "y": 38.24,
+                    "z": 38
+                },
+                "E2": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 23.38,
+                    "y": 38.24,
+                    "z": 38
+                },
+                "E3": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 32.38,
+                    "y": 38.24,
+                    "z": 38
+                },
+                "E4": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 41.38,
+                    "y": 38.24,
+                    "z": 38
+                },
+                "E5": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 50.38,
+                    "y": 38.24,
+                    "z": 38
+                },
+                "E6": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 59.38,
+                    "y": 38.24,
+                    "z": 38
+                },
+                "E7": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 68.38,
+                    "y": 38.24,
+                    "z": 38
+                },
+                "E8": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 77.38,
+                    "y": 38.24,
+                    "z": 38
+                },
+                "E9": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 86.38,
+                    "y": 38.24,
+                    "z": 38
+                },
+                "F1": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 14.38,
+                    "y": 29.24,
+                    "z": 38
+                },
+                "F10": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 95.38,
+                    "y": 29.24,
+                    "z": 38
+                },
+                "F11": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 104.38,
+                    "y": 29.24,
+                    "z": 38
+                },
+                "F12": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 113.38,
+                    "y": 29.24,
+                    "z": 38
+                },
+                "F2": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 23.38,
+                    "y": 29.24,
+                    "z": 38
+                },
+                "F3": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 32.38,
+                    "y": 29.24,
+                    "z": 38
+                },
+                "F4": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 41.38,
+                    "y": 29.24,
+                    "z": 38
+                },
+                "F5": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 50.38,
+                    "y": 29.24,
+                    "z": 38
+                },
+                "F6": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 59.38,
+                    "y": 29.24,
+                    "z": 38
+                },
+                "F7": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 68.38,
+                    "y": 29.24,
+                    "z": 38
+                },
+                "F8": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 77.38,
+                    "y": 29.24,
+                    "z": 38
+                },
+                "F9": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 86.38,
+                    "y": 29.24,
+                    "z": 38
+                },
+                "G1": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 14.38,
+                    "y": 20.24,
+                    "z": 38
+                },
+                "G10": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 95.38,
+                    "y": 20.24,
+                    "z": 38
+                },
+                "G11": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 104.38,
+                    "y": 20.24,
+                    "z": 38
+                },
+                "G12": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 113.38,
+                    "y": 20.24,
+                    "z": 38
+                },
+                "G2": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 23.38,
+                    "y": 20.24,
+                    "z": 38
+                },
+                "G3": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 32.38,
+                    "y": 20.24,
+                    "z": 38
+                },
+                "G4": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 41.38,
+                    "y": 20.24,
+                    "z": 38
+                },
+                "G5": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 50.38,
+                    "y": 20.24,
+                    "z": 38
+                },
+                "G6": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 59.38,
+                    "y": 20.24,
+                    "z": 38
+                },
+                "G7": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 68.38,
+                    "y": 20.24,
+                    "z": 38
+                },
+                "G8": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 77.38,
+                    "y": 20.24,
+                    "z": 38
+                },
+                "G9": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 86.38,
+                    "y": 20.24,
+                    "z": 38
+                },
+                "H1": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 14.38,
+                    "y": 11.24,
+                    "z": 38
+                },
+                "H10": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 95.38,
+                    "y": 11.24,
+                    "z": 38
+                },
+                "H11": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 104.38,
+                    "y": 11.24,
+                    "z": 38
+                },
+                "H12": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 113.38,
+                    "y": 11.24,
+                    "z": 38
+                },
+                "H2": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 23.38,
+                    "y": 11.24,
+                    "z": 38
+                },
+                "H3": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 32.38,
+                    "y": 11.24,
+                    "z": 38
+                },
+                "H4": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 41.38,
+                    "y": 11.24,
+                    "z": 38
+                },
+                "H5": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 50.38,
+                    "y": 11.24,
+                    "z": 38
+                },
+                "H6": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 59.38,
+                    "y": 11.24,
+                    "z": 38
+                },
+                "H7": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 68.38,
+                    "y": 11.24,
+                    "z": 38
+                },
+                "H8": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 77.38,
+                    "y": 11.24,
+                    "z": 38
+                },
+                "H9": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 86.38,
+                    "y": 11.24,
+                    "z": 38
+                }
+            }
+        },
+        {
+            "brand": {
                 "brand": "custom",
                 "brandId": []
             },
@@ -1129,1128 +2251,6 @@
                     "x": 86.38,
                     "y": 11.24,
                     "z": 16
-                }
-            }
-        },
-        {
-            "brand": {
-                "brand": "generic"
-            },
-            "cornerOffsetFromSlot": {
-                "x": 0,
-                "y": 0,
-                "z": 0
-            },
-            "dimensions": {
-                "xDimension": 127.76,
-                "yDimension": 85.48,
-                "zDimension": 70
-            },
-            "groups": [
-                {
-                    "metadata": {},
-                    "wells": [
-                        "A1",
-                        "B1",
-                        "C1",
-                        "D1",
-                        "E1",
-                        "F1",
-                        "G1",
-                        "H1",
-                        "A2",
-                        "B2",
-                        "C2",
-                        "D2",
-                        "E2",
-                        "F2",
-                        "G2",
-                        "H2",
-                        "A3",
-                        "B3",
-                        "C3",
-                        "D3",
-                        "E3",
-                        "F3",
-                        "G3",
-                        "H3",
-                        "A4",
-                        "B4",
-                        "C4",
-                        "D4",
-                        "E4",
-                        "F4",
-                        "G4",
-                        "H4",
-                        "A5",
-                        "B5",
-                        "C5",
-                        "D5",
-                        "E5",
-                        "F5",
-                        "G5",
-                        "H5",
-                        "A6",
-                        "B6",
-                        "C6",
-                        "D6",
-                        "E6",
-                        "F6",
-                        "G6",
-                        "H6",
-                        "A7",
-                        "B7",
-                        "C7",
-                        "D7",
-                        "E7",
-                        "F7",
-                        "G7",
-                        "H7",
-                        "A8",
-                        "B8",
-                        "C8",
-                        "D8",
-                        "E8",
-                        "F8",
-                        "G8",
-                        "H8",
-                        "A9",
-                        "B9",
-                        "C9",
-                        "D9",
-                        "E9",
-                        "F9",
-                        "G9",
-                        "H9",
-                        "A10",
-                        "B10",
-                        "C10",
-                        "D10",
-                        "E10",
-                        "F10",
-                        "G10",
-                        "H10",
-                        "A11",
-                        "B11",
-                        "C11",
-                        "D11",
-                        "E11",
-                        "F11",
-                        "G11",
-                        "H11",
-                        "A12",
-                        "B12",
-                        "C12",
-                        "D12",
-                        "E12",
-                        "F12",
-                        "G12",
-                        "H12"
-                    ]
-                }
-            ],
-            "metadata": {
-                "displayCategory": "tipRack",
-                "displayName": "Custom 200\u00b5L Tiprack",
-                "displayVolumeUnits": "\u00b5L",
-                "tags": []
-            },
-            "namespace": "custom_beta",
-            "ordering": [
-                [
-                    "A1",
-                    "B1",
-                    "C1",
-                    "D1",
-                    "E1",
-                    "F1",
-                    "G1",
-                    "H1"
-                ],
-                [
-                    "A2",
-                    "B2",
-                    "C2",
-                    "D2",
-                    "E2",
-                    "F2",
-                    "G2",
-                    "H2"
-                ],
-                [
-                    "A3",
-                    "B3",
-                    "C3",
-                    "D3",
-                    "E3",
-                    "F3",
-                    "G3",
-                    "H3"
-                ],
-                [
-                    "A4",
-                    "B4",
-                    "C4",
-                    "D4",
-                    "E4",
-                    "F4",
-                    "G4",
-                    "H4"
-                ],
-                [
-                    "A5",
-                    "B5",
-                    "C5",
-                    "D5",
-                    "E5",
-                    "F5",
-                    "G5",
-                    "H5"
-                ],
-                [
-                    "A6",
-                    "B6",
-                    "C6",
-                    "D6",
-                    "E6",
-                    "F6",
-                    "G6",
-                    "H6"
-                ],
-                [
-                    "A7",
-                    "B7",
-                    "C7",
-                    "D7",
-                    "E7",
-                    "F7",
-                    "G7",
-                    "H7"
-                ],
-                [
-                    "A8",
-                    "B8",
-                    "C8",
-                    "D8",
-                    "E8",
-                    "F8",
-                    "G8",
-                    "H8"
-                ],
-                [
-                    "A9",
-                    "B9",
-                    "C9",
-                    "D9",
-                    "E9",
-                    "F9",
-                    "G9",
-                    "H9"
-                ],
-                [
-                    "A10",
-                    "B10",
-                    "C10",
-                    "D10",
-                    "E10",
-                    "F10",
-                    "G10",
-                    "H10"
-                ],
-                [
-                    "A11",
-                    "B11",
-                    "C11",
-                    "D11",
-                    "E11",
-                    "F11",
-                    "G11",
-                    "H11"
-                ],
-                [
-                    "A12",
-                    "B12",
-                    "C12",
-                    "D12",
-                    "E12",
-                    "F12",
-                    "G12",
-                    "H12"
-                ]
-            ],
-            "parameters": {
-                "format": "96Standard",
-                "isMagneticModuleCompatible": false,
-                "isTiprack": true,
-                "loadName": "generic_96_tiprack_20ul",
-                "tipLength": 32
-            },
-            "schemaVersion": 2,
-            "version": 1,
-            "wells": {
-                "A1": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 14.38,
-                    "y": 74.24,
-                    "z": 38
-                },
-                "A10": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 95.38,
-                    "y": 74.24,
-                    "z": 38
-                },
-                "A11": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 104.38,
-                    "y": 74.24,
-                    "z": 38
-                },
-                "A12": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 113.38,
-                    "y": 74.24,
-                    "z": 38
-                },
-                "A2": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 23.38,
-                    "y": 74.24,
-                    "z": 38
-                },
-                "A3": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 32.38,
-                    "y": 74.24,
-                    "z": 38
-                },
-                "A4": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 41.38,
-                    "y": 74.24,
-                    "z": 38
-                },
-                "A5": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 50.38,
-                    "y": 74.24,
-                    "z": 38
-                },
-                "A6": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 59.38,
-                    "y": 74.24,
-                    "z": 38
-                },
-                "A7": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 68.38,
-                    "y": 74.24,
-                    "z": 38
-                },
-                "A8": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 77.38,
-                    "y": 74.24,
-                    "z": 38
-                },
-                "A9": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 86.38,
-                    "y": 74.24,
-                    "z": 38
-                },
-                "B1": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 14.38,
-                    "y": 65.24,
-                    "z": 38
-                },
-                "B10": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 95.38,
-                    "y": 65.24,
-                    "z": 38
-                },
-                "B11": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 104.38,
-                    "y": 65.24,
-                    "z": 38
-                },
-                "B12": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 113.38,
-                    "y": 65.24,
-                    "z": 38
-                },
-                "B2": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 23.38,
-                    "y": 65.24,
-                    "z": 38
-                },
-                "B3": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 32.38,
-                    "y": 65.24,
-                    "z": 38
-                },
-                "B4": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 41.38,
-                    "y": 65.24,
-                    "z": 38
-                },
-                "B5": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 50.38,
-                    "y": 65.24,
-                    "z": 38
-                },
-                "B6": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 59.38,
-                    "y": 65.24,
-                    "z": 38
-                },
-                "B7": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 68.38,
-                    "y": 65.24,
-                    "z": 38
-                },
-                "B8": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 77.38,
-                    "y": 65.24,
-                    "z": 38
-                },
-                "B9": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 86.38,
-                    "y": 65.24,
-                    "z": 38
-                },
-                "C1": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 14.38,
-                    "y": 56.24,
-                    "z": 38
-                },
-                "C10": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 95.38,
-                    "y": 56.24,
-                    "z": 38
-                },
-                "C11": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 104.38,
-                    "y": 56.24,
-                    "z": 38
-                },
-                "C12": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 113.38,
-                    "y": 56.24,
-                    "z": 38
-                },
-                "C2": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 23.38,
-                    "y": 56.24,
-                    "z": 38
-                },
-                "C3": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 32.38,
-                    "y": 56.24,
-                    "z": 38
-                },
-                "C4": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 41.38,
-                    "y": 56.24,
-                    "z": 38
-                },
-                "C5": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 50.38,
-                    "y": 56.24,
-                    "z": 38
-                },
-                "C6": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 59.38,
-                    "y": 56.24,
-                    "z": 38
-                },
-                "C7": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 68.38,
-                    "y": 56.24,
-                    "z": 38
-                },
-                "C8": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 77.38,
-                    "y": 56.24,
-                    "z": 38
-                },
-                "C9": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 86.38,
-                    "y": 56.24,
-                    "z": 38
-                },
-                "D1": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 14.38,
-                    "y": 47.24,
-                    "z": 38
-                },
-                "D10": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 95.38,
-                    "y": 47.24,
-                    "z": 38
-                },
-                "D11": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 104.38,
-                    "y": 47.24,
-                    "z": 38
-                },
-                "D12": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 113.38,
-                    "y": 47.24,
-                    "z": 38
-                },
-                "D2": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 23.38,
-                    "y": 47.24,
-                    "z": 38
-                },
-                "D3": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 32.38,
-                    "y": 47.24,
-                    "z": 38
-                },
-                "D4": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 41.38,
-                    "y": 47.24,
-                    "z": 38
-                },
-                "D5": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 50.38,
-                    "y": 47.24,
-                    "z": 38
-                },
-                "D6": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 59.38,
-                    "y": 47.24,
-                    "z": 38
-                },
-                "D7": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 68.38,
-                    "y": 47.24,
-                    "z": 38
-                },
-                "D8": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 77.38,
-                    "y": 47.24,
-                    "z": 38
-                },
-                "D9": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 86.38,
-                    "y": 47.24,
-                    "z": 38
-                },
-                "E1": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 14.38,
-                    "y": 38.24,
-                    "z": 38
-                },
-                "E10": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 95.38,
-                    "y": 38.24,
-                    "z": 38
-                },
-                "E11": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 104.38,
-                    "y": 38.24,
-                    "z": 38
-                },
-                "E12": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 113.38,
-                    "y": 38.24,
-                    "z": 38
-                },
-                "E2": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 23.38,
-                    "y": 38.24,
-                    "z": 38
-                },
-                "E3": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 32.38,
-                    "y": 38.24,
-                    "z": 38
-                },
-                "E4": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 41.38,
-                    "y": 38.24,
-                    "z": 38
-                },
-                "E5": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 50.38,
-                    "y": 38.24,
-                    "z": 38
-                },
-                "E6": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 59.38,
-                    "y": 38.24,
-                    "z": 38
-                },
-                "E7": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 68.38,
-                    "y": 38.24,
-                    "z": 38
-                },
-                "E8": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 77.38,
-                    "y": 38.24,
-                    "z": 38
-                },
-                "E9": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 86.38,
-                    "y": 38.24,
-                    "z": 38
-                },
-                "F1": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 14.38,
-                    "y": 29.24,
-                    "z": 38
-                },
-                "F10": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 95.38,
-                    "y": 29.24,
-                    "z": 38
-                },
-                "F11": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 104.38,
-                    "y": 29.24,
-                    "z": 38
-                },
-                "F12": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 113.38,
-                    "y": 29.24,
-                    "z": 38
-                },
-                "F2": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 23.38,
-                    "y": 29.24,
-                    "z": 38
-                },
-                "F3": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 32.38,
-                    "y": 29.24,
-                    "z": 38
-                },
-                "F4": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 41.38,
-                    "y": 29.24,
-                    "z": 38
-                },
-                "F5": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 50.38,
-                    "y": 29.24,
-                    "z": 38
-                },
-                "F6": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 59.38,
-                    "y": 29.24,
-                    "z": 38
-                },
-                "F7": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 68.38,
-                    "y": 29.24,
-                    "z": 38
-                },
-                "F8": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 77.38,
-                    "y": 29.24,
-                    "z": 38
-                },
-                "F9": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 86.38,
-                    "y": 29.24,
-                    "z": 38
-                },
-                "G1": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 14.38,
-                    "y": 20.24,
-                    "z": 38
-                },
-                "G10": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 95.38,
-                    "y": 20.24,
-                    "z": 38
-                },
-                "G11": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 104.38,
-                    "y": 20.24,
-                    "z": 38
-                },
-                "G12": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 113.38,
-                    "y": 20.24,
-                    "z": 38
-                },
-                "G2": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 23.38,
-                    "y": 20.24,
-                    "z": 38
-                },
-                "G3": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 32.38,
-                    "y": 20.24,
-                    "z": 38
-                },
-                "G4": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 41.38,
-                    "y": 20.24,
-                    "z": 38
-                },
-                "G5": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 50.38,
-                    "y": 20.24,
-                    "z": 38
-                },
-                "G6": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 59.38,
-                    "y": 20.24,
-                    "z": 38
-                },
-                "G7": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 68.38,
-                    "y": 20.24,
-                    "z": 38
-                },
-                "G8": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 77.38,
-                    "y": 20.24,
-                    "z": 38
-                },
-                "G9": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 86.38,
-                    "y": 20.24,
-                    "z": 38
-                },
-                "H1": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 14.38,
-                    "y": 11.24,
-                    "z": 38
-                },
-                "H10": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 95.38,
-                    "y": 11.24,
-                    "z": 38
-                },
-                "H11": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 104.38,
-                    "y": 11.24,
-                    "z": 38
-                },
-                "H12": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 113.38,
-                    "y": 11.24,
-                    "z": 38
-                },
-                "H2": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 23.38,
-                    "y": 11.24,
-                    "z": 38
-                },
-                "H3": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 32.38,
-                    "y": 11.24,
-                    "z": 38
-                },
-                "H4": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 41.38,
-                    "y": 11.24,
-                    "z": 38
-                },
-                "H5": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 50.38,
-                    "y": 11.24,
-                    "z": 38
-                },
-                "H6": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 59.38,
-                    "y": 11.24,
-                    "z": 38
-                },
-                "H7": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 68.38,
-                    "y": 11.24,
-                    "z": 38
-                },
-                "H8": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 77.38,
-                    "y": 11.24,
-                    "z": 38
-                },
-                "H9": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 86.38,
-                    "y": 11.24,
-                    "z": 38
                 }
             }
         }

--- a/protoBuilds/203136/203136.ot2.apiv2.py.json
+++ b/protoBuilds/203136/203136.ot2.apiv2.py.json
@@ -69,7 +69,7 @@
             "type": "opentrons_96_filtertiprack_200ul"
         },
         {
-            "name": "Deep Well Plate on Magnetic Module on 4",
+            "name": "Deep Well Plate on Magnetic Module GEN1 on 4",
             "share": false,
             "slot": "4",
             "type": "usascientific_96_wellplate_2.4ml_deep"

--- a/protoBuilds/269b21/pcr_prep.ot2.apiv2.py.json
+++ b/protoBuilds/269b21/pcr_prep.ot2.apiv2.py.json
@@ -3,6 +3,1141 @@
     "custom_labware_defs": [
         {
             "brand": {
+                "brand": "GenMate",
+                "brandId": [
+                    "3247-00-210IS"
+                ]
+            },
+            "cornerOffsetFromSlot": {
+                "x": 0,
+                "y": 0,
+                "z": 0
+            },
+            "dimensions": {
+                "xDimension": 127.75,
+                "yDimension": 85.5,
+                "zDimension": 24
+            },
+            "groups": [
+                {
+                    "brand": {
+                        "brand": "GenMate",
+                        "brandId": [
+                            "3247-00-210IS"
+                        ]
+                    },
+                    "metadata": {
+                        "displayCategory": "aluminumBlock",
+                        "displayName": "GenMate 96 Aluminum Block 20 \u00b5L",
+                        "wellBottomShape": "v"
+                    },
+                    "wells": [
+                        "A1",
+                        "B1",
+                        "C1",
+                        "D1",
+                        "E1",
+                        "F1",
+                        "G1",
+                        "H1",
+                        "A2",
+                        "B2",
+                        "C2",
+                        "D2",
+                        "E2",
+                        "F2",
+                        "G2",
+                        "H2",
+                        "A3",
+                        "B3",
+                        "C3",
+                        "D3",
+                        "E3",
+                        "F3",
+                        "G3",
+                        "H3",
+                        "A4",
+                        "B4",
+                        "C4",
+                        "D4",
+                        "E4",
+                        "F4",
+                        "G4",
+                        "H4",
+                        "A5",
+                        "B5",
+                        "C5",
+                        "D5",
+                        "E5",
+                        "F5",
+                        "G5",
+                        "H5",
+                        "A6",
+                        "B6",
+                        "C6",
+                        "D6",
+                        "E6",
+                        "F6",
+                        "G6",
+                        "H6",
+                        "A7",
+                        "B7",
+                        "C7",
+                        "D7",
+                        "E7",
+                        "F7",
+                        "G7",
+                        "H7",
+                        "A8",
+                        "B8",
+                        "C8",
+                        "D8",
+                        "E8",
+                        "F8",
+                        "G8",
+                        "H8",
+                        "A9",
+                        "B9",
+                        "C9",
+                        "D9",
+                        "E9",
+                        "F9",
+                        "G9",
+                        "H9",
+                        "A10",
+                        "B10",
+                        "C10",
+                        "D10",
+                        "E10",
+                        "F10",
+                        "G10",
+                        "H10",
+                        "A11",
+                        "B11",
+                        "C11",
+                        "D11",
+                        "E11",
+                        "F11",
+                        "G11",
+                        "H11",
+                        "A12",
+                        "B12",
+                        "C12",
+                        "D12",
+                        "E12",
+                        "F12",
+                        "G12",
+                        "H12"
+                    ]
+                }
+            ],
+            "metadata": {
+                "displayCategory": "aluminumBlock",
+                "displayName": "GenMate 96 Aluminum Block 20 \u00b5L",
+                "displayVolumeUnits": "\u00b5L",
+                "tags": []
+            },
+            "namespace": "custom_beta",
+            "ordering": [
+                [
+                    "A1",
+                    "B1",
+                    "C1",
+                    "D1",
+                    "E1",
+                    "F1",
+                    "G1",
+                    "H1"
+                ],
+                [
+                    "A2",
+                    "B2",
+                    "C2",
+                    "D2",
+                    "E2",
+                    "F2",
+                    "G2",
+                    "H2"
+                ],
+                [
+                    "A3",
+                    "B3",
+                    "C3",
+                    "D3",
+                    "E3",
+                    "F3",
+                    "G3",
+                    "H3"
+                ],
+                [
+                    "A4",
+                    "B4",
+                    "C4",
+                    "D4",
+                    "E4",
+                    "F4",
+                    "G4",
+                    "H4"
+                ],
+                [
+                    "A5",
+                    "B5",
+                    "C5",
+                    "D5",
+                    "E5",
+                    "F5",
+                    "G5",
+                    "H5"
+                ],
+                [
+                    "A6",
+                    "B6",
+                    "C6",
+                    "D6",
+                    "E6",
+                    "F6",
+                    "G6",
+                    "H6"
+                ],
+                [
+                    "A7",
+                    "B7",
+                    "C7",
+                    "D7",
+                    "E7",
+                    "F7",
+                    "G7",
+                    "H7"
+                ],
+                [
+                    "A8",
+                    "B8",
+                    "C8",
+                    "D8",
+                    "E8",
+                    "F8",
+                    "G8",
+                    "H8"
+                ],
+                [
+                    "A9",
+                    "B9",
+                    "C9",
+                    "D9",
+                    "E9",
+                    "F9",
+                    "G9",
+                    "H9"
+                ],
+                [
+                    "A10",
+                    "B10",
+                    "C10",
+                    "D10",
+                    "E10",
+                    "F10",
+                    "G10",
+                    "H10"
+                ],
+                [
+                    "A11",
+                    "B11",
+                    "C11",
+                    "D11",
+                    "E11",
+                    "F11",
+                    "G11",
+                    "H11"
+                ],
+                [
+                    "A12",
+                    "B12",
+                    "C12",
+                    "D12",
+                    "E12",
+                    "F12",
+                    "G12",
+                    "H12"
+                ]
+            ],
+            "parameters": {
+                "format": "irregular",
+                "isMagneticModuleCompatible": false,
+                "isTiprack": false,
+                "loadName": "genmate_96_aluminumblock_20ul",
+                "quirks": []
+            },
+            "schemaVersion": 2,
+            "version": 1,
+            "wells": {
+                "A1": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 14.38,
+                    "y": 74.25,
+                    "z": 6
+                },
+                "A10": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 95.38,
+                    "y": 74.25,
+                    "z": 6
+                },
+                "A11": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 104.38,
+                    "y": 74.25,
+                    "z": 6
+                },
+                "A12": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 113.38,
+                    "y": 74.25,
+                    "z": 6
+                },
+                "A2": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 23.38,
+                    "y": 74.25,
+                    "z": 6
+                },
+                "A3": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 32.38,
+                    "y": 74.25,
+                    "z": 6
+                },
+                "A4": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 41.38,
+                    "y": 74.25,
+                    "z": 6
+                },
+                "A5": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 50.38,
+                    "y": 74.25,
+                    "z": 6
+                },
+                "A6": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 59.38,
+                    "y": 74.25,
+                    "z": 6
+                },
+                "A7": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 68.38,
+                    "y": 74.25,
+                    "z": 6
+                },
+                "A8": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 77.38,
+                    "y": 74.25,
+                    "z": 6
+                },
+                "A9": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 86.38,
+                    "y": 74.25,
+                    "z": 6
+                },
+                "B1": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 14.38,
+                    "y": 65.25,
+                    "z": 6
+                },
+                "B10": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 95.38,
+                    "y": 65.25,
+                    "z": 6
+                },
+                "B11": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 104.38,
+                    "y": 65.25,
+                    "z": 6
+                },
+                "B12": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 113.38,
+                    "y": 65.25,
+                    "z": 6
+                },
+                "B2": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 23.38,
+                    "y": 65.25,
+                    "z": 6
+                },
+                "B3": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 32.38,
+                    "y": 65.25,
+                    "z": 6
+                },
+                "B4": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 41.38,
+                    "y": 65.25,
+                    "z": 6
+                },
+                "B5": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 50.38,
+                    "y": 65.25,
+                    "z": 6
+                },
+                "B6": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 59.38,
+                    "y": 65.25,
+                    "z": 6
+                },
+                "B7": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 68.38,
+                    "y": 65.25,
+                    "z": 6
+                },
+                "B8": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 77.38,
+                    "y": 65.25,
+                    "z": 6
+                },
+                "B9": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 86.38,
+                    "y": 65.25,
+                    "z": 6
+                },
+                "C1": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 14.38,
+                    "y": 56.25,
+                    "z": 6
+                },
+                "C10": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 95.38,
+                    "y": 56.25,
+                    "z": 6
+                },
+                "C11": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 104.38,
+                    "y": 56.25,
+                    "z": 6
+                },
+                "C12": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 113.38,
+                    "y": 56.25,
+                    "z": 6
+                },
+                "C2": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 23.38,
+                    "y": 56.25,
+                    "z": 6
+                },
+                "C3": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 32.38,
+                    "y": 56.25,
+                    "z": 6
+                },
+                "C4": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 41.38,
+                    "y": 56.25,
+                    "z": 6
+                },
+                "C5": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 50.38,
+                    "y": 56.25,
+                    "z": 6
+                },
+                "C6": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 59.38,
+                    "y": 56.25,
+                    "z": 6
+                },
+                "C7": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 68.38,
+                    "y": 56.25,
+                    "z": 6
+                },
+                "C8": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 77.38,
+                    "y": 56.25,
+                    "z": 6
+                },
+                "C9": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 86.38,
+                    "y": 56.25,
+                    "z": 6
+                },
+                "D1": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 14.38,
+                    "y": 47.25,
+                    "z": 6
+                },
+                "D10": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 95.38,
+                    "y": 47.25,
+                    "z": 6
+                },
+                "D11": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 104.38,
+                    "y": 47.25,
+                    "z": 6
+                },
+                "D12": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 113.38,
+                    "y": 47.25,
+                    "z": 6
+                },
+                "D2": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 23.38,
+                    "y": 47.25,
+                    "z": 6
+                },
+                "D3": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 32.38,
+                    "y": 47.25,
+                    "z": 6
+                },
+                "D4": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 41.38,
+                    "y": 47.25,
+                    "z": 6
+                },
+                "D5": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 50.38,
+                    "y": 47.25,
+                    "z": 6
+                },
+                "D6": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 59.38,
+                    "y": 47.25,
+                    "z": 6
+                },
+                "D7": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 68.38,
+                    "y": 47.25,
+                    "z": 6
+                },
+                "D8": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 77.38,
+                    "y": 47.25,
+                    "z": 6
+                },
+                "D9": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 86.38,
+                    "y": 47.25,
+                    "z": 6
+                },
+                "E1": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 14.38,
+                    "y": 38.25,
+                    "z": 6
+                },
+                "E10": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 95.38,
+                    "y": 38.25,
+                    "z": 6
+                },
+                "E11": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 104.38,
+                    "y": 38.25,
+                    "z": 6
+                },
+                "E12": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 113.38,
+                    "y": 38.25,
+                    "z": 6
+                },
+                "E2": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 23.38,
+                    "y": 38.25,
+                    "z": 6
+                },
+                "E3": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 32.38,
+                    "y": 38.25,
+                    "z": 6
+                },
+                "E4": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 41.38,
+                    "y": 38.25,
+                    "z": 6
+                },
+                "E5": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 50.38,
+                    "y": 38.25,
+                    "z": 6
+                },
+                "E6": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 59.38,
+                    "y": 38.25,
+                    "z": 6
+                },
+                "E7": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 68.38,
+                    "y": 38.25,
+                    "z": 6
+                },
+                "E8": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 77.38,
+                    "y": 38.25,
+                    "z": 6
+                },
+                "E9": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 86.38,
+                    "y": 38.25,
+                    "z": 6
+                },
+                "F1": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 14.38,
+                    "y": 29.25,
+                    "z": 6
+                },
+                "F10": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 95.38,
+                    "y": 29.25,
+                    "z": 6
+                },
+                "F11": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 104.38,
+                    "y": 29.25,
+                    "z": 6
+                },
+                "F12": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 113.38,
+                    "y": 29.25,
+                    "z": 6
+                },
+                "F2": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 23.38,
+                    "y": 29.25,
+                    "z": 6
+                },
+                "F3": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 32.38,
+                    "y": 29.25,
+                    "z": 6
+                },
+                "F4": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 41.38,
+                    "y": 29.25,
+                    "z": 6
+                },
+                "F5": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 50.38,
+                    "y": 29.25,
+                    "z": 6
+                },
+                "F6": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 59.38,
+                    "y": 29.25,
+                    "z": 6
+                },
+                "F7": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 68.38,
+                    "y": 29.25,
+                    "z": 6
+                },
+                "F8": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 77.38,
+                    "y": 29.25,
+                    "z": 6
+                },
+                "F9": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 86.38,
+                    "y": 29.25,
+                    "z": 6
+                },
+                "G1": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 14.38,
+                    "y": 20.25,
+                    "z": 6
+                },
+                "G10": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 95.38,
+                    "y": 20.25,
+                    "z": 6
+                },
+                "G11": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 104.38,
+                    "y": 20.25,
+                    "z": 6
+                },
+                "G12": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 113.38,
+                    "y": 20.25,
+                    "z": 6
+                },
+                "G2": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 23.38,
+                    "y": 20.25,
+                    "z": 6
+                },
+                "G3": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 32.38,
+                    "y": 20.25,
+                    "z": 6
+                },
+                "G4": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 41.38,
+                    "y": 20.25,
+                    "z": 6
+                },
+                "G5": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 50.38,
+                    "y": 20.25,
+                    "z": 6
+                },
+                "G6": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 59.38,
+                    "y": 20.25,
+                    "z": 6
+                },
+                "G7": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 68.38,
+                    "y": 20.25,
+                    "z": 6
+                },
+                "G8": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 77.38,
+                    "y": 20.25,
+                    "z": 6
+                },
+                "G9": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 86.38,
+                    "y": 20.25,
+                    "z": 6
+                },
+                "H1": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 14.38,
+                    "y": 11.25,
+                    "z": 6
+                },
+                "H10": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 95.38,
+                    "y": 11.25,
+                    "z": 6
+                },
+                "H11": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 104.38,
+                    "y": 11.25,
+                    "z": 6
+                },
+                "H12": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 113.38,
+                    "y": 11.25,
+                    "z": 6
+                },
+                "H2": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 23.38,
+                    "y": 11.25,
+                    "z": 6
+                },
+                "H3": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 32.38,
+                    "y": 11.25,
+                    "z": 6
+                },
+                "H4": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 41.38,
+                    "y": 11.25,
+                    "z": 6
+                },
+                "H5": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 50.38,
+                    "y": 11.25,
+                    "z": 6
+                },
+                "H6": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 59.38,
+                    "y": 11.25,
+                    "z": 6
+                },
+                "H7": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 68.38,
+                    "y": 11.25,
+                    "z": 6
+                },
+                "H8": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 77.38,
+                    "y": 11.25,
+                    "z": 6
+                },
+                "H9": {
+                    "depth": 18,
+                    "diameter": 2.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 86.38,
+                    "y": 11.25,
+                    "z": 6
+                }
+            }
+        },
+        {
+            "brand": {
                 "brand": "Bio-Rad",
                 "brandId": [
                     "HSP3805"
@@ -4327,1141 +5462,6 @@
                     "z": 1.05
                 }
             }
-        },
-        {
-            "brand": {
-                "brand": "GenMate",
-                "brandId": [
-                    "3247-00-210IS"
-                ]
-            },
-            "cornerOffsetFromSlot": {
-                "x": 0,
-                "y": 0,
-                "z": 0
-            },
-            "dimensions": {
-                "xDimension": 127.75,
-                "yDimension": 85.5,
-                "zDimension": 24
-            },
-            "groups": [
-                {
-                    "brand": {
-                        "brand": "GenMate",
-                        "brandId": [
-                            "3247-00-210IS"
-                        ]
-                    },
-                    "metadata": {
-                        "displayCategory": "aluminumBlock",
-                        "displayName": "GenMate 96 Aluminum Block 20 \u00b5L",
-                        "wellBottomShape": "v"
-                    },
-                    "wells": [
-                        "A1",
-                        "B1",
-                        "C1",
-                        "D1",
-                        "E1",
-                        "F1",
-                        "G1",
-                        "H1",
-                        "A2",
-                        "B2",
-                        "C2",
-                        "D2",
-                        "E2",
-                        "F2",
-                        "G2",
-                        "H2",
-                        "A3",
-                        "B3",
-                        "C3",
-                        "D3",
-                        "E3",
-                        "F3",
-                        "G3",
-                        "H3",
-                        "A4",
-                        "B4",
-                        "C4",
-                        "D4",
-                        "E4",
-                        "F4",
-                        "G4",
-                        "H4",
-                        "A5",
-                        "B5",
-                        "C5",
-                        "D5",
-                        "E5",
-                        "F5",
-                        "G5",
-                        "H5",
-                        "A6",
-                        "B6",
-                        "C6",
-                        "D6",
-                        "E6",
-                        "F6",
-                        "G6",
-                        "H6",
-                        "A7",
-                        "B7",
-                        "C7",
-                        "D7",
-                        "E7",
-                        "F7",
-                        "G7",
-                        "H7",
-                        "A8",
-                        "B8",
-                        "C8",
-                        "D8",
-                        "E8",
-                        "F8",
-                        "G8",
-                        "H8",
-                        "A9",
-                        "B9",
-                        "C9",
-                        "D9",
-                        "E9",
-                        "F9",
-                        "G9",
-                        "H9",
-                        "A10",
-                        "B10",
-                        "C10",
-                        "D10",
-                        "E10",
-                        "F10",
-                        "G10",
-                        "H10",
-                        "A11",
-                        "B11",
-                        "C11",
-                        "D11",
-                        "E11",
-                        "F11",
-                        "G11",
-                        "H11",
-                        "A12",
-                        "B12",
-                        "C12",
-                        "D12",
-                        "E12",
-                        "F12",
-                        "G12",
-                        "H12"
-                    ]
-                }
-            ],
-            "metadata": {
-                "displayCategory": "aluminumBlock",
-                "displayName": "GenMate 96 Aluminum Block 20 \u00b5L",
-                "displayVolumeUnits": "\u00b5L",
-                "tags": []
-            },
-            "namespace": "custom_beta",
-            "ordering": [
-                [
-                    "A1",
-                    "B1",
-                    "C1",
-                    "D1",
-                    "E1",
-                    "F1",
-                    "G1",
-                    "H1"
-                ],
-                [
-                    "A2",
-                    "B2",
-                    "C2",
-                    "D2",
-                    "E2",
-                    "F2",
-                    "G2",
-                    "H2"
-                ],
-                [
-                    "A3",
-                    "B3",
-                    "C3",
-                    "D3",
-                    "E3",
-                    "F3",
-                    "G3",
-                    "H3"
-                ],
-                [
-                    "A4",
-                    "B4",
-                    "C4",
-                    "D4",
-                    "E4",
-                    "F4",
-                    "G4",
-                    "H4"
-                ],
-                [
-                    "A5",
-                    "B5",
-                    "C5",
-                    "D5",
-                    "E5",
-                    "F5",
-                    "G5",
-                    "H5"
-                ],
-                [
-                    "A6",
-                    "B6",
-                    "C6",
-                    "D6",
-                    "E6",
-                    "F6",
-                    "G6",
-                    "H6"
-                ],
-                [
-                    "A7",
-                    "B7",
-                    "C7",
-                    "D7",
-                    "E7",
-                    "F7",
-                    "G7",
-                    "H7"
-                ],
-                [
-                    "A8",
-                    "B8",
-                    "C8",
-                    "D8",
-                    "E8",
-                    "F8",
-                    "G8",
-                    "H8"
-                ],
-                [
-                    "A9",
-                    "B9",
-                    "C9",
-                    "D9",
-                    "E9",
-                    "F9",
-                    "G9",
-                    "H9"
-                ],
-                [
-                    "A10",
-                    "B10",
-                    "C10",
-                    "D10",
-                    "E10",
-                    "F10",
-                    "G10",
-                    "H10"
-                ],
-                [
-                    "A11",
-                    "B11",
-                    "C11",
-                    "D11",
-                    "E11",
-                    "F11",
-                    "G11",
-                    "H11"
-                ],
-                [
-                    "A12",
-                    "B12",
-                    "C12",
-                    "D12",
-                    "E12",
-                    "F12",
-                    "G12",
-                    "H12"
-                ]
-            ],
-            "parameters": {
-                "format": "irregular",
-                "isMagneticModuleCompatible": false,
-                "isTiprack": false,
-                "loadName": "genmate_96_aluminumblock_20ul",
-                "quirks": []
-            },
-            "schemaVersion": 2,
-            "version": 1,
-            "wells": {
-                "A1": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 14.38,
-                    "y": 74.25,
-                    "z": 6
-                },
-                "A10": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 95.38,
-                    "y": 74.25,
-                    "z": 6
-                },
-                "A11": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 104.38,
-                    "y": 74.25,
-                    "z": 6
-                },
-                "A12": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 113.38,
-                    "y": 74.25,
-                    "z": 6
-                },
-                "A2": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 23.38,
-                    "y": 74.25,
-                    "z": 6
-                },
-                "A3": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 32.38,
-                    "y": 74.25,
-                    "z": 6
-                },
-                "A4": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 41.38,
-                    "y": 74.25,
-                    "z": 6
-                },
-                "A5": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 50.38,
-                    "y": 74.25,
-                    "z": 6
-                },
-                "A6": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 59.38,
-                    "y": 74.25,
-                    "z": 6
-                },
-                "A7": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 68.38,
-                    "y": 74.25,
-                    "z": 6
-                },
-                "A8": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 77.38,
-                    "y": 74.25,
-                    "z": 6
-                },
-                "A9": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 86.38,
-                    "y": 74.25,
-                    "z": 6
-                },
-                "B1": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 14.38,
-                    "y": 65.25,
-                    "z": 6
-                },
-                "B10": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 95.38,
-                    "y": 65.25,
-                    "z": 6
-                },
-                "B11": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 104.38,
-                    "y": 65.25,
-                    "z": 6
-                },
-                "B12": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 113.38,
-                    "y": 65.25,
-                    "z": 6
-                },
-                "B2": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 23.38,
-                    "y": 65.25,
-                    "z": 6
-                },
-                "B3": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 32.38,
-                    "y": 65.25,
-                    "z": 6
-                },
-                "B4": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 41.38,
-                    "y": 65.25,
-                    "z": 6
-                },
-                "B5": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 50.38,
-                    "y": 65.25,
-                    "z": 6
-                },
-                "B6": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 59.38,
-                    "y": 65.25,
-                    "z": 6
-                },
-                "B7": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 68.38,
-                    "y": 65.25,
-                    "z": 6
-                },
-                "B8": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 77.38,
-                    "y": 65.25,
-                    "z": 6
-                },
-                "B9": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 86.38,
-                    "y": 65.25,
-                    "z": 6
-                },
-                "C1": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 14.38,
-                    "y": 56.25,
-                    "z": 6
-                },
-                "C10": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 95.38,
-                    "y": 56.25,
-                    "z": 6
-                },
-                "C11": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 104.38,
-                    "y": 56.25,
-                    "z": 6
-                },
-                "C12": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 113.38,
-                    "y": 56.25,
-                    "z": 6
-                },
-                "C2": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 23.38,
-                    "y": 56.25,
-                    "z": 6
-                },
-                "C3": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 32.38,
-                    "y": 56.25,
-                    "z": 6
-                },
-                "C4": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 41.38,
-                    "y": 56.25,
-                    "z": 6
-                },
-                "C5": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 50.38,
-                    "y": 56.25,
-                    "z": 6
-                },
-                "C6": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 59.38,
-                    "y": 56.25,
-                    "z": 6
-                },
-                "C7": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 68.38,
-                    "y": 56.25,
-                    "z": 6
-                },
-                "C8": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 77.38,
-                    "y": 56.25,
-                    "z": 6
-                },
-                "C9": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 86.38,
-                    "y": 56.25,
-                    "z": 6
-                },
-                "D1": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 14.38,
-                    "y": 47.25,
-                    "z": 6
-                },
-                "D10": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 95.38,
-                    "y": 47.25,
-                    "z": 6
-                },
-                "D11": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 104.38,
-                    "y": 47.25,
-                    "z": 6
-                },
-                "D12": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 113.38,
-                    "y": 47.25,
-                    "z": 6
-                },
-                "D2": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 23.38,
-                    "y": 47.25,
-                    "z": 6
-                },
-                "D3": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 32.38,
-                    "y": 47.25,
-                    "z": 6
-                },
-                "D4": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 41.38,
-                    "y": 47.25,
-                    "z": 6
-                },
-                "D5": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 50.38,
-                    "y": 47.25,
-                    "z": 6
-                },
-                "D6": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 59.38,
-                    "y": 47.25,
-                    "z": 6
-                },
-                "D7": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 68.38,
-                    "y": 47.25,
-                    "z": 6
-                },
-                "D8": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 77.38,
-                    "y": 47.25,
-                    "z": 6
-                },
-                "D9": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 86.38,
-                    "y": 47.25,
-                    "z": 6
-                },
-                "E1": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 14.38,
-                    "y": 38.25,
-                    "z": 6
-                },
-                "E10": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 95.38,
-                    "y": 38.25,
-                    "z": 6
-                },
-                "E11": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 104.38,
-                    "y": 38.25,
-                    "z": 6
-                },
-                "E12": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 113.38,
-                    "y": 38.25,
-                    "z": 6
-                },
-                "E2": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 23.38,
-                    "y": 38.25,
-                    "z": 6
-                },
-                "E3": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 32.38,
-                    "y": 38.25,
-                    "z": 6
-                },
-                "E4": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 41.38,
-                    "y": 38.25,
-                    "z": 6
-                },
-                "E5": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 50.38,
-                    "y": 38.25,
-                    "z": 6
-                },
-                "E6": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 59.38,
-                    "y": 38.25,
-                    "z": 6
-                },
-                "E7": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 68.38,
-                    "y": 38.25,
-                    "z": 6
-                },
-                "E8": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 77.38,
-                    "y": 38.25,
-                    "z": 6
-                },
-                "E9": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 86.38,
-                    "y": 38.25,
-                    "z": 6
-                },
-                "F1": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 14.38,
-                    "y": 29.25,
-                    "z": 6
-                },
-                "F10": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 95.38,
-                    "y": 29.25,
-                    "z": 6
-                },
-                "F11": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 104.38,
-                    "y": 29.25,
-                    "z": 6
-                },
-                "F12": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 113.38,
-                    "y": 29.25,
-                    "z": 6
-                },
-                "F2": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 23.38,
-                    "y": 29.25,
-                    "z": 6
-                },
-                "F3": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 32.38,
-                    "y": 29.25,
-                    "z": 6
-                },
-                "F4": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 41.38,
-                    "y": 29.25,
-                    "z": 6
-                },
-                "F5": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 50.38,
-                    "y": 29.25,
-                    "z": 6
-                },
-                "F6": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 59.38,
-                    "y": 29.25,
-                    "z": 6
-                },
-                "F7": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 68.38,
-                    "y": 29.25,
-                    "z": 6
-                },
-                "F8": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 77.38,
-                    "y": 29.25,
-                    "z": 6
-                },
-                "F9": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 86.38,
-                    "y": 29.25,
-                    "z": 6
-                },
-                "G1": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 14.38,
-                    "y": 20.25,
-                    "z": 6
-                },
-                "G10": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 95.38,
-                    "y": 20.25,
-                    "z": 6
-                },
-                "G11": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 104.38,
-                    "y": 20.25,
-                    "z": 6
-                },
-                "G12": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 113.38,
-                    "y": 20.25,
-                    "z": 6
-                },
-                "G2": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 23.38,
-                    "y": 20.25,
-                    "z": 6
-                },
-                "G3": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 32.38,
-                    "y": 20.25,
-                    "z": 6
-                },
-                "G4": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 41.38,
-                    "y": 20.25,
-                    "z": 6
-                },
-                "G5": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 50.38,
-                    "y": 20.25,
-                    "z": 6
-                },
-                "G6": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 59.38,
-                    "y": 20.25,
-                    "z": 6
-                },
-                "G7": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 68.38,
-                    "y": 20.25,
-                    "z": 6
-                },
-                "G8": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 77.38,
-                    "y": 20.25,
-                    "z": 6
-                },
-                "G9": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 86.38,
-                    "y": 20.25,
-                    "z": 6
-                },
-                "H1": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 14.38,
-                    "y": 11.25,
-                    "z": 6
-                },
-                "H10": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 95.38,
-                    "y": 11.25,
-                    "z": 6
-                },
-                "H11": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 104.38,
-                    "y": 11.25,
-                    "z": 6
-                },
-                "H12": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 113.38,
-                    "y": 11.25,
-                    "z": 6
-                },
-                "H2": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 23.38,
-                    "y": 11.25,
-                    "z": 6
-                },
-                "H3": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 32.38,
-                    "y": 11.25,
-                    "z": 6
-                },
-                "H4": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 41.38,
-                    "y": 11.25,
-                    "z": 6
-                },
-                "H5": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 50.38,
-                    "y": 11.25,
-                    "z": 6
-                },
-                "H6": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 59.38,
-                    "y": 11.25,
-                    "z": 6
-                },
-                "H7": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 68.38,
-                    "y": 11.25,
-                    "z": 6
-                },
-                "H8": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 77.38,
-                    "y": 11.25,
-                    "z": 6
-                },
-                "H9": {
-                    "depth": 18,
-                    "diameter": 2.5,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 86.38,
-                    "y": 11.25,
-                    "z": 6
-                }
-            }
         }
     ],
     "fields": [
@@ -5513,7 +5513,7 @@
             "type": "genmate_96_aluminumblock_20ul"
         },
         {
-            "name": "Opentrons 24 Well Aluminum Block with NEST 1.5 mL Snapcap on Temperature Module on 4",
+            "name": "Opentrons 24 Well Aluminum Block with NEST 1.5 mL Snapcap on Temperature Module GEN1 on 4",
             "share": false,
             "slot": "4",
             "type": "opentrons_24_aluminumblock_nest_1.5ml_snapcap"

--- a/protoBuilds/29414b/29414b.ot2.apiv2.py.json
+++ b/protoBuilds/29414b/29414b.ot2.apiv2.py.json
@@ -251,875 +251,875 @@
                 "format": "96Standard",
                 "isMagneticModuleCompatible": false,
                 "isTiprack": true,
-                "loadName": "generic_96_tiprack_200ul",
-                "tipLength": 50
+                "loadName": "generic_96_tiprack_20ul",
+                "tipLength": 32
             },
             "schemaVersion": 2,
             "version": 1,
             "wells": {
                 "A1": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 14.38,
                     "y": 74.24,
-                    "z": 20
+                    "z": 38
                 },
                 "A10": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 95.38,
                     "y": 74.24,
-                    "z": 20
+                    "z": 38
                 },
                 "A11": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 104.38,
                     "y": 74.24,
-                    "z": 20
+                    "z": 38
                 },
                 "A12": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 113.38,
                     "y": 74.24,
-                    "z": 20
+                    "z": 38
                 },
                 "A2": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 23.38,
                     "y": 74.24,
-                    "z": 20
+                    "z": 38
                 },
                 "A3": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 32.38,
                     "y": 74.24,
-                    "z": 20
+                    "z": 38
                 },
                 "A4": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 41.38,
                     "y": 74.24,
-                    "z": 20
+                    "z": 38
                 },
                 "A5": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 50.38,
                     "y": 74.24,
-                    "z": 20
+                    "z": 38
                 },
                 "A6": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 59.38,
                     "y": 74.24,
-                    "z": 20
+                    "z": 38
                 },
                 "A7": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 68.38,
                     "y": 74.24,
-                    "z": 20
+                    "z": 38
                 },
                 "A8": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 77.38,
                     "y": 74.24,
-                    "z": 20
+                    "z": 38
                 },
                 "A9": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 86.38,
                     "y": 74.24,
-                    "z": 20
+                    "z": 38
                 },
                 "B1": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 14.38,
                     "y": 65.24,
-                    "z": 20
+                    "z": 38
                 },
                 "B10": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 95.38,
                     "y": 65.24,
-                    "z": 20
+                    "z": 38
                 },
                 "B11": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 104.38,
                     "y": 65.24,
-                    "z": 20
+                    "z": 38
                 },
                 "B12": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 113.38,
                     "y": 65.24,
-                    "z": 20
+                    "z": 38
                 },
                 "B2": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 23.38,
                     "y": 65.24,
-                    "z": 20
+                    "z": 38
                 },
                 "B3": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 32.38,
                     "y": 65.24,
-                    "z": 20
+                    "z": 38
                 },
                 "B4": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 41.38,
                     "y": 65.24,
-                    "z": 20
+                    "z": 38
                 },
                 "B5": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 50.38,
                     "y": 65.24,
-                    "z": 20
+                    "z": 38
                 },
                 "B6": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 59.38,
                     "y": 65.24,
-                    "z": 20
+                    "z": 38
                 },
                 "B7": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 68.38,
                     "y": 65.24,
-                    "z": 20
+                    "z": 38
                 },
                 "B8": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 77.38,
                     "y": 65.24,
-                    "z": 20
+                    "z": 38
                 },
                 "B9": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 86.38,
                     "y": 65.24,
-                    "z": 20
+                    "z": 38
                 },
                 "C1": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 14.38,
                     "y": 56.24,
-                    "z": 20
+                    "z": 38
                 },
                 "C10": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 95.38,
                     "y": 56.24,
-                    "z": 20
+                    "z": 38
                 },
                 "C11": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 104.38,
                     "y": 56.24,
-                    "z": 20
+                    "z": 38
                 },
                 "C12": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 113.38,
                     "y": 56.24,
-                    "z": 20
+                    "z": 38
                 },
                 "C2": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 23.38,
                     "y": 56.24,
-                    "z": 20
+                    "z": 38
                 },
                 "C3": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 32.38,
                     "y": 56.24,
-                    "z": 20
+                    "z": 38
                 },
                 "C4": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 41.38,
                     "y": 56.24,
-                    "z": 20
+                    "z": 38
                 },
                 "C5": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 50.38,
                     "y": 56.24,
-                    "z": 20
+                    "z": 38
                 },
                 "C6": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 59.38,
                     "y": 56.24,
-                    "z": 20
+                    "z": 38
                 },
                 "C7": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 68.38,
                     "y": 56.24,
-                    "z": 20
+                    "z": 38
                 },
                 "C8": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 77.38,
                     "y": 56.24,
-                    "z": 20
+                    "z": 38
                 },
                 "C9": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 86.38,
                     "y": 56.24,
-                    "z": 20
+                    "z": 38
                 },
                 "D1": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 14.38,
                     "y": 47.24,
-                    "z": 20
+                    "z": 38
                 },
                 "D10": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 95.38,
                     "y": 47.24,
-                    "z": 20
+                    "z": 38
                 },
                 "D11": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 104.38,
                     "y": 47.24,
-                    "z": 20
+                    "z": 38
                 },
                 "D12": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 113.38,
                     "y": 47.24,
-                    "z": 20
+                    "z": 38
                 },
                 "D2": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 23.38,
                     "y": 47.24,
-                    "z": 20
+                    "z": 38
                 },
                 "D3": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 32.38,
                     "y": 47.24,
-                    "z": 20
+                    "z": 38
                 },
                 "D4": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 41.38,
                     "y": 47.24,
-                    "z": 20
+                    "z": 38
                 },
                 "D5": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 50.38,
                     "y": 47.24,
-                    "z": 20
+                    "z": 38
                 },
                 "D6": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 59.38,
                     "y": 47.24,
-                    "z": 20
+                    "z": 38
                 },
                 "D7": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 68.38,
                     "y": 47.24,
-                    "z": 20
+                    "z": 38
                 },
                 "D8": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 77.38,
                     "y": 47.24,
-                    "z": 20
+                    "z": 38
                 },
                 "D9": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 86.38,
                     "y": 47.24,
-                    "z": 20
+                    "z": 38
                 },
                 "E1": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 14.38,
                     "y": 38.24,
-                    "z": 20
+                    "z": 38
                 },
                 "E10": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 95.38,
                     "y": 38.24,
-                    "z": 20
+                    "z": 38
                 },
                 "E11": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 104.38,
                     "y": 38.24,
-                    "z": 20
+                    "z": 38
                 },
                 "E12": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 113.38,
                     "y": 38.24,
-                    "z": 20
+                    "z": 38
                 },
                 "E2": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 23.38,
                     "y": 38.24,
-                    "z": 20
+                    "z": 38
                 },
                 "E3": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 32.38,
                     "y": 38.24,
-                    "z": 20
+                    "z": 38
                 },
                 "E4": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 41.38,
                     "y": 38.24,
-                    "z": 20
+                    "z": 38
                 },
                 "E5": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 50.38,
                     "y": 38.24,
-                    "z": 20
+                    "z": 38
                 },
                 "E6": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 59.38,
                     "y": 38.24,
-                    "z": 20
+                    "z": 38
                 },
                 "E7": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 68.38,
                     "y": 38.24,
-                    "z": 20
+                    "z": 38
                 },
                 "E8": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 77.38,
                     "y": 38.24,
-                    "z": 20
+                    "z": 38
                 },
                 "E9": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 86.38,
                     "y": 38.24,
-                    "z": 20
+                    "z": 38
                 },
                 "F1": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 14.38,
                     "y": 29.24,
-                    "z": 20
+                    "z": 38
                 },
                 "F10": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 95.38,
                     "y": 29.24,
-                    "z": 20
+                    "z": 38
                 },
                 "F11": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 104.38,
                     "y": 29.24,
-                    "z": 20
+                    "z": 38
                 },
                 "F12": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 113.38,
                     "y": 29.24,
-                    "z": 20
+                    "z": 38
                 },
                 "F2": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 23.38,
                     "y": 29.24,
-                    "z": 20
+                    "z": 38
                 },
                 "F3": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 32.38,
                     "y": 29.24,
-                    "z": 20
+                    "z": 38
                 },
                 "F4": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 41.38,
                     "y": 29.24,
-                    "z": 20
+                    "z": 38
                 },
                 "F5": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 50.38,
                     "y": 29.24,
-                    "z": 20
+                    "z": 38
                 },
                 "F6": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 59.38,
                     "y": 29.24,
-                    "z": 20
+                    "z": 38
                 },
                 "F7": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 68.38,
                     "y": 29.24,
-                    "z": 20
+                    "z": 38
                 },
                 "F8": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 77.38,
                     "y": 29.24,
-                    "z": 20
+                    "z": 38
                 },
                 "F9": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 86.38,
                     "y": 29.24,
-                    "z": 20
+                    "z": 38
                 },
                 "G1": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 14.38,
                     "y": 20.24,
-                    "z": 20
+                    "z": 38
                 },
                 "G10": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 95.38,
                     "y": 20.24,
-                    "z": 20
+                    "z": 38
                 },
                 "G11": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 104.38,
                     "y": 20.24,
-                    "z": 20
+                    "z": 38
                 },
                 "G12": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 113.38,
                     "y": 20.24,
-                    "z": 20
+                    "z": 38
                 },
                 "G2": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 23.38,
                     "y": 20.24,
-                    "z": 20
+                    "z": 38
                 },
                 "G3": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 32.38,
                     "y": 20.24,
-                    "z": 20
+                    "z": 38
                 },
                 "G4": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 41.38,
                     "y": 20.24,
-                    "z": 20
+                    "z": 38
                 },
                 "G5": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 50.38,
                     "y": 20.24,
-                    "z": 20
+                    "z": 38
                 },
                 "G6": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 59.38,
                     "y": 20.24,
-                    "z": 20
+                    "z": 38
                 },
                 "G7": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 68.38,
                     "y": 20.24,
-                    "z": 20
+                    "z": 38
                 },
                 "G8": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 77.38,
                     "y": 20.24,
-                    "z": 20
+                    "z": 38
                 },
                 "G9": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 86.38,
                     "y": 20.24,
-                    "z": 20
+                    "z": 38
                 },
                 "H1": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 14.38,
                     "y": 11.24,
-                    "z": 20
+                    "z": 38
                 },
                 "H10": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 95.38,
                     "y": 11.24,
-                    "z": 20
+                    "z": 38
                 },
                 "H11": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 104.38,
                     "y": 11.24,
-                    "z": 20
+                    "z": 38
                 },
                 "H12": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 113.38,
                     "y": 11.24,
-                    "z": 20
+                    "z": 38
                 },
                 "H2": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 23.38,
                     "y": 11.24,
-                    "z": 20
+                    "z": 38
                 },
                 "H3": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 32.38,
                     "y": 11.24,
-                    "z": 20
+                    "z": 38
                 },
                 "H4": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 41.38,
                     "y": 11.24,
-                    "z": 20
+                    "z": 38
                 },
                 "H5": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 50.38,
                     "y": 11.24,
-                    "z": 20
+                    "z": 38
                 },
                 "H6": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 59.38,
                     "y": 11.24,
-                    "z": 20
+                    "z": 38
                 },
                 "H7": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 68.38,
                     "y": 11.24,
-                    "z": 20
+                    "z": 38
                 },
                 "H8": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 77.38,
                     "y": 11.24,
-                    "z": 20
+                    "z": 38
                 },
                 "H9": {
-                    "depth": 50,
+                    "depth": 32,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 200,
+                    "totalLiquidVolume": 20,
                     "x": 86.38,
                     "y": 11.24,
-                    "z": 20
+                    "z": 38
                 }
             }
         },
@@ -2504,875 +2504,875 @@
                 "format": "96Standard",
                 "isMagneticModuleCompatible": false,
                 "isTiprack": true,
-                "loadName": "generic_96_tiprack_20ul",
-                "tipLength": 32
+                "loadName": "generic_96_tiprack_200ul",
+                "tipLength": 50
             },
             "schemaVersion": 2,
             "version": 1,
             "wells": {
                 "A1": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 14.38,
                     "y": 74.24,
-                    "z": 38
+                    "z": 20
                 },
                 "A10": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 95.38,
                     "y": 74.24,
-                    "z": 38
+                    "z": 20
                 },
                 "A11": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 104.38,
                     "y": 74.24,
-                    "z": 38
+                    "z": 20
                 },
                 "A12": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 113.38,
                     "y": 74.24,
-                    "z": 38
+                    "z": 20
                 },
                 "A2": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 23.38,
                     "y": 74.24,
-                    "z": 38
+                    "z": 20
                 },
                 "A3": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 32.38,
                     "y": 74.24,
-                    "z": 38
+                    "z": 20
                 },
                 "A4": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 41.38,
                     "y": 74.24,
-                    "z": 38
+                    "z": 20
                 },
                 "A5": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 50.38,
                     "y": 74.24,
-                    "z": 38
+                    "z": 20
                 },
                 "A6": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 59.38,
                     "y": 74.24,
-                    "z": 38
+                    "z": 20
                 },
                 "A7": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 68.38,
                     "y": 74.24,
-                    "z": 38
+                    "z": 20
                 },
                 "A8": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 77.38,
                     "y": 74.24,
-                    "z": 38
+                    "z": 20
                 },
                 "A9": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 86.38,
                     "y": 74.24,
-                    "z": 38
+                    "z": 20
                 },
                 "B1": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 14.38,
                     "y": 65.24,
-                    "z": 38
+                    "z": 20
                 },
                 "B10": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 95.38,
                     "y": 65.24,
-                    "z": 38
+                    "z": 20
                 },
                 "B11": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 104.38,
                     "y": 65.24,
-                    "z": 38
+                    "z": 20
                 },
                 "B12": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 113.38,
                     "y": 65.24,
-                    "z": 38
+                    "z": 20
                 },
                 "B2": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 23.38,
                     "y": 65.24,
-                    "z": 38
+                    "z": 20
                 },
                 "B3": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 32.38,
                     "y": 65.24,
-                    "z": 38
+                    "z": 20
                 },
                 "B4": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 41.38,
                     "y": 65.24,
-                    "z": 38
+                    "z": 20
                 },
                 "B5": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 50.38,
                     "y": 65.24,
-                    "z": 38
+                    "z": 20
                 },
                 "B6": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 59.38,
                     "y": 65.24,
-                    "z": 38
+                    "z": 20
                 },
                 "B7": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 68.38,
                     "y": 65.24,
-                    "z": 38
+                    "z": 20
                 },
                 "B8": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 77.38,
                     "y": 65.24,
-                    "z": 38
+                    "z": 20
                 },
                 "B9": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 86.38,
                     "y": 65.24,
-                    "z": 38
+                    "z": 20
                 },
                 "C1": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 14.38,
                     "y": 56.24,
-                    "z": 38
+                    "z": 20
                 },
                 "C10": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 95.38,
                     "y": 56.24,
-                    "z": 38
+                    "z": 20
                 },
                 "C11": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 104.38,
                     "y": 56.24,
-                    "z": 38
+                    "z": 20
                 },
                 "C12": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 113.38,
                     "y": 56.24,
-                    "z": 38
+                    "z": 20
                 },
                 "C2": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 23.38,
                     "y": 56.24,
-                    "z": 38
+                    "z": 20
                 },
                 "C3": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 32.38,
                     "y": 56.24,
-                    "z": 38
+                    "z": 20
                 },
                 "C4": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 41.38,
                     "y": 56.24,
-                    "z": 38
+                    "z": 20
                 },
                 "C5": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 50.38,
                     "y": 56.24,
-                    "z": 38
+                    "z": 20
                 },
                 "C6": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 59.38,
                     "y": 56.24,
-                    "z": 38
+                    "z": 20
                 },
                 "C7": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 68.38,
                     "y": 56.24,
-                    "z": 38
+                    "z": 20
                 },
                 "C8": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 77.38,
                     "y": 56.24,
-                    "z": 38
+                    "z": 20
                 },
                 "C9": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 86.38,
                     "y": 56.24,
-                    "z": 38
+                    "z": 20
                 },
                 "D1": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 14.38,
                     "y": 47.24,
-                    "z": 38
+                    "z": 20
                 },
                 "D10": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 95.38,
                     "y": 47.24,
-                    "z": 38
+                    "z": 20
                 },
                 "D11": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 104.38,
                     "y": 47.24,
-                    "z": 38
+                    "z": 20
                 },
                 "D12": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 113.38,
                     "y": 47.24,
-                    "z": 38
+                    "z": 20
                 },
                 "D2": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 23.38,
                     "y": 47.24,
-                    "z": 38
+                    "z": 20
                 },
                 "D3": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 32.38,
                     "y": 47.24,
-                    "z": 38
+                    "z": 20
                 },
                 "D4": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 41.38,
                     "y": 47.24,
-                    "z": 38
+                    "z": 20
                 },
                 "D5": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 50.38,
                     "y": 47.24,
-                    "z": 38
+                    "z": 20
                 },
                 "D6": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 59.38,
                     "y": 47.24,
-                    "z": 38
+                    "z": 20
                 },
                 "D7": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 68.38,
                     "y": 47.24,
-                    "z": 38
+                    "z": 20
                 },
                 "D8": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 77.38,
                     "y": 47.24,
-                    "z": 38
+                    "z": 20
                 },
                 "D9": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 86.38,
                     "y": 47.24,
-                    "z": 38
+                    "z": 20
                 },
                 "E1": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 14.38,
                     "y": 38.24,
-                    "z": 38
+                    "z": 20
                 },
                 "E10": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 95.38,
                     "y": 38.24,
-                    "z": 38
+                    "z": 20
                 },
                 "E11": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 104.38,
                     "y": 38.24,
-                    "z": 38
+                    "z": 20
                 },
                 "E12": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 113.38,
                     "y": 38.24,
-                    "z": 38
+                    "z": 20
                 },
                 "E2": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 23.38,
                     "y": 38.24,
-                    "z": 38
+                    "z": 20
                 },
                 "E3": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 32.38,
                     "y": 38.24,
-                    "z": 38
+                    "z": 20
                 },
                 "E4": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 41.38,
                     "y": 38.24,
-                    "z": 38
+                    "z": 20
                 },
                 "E5": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 50.38,
                     "y": 38.24,
-                    "z": 38
+                    "z": 20
                 },
                 "E6": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 59.38,
                     "y": 38.24,
-                    "z": 38
+                    "z": 20
                 },
                 "E7": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 68.38,
                     "y": 38.24,
-                    "z": 38
+                    "z": 20
                 },
                 "E8": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 77.38,
                     "y": 38.24,
-                    "z": 38
+                    "z": 20
                 },
                 "E9": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 86.38,
                     "y": 38.24,
-                    "z": 38
+                    "z": 20
                 },
                 "F1": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 14.38,
                     "y": 29.24,
-                    "z": 38
+                    "z": 20
                 },
                 "F10": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 95.38,
                     "y": 29.24,
-                    "z": 38
+                    "z": 20
                 },
                 "F11": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 104.38,
                     "y": 29.24,
-                    "z": 38
+                    "z": 20
                 },
                 "F12": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 113.38,
                     "y": 29.24,
-                    "z": 38
+                    "z": 20
                 },
                 "F2": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 23.38,
                     "y": 29.24,
-                    "z": 38
+                    "z": 20
                 },
                 "F3": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 32.38,
                     "y": 29.24,
-                    "z": 38
+                    "z": 20
                 },
                 "F4": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 41.38,
                     "y": 29.24,
-                    "z": 38
+                    "z": 20
                 },
                 "F5": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 50.38,
                     "y": 29.24,
-                    "z": 38
+                    "z": 20
                 },
                 "F6": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 59.38,
                     "y": 29.24,
-                    "z": 38
+                    "z": 20
                 },
                 "F7": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 68.38,
                     "y": 29.24,
-                    "z": 38
+                    "z": 20
                 },
                 "F8": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 77.38,
                     "y": 29.24,
-                    "z": 38
+                    "z": 20
                 },
                 "F9": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 86.38,
                     "y": 29.24,
-                    "z": 38
+                    "z": 20
                 },
                 "G1": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 14.38,
                     "y": 20.24,
-                    "z": 38
+                    "z": 20
                 },
                 "G10": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 95.38,
                     "y": 20.24,
-                    "z": 38
+                    "z": 20
                 },
                 "G11": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 104.38,
                     "y": 20.24,
-                    "z": 38
+                    "z": 20
                 },
                 "G12": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 113.38,
                     "y": 20.24,
-                    "z": 38
+                    "z": 20
                 },
                 "G2": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 23.38,
                     "y": 20.24,
-                    "z": 38
+                    "z": 20
                 },
                 "G3": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 32.38,
                     "y": 20.24,
-                    "z": 38
+                    "z": 20
                 },
                 "G4": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 41.38,
                     "y": 20.24,
-                    "z": 38
+                    "z": 20
                 },
                 "G5": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 50.38,
                     "y": 20.24,
-                    "z": 38
+                    "z": 20
                 },
                 "G6": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 59.38,
                     "y": 20.24,
-                    "z": 38
+                    "z": 20
                 },
                 "G7": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 68.38,
                     "y": 20.24,
-                    "z": 38
+                    "z": 20
                 },
                 "G8": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 77.38,
                     "y": 20.24,
-                    "z": 38
+                    "z": 20
                 },
                 "G9": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 86.38,
                     "y": 20.24,
-                    "z": 38
+                    "z": 20
                 },
                 "H1": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 14.38,
                     "y": 11.24,
-                    "z": 38
+                    "z": 20
                 },
                 "H10": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 95.38,
                     "y": 11.24,
-                    "z": 38
+                    "z": 20
                 },
                 "H11": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 104.38,
                     "y": 11.24,
-                    "z": 38
+                    "z": 20
                 },
                 "H12": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 113.38,
                     "y": 11.24,
-                    "z": 38
+                    "z": 20
                 },
                 "H2": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 23.38,
                     "y": 11.24,
-                    "z": 38
+                    "z": 20
                 },
                 "H3": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 32.38,
                     "y": 11.24,
-                    "z": 38
+                    "z": 20
                 },
                 "H4": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 41.38,
                     "y": 11.24,
-                    "z": 38
+                    "z": 20
                 },
                 "H5": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 50.38,
                     "y": 11.24,
-                    "z": 38
+                    "z": 20
                 },
                 "H6": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 59.38,
                     "y": 11.24,
-                    "z": 38
+                    "z": 20
                 },
                 "H7": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 68.38,
                     "y": 11.24,
-                    "z": 38
+                    "z": 20
                 },
                 "H8": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 77.38,
                     "y": 11.24,
-                    "z": 38
+                    "z": 20
                 },
                 "H9": {
-                    "depth": 32,
+                    "depth": 50,
                     "diameter": 5.2,
                     "shape": "circular",
-                    "totalLiquidVolume": 20,
+                    "totalLiquidVolume": 200,
                     "x": 86.38,
                     "y": 11.24,
-                    "z": 38
+                    "z": 20
                 }
             }
         }

--- a/protoBuilds/33900b/protein_purification.ot2.apiv2.py.json
+++ b/protoBuilds/33900b/protein_purification.ot2.apiv2.py.json
@@ -5,1141 +5,6 @@
             "brand": {
                 "brand": "Greiner Bio-One",
                 "brandId": [
-                    "651161"
-                ]
-            },
-            "cornerOffsetFromSlot": {
-                "x": 0,
-                "y": 0,
-                "z": 0
-            },
-            "dimensions": {
-                "xDimension": 127.76,
-                "yDimension": 85.48,
-                "zDimension": 14.1
-            },
-            "groups": [
-                {
-                    "brand": {
-                        "brand": "Greiner Bio-One",
-                        "brandId": [
-                            "651161"
-                        ]
-                    },
-                    "metadata": {
-                        "displayCategory": "wellPlate",
-                        "displayName": "Greiner Bio-One 96 Well Plate 200 \u00b5L",
-                        "wellBottomShape": "v"
-                    },
-                    "wells": [
-                        "A1",
-                        "B1",
-                        "C1",
-                        "D1",
-                        "E1",
-                        "F1",
-                        "G1",
-                        "H1",
-                        "A2",
-                        "B2",
-                        "C2",
-                        "D2",
-                        "E2",
-                        "F2",
-                        "G2",
-                        "H2",
-                        "A3",
-                        "B3",
-                        "C3",
-                        "D3",
-                        "E3",
-                        "F3",
-                        "G3",
-                        "H3",
-                        "A4",
-                        "B4",
-                        "C4",
-                        "D4",
-                        "E4",
-                        "F4",
-                        "G4",
-                        "H4",
-                        "A5",
-                        "B5",
-                        "C5",
-                        "D5",
-                        "E5",
-                        "F5",
-                        "G5",
-                        "H5",
-                        "A6",
-                        "B6",
-                        "C6",
-                        "D6",
-                        "E6",
-                        "F6",
-                        "G6",
-                        "H6",
-                        "A7",
-                        "B7",
-                        "C7",
-                        "D7",
-                        "E7",
-                        "F7",
-                        "G7",
-                        "H7",
-                        "A8",
-                        "B8",
-                        "C8",
-                        "D8",
-                        "E8",
-                        "F8",
-                        "G8",
-                        "H8",
-                        "A9",
-                        "B9",
-                        "C9",
-                        "D9",
-                        "E9",
-                        "F9",
-                        "G9",
-                        "H9",
-                        "A10",
-                        "B10",
-                        "C10",
-                        "D10",
-                        "E10",
-                        "F10",
-                        "G10",
-                        "H10",
-                        "A11",
-                        "B11",
-                        "C11",
-                        "D11",
-                        "E11",
-                        "F11",
-                        "G11",
-                        "H11",
-                        "A12",
-                        "B12",
-                        "C12",
-                        "D12",
-                        "E12",
-                        "F12",
-                        "G12",
-                        "H12"
-                    ]
-                }
-            ],
-            "metadata": {
-                "displayCategory": "wellPlate",
-                "displayName": "Greiner Bio-One 96 Well Plate 200 \u00b5L",
-                "displayVolumeUnits": "\u00b5L",
-                "tags": []
-            },
-            "namespace": "custom_beta",
-            "ordering": [
-                [
-                    "A1",
-                    "B1",
-                    "C1",
-                    "D1",
-                    "E1",
-                    "F1",
-                    "G1",
-                    "H1"
-                ],
-                [
-                    "A2",
-                    "B2",
-                    "C2",
-                    "D2",
-                    "E2",
-                    "F2",
-                    "G2",
-                    "H2"
-                ],
-                [
-                    "A3",
-                    "B3",
-                    "C3",
-                    "D3",
-                    "E3",
-                    "F3",
-                    "G3",
-                    "H3"
-                ],
-                [
-                    "A4",
-                    "B4",
-                    "C4",
-                    "D4",
-                    "E4",
-                    "F4",
-                    "G4",
-                    "H4"
-                ],
-                [
-                    "A5",
-                    "B5",
-                    "C5",
-                    "D5",
-                    "E5",
-                    "F5",
-                    "G5",
-                    "H5"
-                ],
-                [
-                    "A6",
-                    "B6",
-                    "C6",
-                    "D6",
-                    "E6",
-                    "F6",
-                    "G6",
-                    "H6"
-                ],
-                [
-                    "A7",
-                    "B7",
-                    "C7",
-                    "D7",
-                    "E7",
-                    "F7",
-                    "G7",
-                    "H7"
-                ],
-                [
-                    "A8",
-                    "B8",
-                    "C8",
-                    "D8",
-                    "E8",
-                    "F8",
-                    "G8",
-                    "H8"
-                ],
-                [
-                    "A9",
-                    "B9",
-                    "C9",
-                    "D9",
-                    "E9",
-                    "F9",
-                    "G9",
-                    "H9"
-                ],
-                [
-                    "A10",
-                    "B10",
-                    "C10",
-                    "D10",
-                    "E10",
-                    "F10",
-                    "G10",
-                    "H10"
-                ],
-                [
-                    "A11",
-                    "B11",
-                    "C11",
-                    "D11",
-                    "E11",
-                    "F11",
-                    "G11",
-                    "H11"
-                ],
-                [
-                    "A12",
-                    "B12",
-                    "C12",
-                    "D12",
-                    "E12",
-                    "F12",
-                    "G12",
-                    "H12"
-                ]
-            ],
-            "parameters": {
-                "format": "irregular",
-                "isMagneticModuleCompatible": true,
-                "isTiprack": false,
-                "loadName": "greinerbioone_96_wellplate_200ul",
-                "quirks": []
-            },
-            "schemaVersion": 2,
-            "version": 1,
-            "wells": {
-                "A1": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 14.29,
-                    "y": 74.3,
-                    "z": 4.07
-                },
-                "A10": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 95.29,
-                    "y": 74.3,
-                    "z": 4.07
-                },
-                "A11": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 104.29,
-                    "y": 74.3,
-                    "z": 4.07
-                },
-                "A12": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 113.29,
-                    "y": 74.3,
-                    "z": 4.07
-                },
-                "A2": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 23.29,
-                    "y": 74.3,
-                    "z": 4.07
-                },
-                "A3": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 32.29,
-                    "y": 74.3,
-                    "z": 4.07
-                },
-                "A4": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 41.29,
-                    "y": 74.3,
-                    "z": 4.07
-                },
-                "A5": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 50.29,
-                    "y": 74.3,
-                    "z": 4.07
-                },
-                "A6": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 59.29,
-                    "y": 74.3,
-                    "z": 4.07
-                },
-                "A7": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 68.29,
-                    "y": 74.3,
-                    "z": 4.07
-                },
-                "A8": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 77.29,
-                    "y": 74.3,
-                    "z": 4.07
-                },
-                "A9": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 86.29,
-                    "y": 74.3,
-                    "z": 4.07
-                },
-                "B1": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 14.29,
-                    "y": 65.3,
-                    "z": 4.07
-                },
-                "B10": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 95.29,
-                    "y": 65.3,
-                    "z": 4.07
-                },
-                "B11": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 104.29,
-                    "y": 65.3,
-                    "z": 4.07
-                },
-                "B12": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 113.29,
-                    "y": 65.3,
-                    "z": 4.07
-                },
-                "B2": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 23.29,
-                    "y": 65.3,
-                    "z": 4.07
-                },
-                "B3": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 32.29,
-                    "y": 65.3,
-                    "z": 4.07
-                },
-                "B4": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 41.29,
-                    "y": 65.3,
-                    "z": 4.07
-                },
-                "B5": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 50.29,
-                    "y": 65.3,
-                    "z": 4.07
-                },
-                "B6": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 59.29,
-                    "y": 65.3,
-                    "z": 4.07
-                },
-                "B7": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 68.29,
-                    "y": 65.3,
-                    "z": 4.07
-                },
-                "B8": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 77.29,
-                    "y": 65.3,
-                    "z": 4.07
-                },
-                "B9": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 86.29,
-                    "y": 65.3,
-                    "z": 4.07
-                },
-                "C1": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 14.29,
-                    "y": 56.3,
-                    "z": 4.07
-                },
-                "C10": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 95.29,
-                    "y": 56.3,
-                    "z": 4.07
-                },
-                "C11": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 104.29,
-                    "y": 56.3,
-                    "z": 4.07
-                },
-                "C12": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 113.29,
-                    "y": 56.3,
-                    "z": 4.07
-                },
-                "C2": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 23.29,
-                    "y": 56.3,
-                    "z": 4.07
-                },
-                "C3": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 32.29,
-                    "y": 56.3,
-                    "z": 4.07
-                },
-                "C4": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 41.29,
-                    "y": 56.3,
-                    "z": 4.07
-                },
-                "C5": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 50.29,
-                    "y": 56.3,
-                    "z": 4.07
-                },
-                "C6": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 59.29,
-                    "y": 56.3,
-                    "z": 4.07
-                },
-                "C7": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 68.29,
-                    "y": 56.3,
-                    "z": 4.07
-                },
-                "C8": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 77.29,
-                    "y": 56.3,
-                    "z": 4.07
-                },
-                "C9": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 86.29,
-                    "y": 56.3,
-                    "z": 4.07
-                },
-                "D1": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 14.29,
-                    "y": 47.3,
-                    "z": 4.07
-                },
-                "D10": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 95.29,
-                    "y": 47.3,
-                    "z": 4.07
-                },
-                "D11": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 104.29,
-                    "y": 47.3,
-                    "z": 4.07
-                },
-                "D12": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 113.29,
-                    "y": 47.3,
-                    "z": 4.07
-                },
-                "D2": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 23.29,
-                    "y": 47.3,
-                    "z": 4.07
-                },
-                "D3": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 32.29,
-                    "y": 47.3,
-                    "z": 4.07
-                },
-                "D4": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 41.29,
-                    "y": 47.3,
-                    "z": 4.07
-                },
-                "D5": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 50.29,
-                    "y": 47.3,
-                    "z": 4.07
-                },
-                "D6": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 59.29,
-                    "y": 47.3,
-                    "z": 4.07
-                },
-                "D7": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 68.29,
-                    "y": 47.3,
-                    "z": 4.07
-                },
-                "D8": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 77.29,
-                    "y": 47.3,
-                    "z": 4.07
-                },
-                "D9": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 86.29,
-                    "y": 47.3,
-                    "z": 4.07
-                },
-                "E1": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 14.29,
-                    "y": 38.3,
-                    "z": 4.07
-                },
-                "E10": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 95.29,
-                    "y": 38.3,
-                    "z": 4.07
-                },
-                "E11": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 104.29,
-                    "y": 38.3,
-                    "z": 4.07
-                },
-                "E12": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 113.29,
-                    "y": 38.3,
-                    "z": 4.07
-                },
-                "E2": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 23.29,
-                    "y": 38.3,
-                    "z": 4.07
-                },
-                "E3": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 32.29,
-                    "y": 38.3,
-                    "z": 4.07
-                },
-                "E4": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 41.29,
-                    "y": 38.3,
-                    "z": 4.07
-                },
-                "E5": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 50.29,
-                    "y": 38.3,
-                    "z": 4.07
-                },
-                "E6": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 59.29,
-                    "y": 38.3,
-                    "z": 4.07
-                },
-                "E7": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 68.29,
-                    "y": 38.3,
-                    "z": 4.07
-                },
-                "E8": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 77.29,
-                    "y": 38.3,
-                    "z": 4.07
-                },
-                "E9": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 86.29,
-                    "y": 38.3,
-                    "z": 4.07
-                },
-                "F1": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 14.29,
-                    "y": 29.3,
-                    "z": 4.07
-                },
-                "F10": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 95.29,
-                    "y": 29.3,
-                    "z": 4.07
-                },
-                "F11": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 104.29,
-                    "y": 29.3,
-                    "z": 4.07
-                },
-                "F12": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 113.29,
-                    "y": 29.3,
-                    "z": 4.07
-                },
-                "F2": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 23.29,
-                    "y": 29.3,
-                    "z": 4.07
-                },
-                "F3": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 32.29,
-                    "y": 29.3,
-                    "z": 4.07
-                },
-                "F4": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 41.29,
-                    "y": 29.3,
-                    "z": 4.07
-                },
-                "F5": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 50.29,
-                    "y": 29.3,
-                    "z": 4.07
-                },
-                "F6": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 59.29,
-                    "y": 29.3,
-                    "z": 4.07
-                },
-                "F7": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 68.29,
-                    "y": 29.3,
-                    "z": 4.07
-                },
-                "F8": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 77.29,
-                    "y": 29.3,
-                    "z": 4.07
-                },
-                "F9": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 86.29,
-                    "y": 29.3,
-                    "z": 4.07
-                },
-                "G1": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 14.29,
-                    "y": 20.3,
-                    "z": 4.07
-                },
-                "G10": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 95.29,
-                    "y": 20.3,
-                    "z": 4.07
-                },
-                "G11": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 104.29,
-                    "y": 20.3,
-                    "z": 4.07
-                },
-                "G12": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 113.29,
-                    "y": 20.3,
-                    "z": 4.07
-                },
-                "G2": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 23.29,
-                    "y": 20.3,
-                    "z": 4.07
-                },
-                "G3": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 32.29,
-                    "y": 20.3,
-                    "z": 4.07
-                },
-                "G4": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 41.29,
-                    "y": 20.3,
-                    "z": 4.07
-                },
-                "G5": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 50.29,
-                    "y": 20.3,
-                    "z": 4.07
-                },
-                "G6": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 59.29,
-                    "y": 20.3,
-                    "z": 4.07
-                },
-                "G7": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 68.29,
-                    "y": 20.3,
-                    "z": 4.07
-                },
-                "G8": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 77.29,
-                    "y": 20.3,
-                    "z": 4.07
-                },
-                "G9": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 86.29,
-                    "y": 20.3,
-                    "z": 4.07
-                },
-                "H1": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 14.29,
-                    "y": 11.3,
-                    "z": 4.07
-                },
-                "H10": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 95.29,
-                    "y": 11.3,
-                    "z": 4.07
-                },
-                "H11": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 104.29,
-                    "y": 11.3,
-                    "z": 4.07
-                },
-                "H12": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 113.29,
-                    "y": 11.3,
-                    "z": 4.07
-                },
-                "H2": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 23.29,
-                    "y": 11.3,
-                    "z": 4.07
-                },
-                "H3": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 32.29,
-                    "y": 11.3,
-                    "z": 4.07
-                },
-                "H4": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 41.29,
-                    "y": 11.3,
-                    "z": 4.07
-                },
-                "H5": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 50.29,
-                    "y": 11.3,
-                    "z": 4.07
-                },
-                "H6": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 59.29,
-                    "y": 11.3,
-                    "z": 4.07
-                },
-                "H7": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 68.29,
-                    "y": 11.3,
-                    "z": 4.07
-                },
-                "H8": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 77.29,
-                    "y": 11.3,
-                    "z": 4.07
-                },
-                "H9": {
-                    "depth": 10.03,
-                    "diameter": 6.18,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 86.29,
-                    "y": 11.3,
-                    "z": 4.07
-                }
-            }
-        },
-        {
-            "brand": {
-                "brand": "Greiner Bio-One",
-                "brandId": [
                     "780270"
                 ]
             },
@@ -2370,6 +1235,1241 @@
         },
         {
             "brand": {
+                "brand": "Greiner Bio-One",
+                "brandId": [
+                    "651161"
+                ]
+            },
+            "cornerOffsetFromSlot": {
+                "x": 0,
+                "y": 0,
+                "z": 0
+            },
+            "dimensions": {
+                "xDimension": 127.76,
+                "yDimension": 85.48,
+                "zDimension": 14.1
+            },
+            "groups": [
+                {
+                    "brand": {
+                        "brand": "Greiner Bio-One",
+                        "brandId": [
+                            "651161"
+                        ]
+                    },
+                    "metadata": {
+                        "displayCategory": "wellPlate",
+                        "displayName": "Greiner Bio-One 96 Well Plate 200 \u00b5L",
+                        "wellBottomShape": "v"
+                    },
+                    "wells": [
+                        "A1",
+                        "B1",
+                        "C1",
+                        "D1",
+                        "E1",
+                        "F1",
+                        "G1",
+                        "H1",
+                        "A2",
+                        "B2",
+                        "C2",
+                        "D2",
+                        "E2",
+                        "F2",
+                        "G2",
+                        "H2",
+                        "A3",
+                        "B3",
+                        "C3",
+                        "D3",
+                        "E3",
+                        "F3",
+                        "G3",
+                        "H3",
+                        "A4",
+                        "B4",
+                        "C4",
+                        "D4",
+                        "E4",
+                        "F4",
+                        "G4",
+                        "H4",
+                        "A5",
+                        "B5",
+                        "C5",
+                        "D5",
+                        "E5",
+                        "F5",
+                        "G5",
+                        "H5",
+                        "A6",
+                        "B6",
+                        "C6",
+                        "D6",
+                        "E6",
+                        "F6",
+                        "G6",
+                        "H6",
+                        "A7",
+                        "B7",
+                        "C7",
+                        "D7",
+                        "E7",
+                        "F7",
+                        "G7",
+                        "H7",
+                        "A8",
+                        "B8",
+                        "C8",
+                        "D8",
+                        "E8",
+                        "F8",
+                        "G8",
+                        "H8",
+                        "A9",
+                        "B9",
+                        "C9",
+                        "D9",
+                        "E9",
+                        "F9",
+                        "G9",
+                        "H9",
+                        "A10",
+                        "B10",
+                        "C10",
+                        "D10",
+                        "E10",
+                        "F10",
+                        "G10",
+                        "H10",
+                        "A11",
+                        "B11",
+                        "C11",
+                        "D11",
+                        "E11",
+                        "F11",
+                        "G11",
+                        "H11",
+                        "A12",
+                        "B12",
+                        "C12",
+                        "D12",
+                        "E12",
+                        "F12",
+                        "G12",
+                        "H12"
+                    ]
+                }
+            ],
+            "metadata": {
+                "displayCategory": "wellPlate",
+                "displayName": "Greiner Bio-One 96 Well Plate 200 \u00b5L",
+                "displayVolumeUnits": "\u00b5L",
+                "tags": []
+            },
+            "namespace": "custom_beta",
+            "ordering": [
+                [
+                    "A1",
+                    "B1",
+                    "C1",
+                    "D1",
+                    "E1",
+                    "F1",
+                    "G1",
+                    "H1"
+                ],
+                [
+                    "A2",
+                    "B2",
+                    "C2",
+                    "D2",
+                    "E2",
+                    "F2",
+                    "G2",
+                    "H2"
+                ],
+                [
+                    "A3",
+                    "B3",
+                    "C3",
+                    "D3",
+                    "E3",
+                    "F3",
+                    "G3",
+                    "H3"
+                ],
+                [
+                    "A4",
+                    "B4",
+                    "C4",
+                    "D4",
+                    "E4",
+                    "F4",
+                    "G4",
+                    "H4"
+                ],
+                [
+                    "A5",
+                    "B5",
+                    "C5",
+                    "D5",
+                    "E5",
+                    "F5",
+                    "G5",
+                    "H5"
+                ],
+                [
+                    "A6",
+                    "B6",
+                    "C6",
+                    "D6",
+                    "E6",
+                    "F6",
+                    "G6",
+                    "H6"
+                ],
+                [
+                    "A7",
+                    "B7",
+                    "C7",
+                    "D7",
+                    "E7",
+                    "F7",
+                    "G7",
+                    "H7"
+                ],
+                [
+                    "A8",
+                    "B8",
+                    "C8",
+                    "D8",
+                    "E8",
+                    "F8",
+                    "G8",
+                    "H8"
+                ],
+                [
+                    "A9",
+                    "B9",
+                    "C9",
+                    "D9",
+                    "E9",
+                    "F9",
+                    "G9",
+                    "H9"
+                ],
+                [
+                    "A10",
+                    "B10",
+                    "C10",
+                    "D10",
+                    "E10",
+                    "F10",
+                    "G10",
+                    "H10"
+                ],
+                [
+                    "A11",
+                    "B11",
+                    "C11",
+                    "D11",
+                    "E11",
+                    "F11",
+                    "G11",
+                    "H11"
+                ],
+                [
+                    "A12",
+                    "B12",
+                    "C12",
+                    "D12",
+                    "E12",
+                    "F12",
+                    "G12",
+                    "H12"
+                ]
+            ],
+            "parameters": {
+                "format": "irregular",
+                "isMagneticModuleCompatible": true,
+                "isTiprack": false,
+                "loadName": "greinerbioone_96_wellplate_200ul",
+                "quirks": []
+            },
+            "schemaVersion": 2,
+            "version": 1,
+            "wells": {
+                "A1": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 14.29,
+                    "y": 74.3,
+                    "z": 4.07
+                },
+                "A10": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 95.29,
+                    "y": 74.3,
+                    "z": 4.07
+                },
+                "A11": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 104.29,
+                    "y": 74.3,
+                    "z": 4.07
+                },
+                "A12": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 113.29,
+                    "y": 74.3,
+                    "z": 4.07
+                },
+                "A2": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 23.29,
+                    "y": 74.3,
+                    "z": 4.07
+                },
+                "A3": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 32.29,
+                    "y": 74.3,
+                    "z": 4.07
+                },
+                "A4": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 41.29,
+                    "y": 74.3,
+                    "z": 4.07
+                },
+                "A5": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 50.29,
+                    "y": 74.3,
+                    "z": 4.07
+                },
+                "A6": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 59.29,
+                    "y": 74.3,
+                    "z": 4.07
+                },
+                "A7": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 68.29,
+                    "y": 74.3,
+                    "z": 4.07
+                },
+                "A8": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 77.29,
+                    "y": 74.3,
+                    "z": 4.07
+                },
+                "A9": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 86.29,
+                    "y": 74.3,
+                    "z": 4.07
+                },
+                "B1": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 14.29,
+                    "y": 65.3,
+                    "z": 4.07
+                },
+                "B10": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 95.29,
+                    "y": 65.3,
+                    "z": 4.07
+                },
+                "B11": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 104.29,
+                    "y": 65.3,
+                    "z": 4.07
+                },
+                "B12": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 113.29,
+                    "y": 65.3,
+                    "z": 4.07
+                },
+                "B2": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 23.29,
+                    "y": 65.3,
+                    "z": 4.07
+                },
+                "B3": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 32.29,
+                    "y": 65.3,
+                    "z": 4.07
+                },
+                "B4": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 41.29,
+                    "y": 65.3,
+                    "z": 4.07
+                },
+                "B5": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 50.29,
+                    "y": 65.3,
+                    "z": 4.07
+                },
+                "B6": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 59.29,
+                    "y": 65.3,
+                    "z": 4.07
+                },
+                "B7": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 68.29,
+                    "y": 65.3,
+                    "z": 4.07
+                },
+                "B8": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 77.29,
+                    "y": 65.3,
+                    "z": 4.07
+                },
+                "B9": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 86.29,
+                    "y": 65.3,
+                    "z": 4.07
+                },
+                "C1": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 14.29,
+                    "y": 56.3,
+                    "z": 4.07
+                },
+                "C10": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 95.29,
+                    "y": 56.3,
+                    "z": 4.07
+                },
+                "C11": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 104.29,
+                    "y": 56.3,
+                    "z": 4.07
+                },
+                "C12": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 113.29,
+                    "y": 56.3,
+                    "z": 4.07
+                },
+                "C2": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 23.29,
+                    "y": 56.3,
+                    "z": 4.07
+                },
+                "C3": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 32.29,
+                    "y": 56.3,
+                    "z": 4.07
+                },
+                "C4": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 41.29,
+                    "y": 56.3,
+                    "z": 4.07
+                },
+                "C5": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 50.29,
+                    "y": 56.3,
+                    "z": 4.07
+                },
+                "C6": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 59.29,
+                    "y": 56.3,
+                    "z": 4.07
+                },
+                "C7": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 68.29,
+                    "y": 56.3,
+                    "z": 4.07
+                },
+                "C8": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 77.29,
+                    "y": 56.3,
+                    "z": 4.07
+                },
+                "C9": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 86.29,
+                    "y": 56.3,
+                    "z": 4.07
+                },
+                "D1": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 14.29,
+                    "y": 47.3,
+                    "z": 4.07
+                },
+                "D10": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 95.29,
+                    "y": 47.3,
+                    "z": 4.07
+                },
+                "D11": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 104.29,
+                    "y": 47.3,
+                    "z": 4.07
+                },
+                "D12": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 113.29,
+                    "y": 47.3,
+                    "z": 4.07
+                },
+                "D2": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 23.29,
+                    "y": 47.3,
+                    "z": 4.07
+                },
+                "D3": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 32.29,
+                    "y": 47.3,
+                    "z": 4.07
+                },
+                "D4": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 41.29,
+                    "y": 47.3,
+                    "z": 4.07
+                },
+                "D5": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 50.29,
+                    "y": 47.3,
+                    "z": 4.07
+                },
+                "D6": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 59.29,
+                    "y": 47.3,
+                    "z": 4.07
+                },
+                "D7": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 68.29,
+                    "y": 47.3,
+                    "z": 4.07
+                },
+                "D8": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 77.29,
+                    "y": 47.3,
+                    "z": 4.07
+                },
+                "D9": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 86.29,
+                    "y": 47.3,
+                    "z": 4.07
+                },
+                "E1": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 14.29,
+                    "y": 38.3,
+                    "z": 4.07
+                },
+                "E10": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 95.29,
+                    "y": 38.3,
+                    "z": 4.07
+                },
+                "E11": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 104.29,
+                    "y": 38.3,
+                    "z": 4.07
+                },
+                "E12": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 113.29,
+                    "y": 38.3,
+                    "z": 4.07
+                },
+                "E2": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 23.29,
+                    "y": 38.3,
+                    "z": 4.07
+                },
+                "E3": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 32.29,
+                    "y": 38.3,
+                    "z": 4.07
+                },
+                "E4": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 41.29,
+                    "y": 38.3,
+                    "z": 4.07
+                },
+                "E5": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 50.29,
+                    "y": 38.3,
+                    "z": 4.07
+                },
+                "E6": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 59.29,
+                    "y": 38.3,
+                    "z": 4.07
+                },
+                "E7": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 68.29,
+                    "y": 38.3,
+                    "z": 4.07
+                },
+                "E8": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 77.29,
+                    "y": 38.3,
+                    "z": 4.07
+                },
+                "E9": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 86.29,
+                    "y": 38.3,
+                    "z": 4.07
+                },
+                "F1": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 14.29,
+                    "y": 29.3,
+                    "z": 4.07
+                },
+                "F10": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 95.29,
+                    "y": 29.3,
+                    "z": 4.07
+                },
+                "F11": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 104.29,
+                    "y": 29.3,
+                    "z": 4.07
+                },
+                "F12": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 113.29,
+                    "y": 29.3,
+                    "z": 4.07
+                },
+                "F2": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 23.29,
+                    "y": 29.3,
+                    "z": 4.07
+                },
+                "F3": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 32.29,
+                    "y": 29.3,
+                    "z": 4.07
+                },
+                "F4": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 41.29,
+                    "y": 29.3,
+                    "z": 4.07
+                },
+                "F5": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 50.29,
+                    "y": 29.3,
+                    "z": 4.07
+                },
+                "F6": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 59.29,
+                    "y": 29.3,
+                    "z": 4.07
+                },
+                "F7": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 68.29,
+                    "y": 29.3,
+                    "z": 4.07
+                },
+                "F8": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 77.29,
+                    "y": 29.3,
+                    "z": 4.07
+                },
+                "F9": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 86.29,
+                    "y": 29.3,
+                    "z": 4.07
+                },
+                "G1": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 14.29,
+                    "y": 20.3,
+                    "z": 4.07
+                },
+                "G10": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 95.29,
+                    "y": 20.3,
+                    "z": 4.07
+                },
+                "G11": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 104.29,
+                    "y": 20.3,
+                    "z": 4.07
+                },
+                "G12": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 113.29,
+                    "y": 20.3,
+                    "z": 4.07
+                },
+                "G2": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 23.29,
+                    "y": 20.3,
+                    "z": 4.07
+                },
+                "G3": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 32.29,
+                    "y": 20.3,
+                    "z": 4.07
+                },
+                "G4": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 41.29,
+                    "y": 20.3,
+                    "z": 4.07
+                },
+                "G5": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 50.29,
+                    "y": 20.3,
+                    "z": 4.07
+                },
+                "G6": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 59.29,
+                    "y": 20.3,
+                    "z": 4.07
+                },
+                "G7": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 68.29,
+                    "y": 20.3,
+                    "z": 4.07
+                },
+                "G8": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 77.29,
+                    "y": 20.3,
+                    "z": 4.07
+                },
+                "G9": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 86.29,
+                    "y": 20.3,
+                    "z": 4.07
+                },
+                "H1": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 14.29,
+                    "y": 11.3,
+                    "z": 4.07
+                },
+                "H10": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 95.29,
+                    "y": 11.3,
+                    "z": 4.07
+                },
+                "H11": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 104.29,
+                    "y": 11.3,
+                    "z": 4.07
+                },
+                "H12": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 113.29,
+                    "y": 11.3,
+                    "z": 4.07
+                },
+                "H2": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 23.29,
+                    "y": 11.3,
+                    "z": 4.07
+                },
+                "H3": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 32.29,
+                    "y": 11.3,
+                    "z": 4.07
+                },
+                "H4": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 41.29,
+                    "y": 11.3,
+                    "z": 4.07
+                },
+                "H5": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 50.29,
+                    "y": 11.3,
+                    "z": 4.07
+                },
+                "H6": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 59.29,
+                    "y": 11.3,
+                    "z": 4.07
+                },
+                "H7": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 68.29,
+                    "y": 11.3,
+                    "z": 4.07
+                },
+                "H8": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 77.29,
+                    "y": 11.3,
+                    "z": 4.07
+                },
+                "H9": {
+                    "depth": 10.03,
+                    "diameter": 6.18,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 86.29,
+                    "y": 11.3,
+                    "z": 4.07
+                }
+            }
+        },
+        {
+            "brand": {
+                "brand": "Agilent",
+                "brandId": [
+                    "204249-100"
+                ]
+            },
+            "cornerOffsetFromSlot": {
+                "x": 0,
+                "y": 0,
+                "z": 0
+            },
+            "dimensions": {
+                "xDimension": 127.76,
+                "yDimension": 85.47,
+                "zDimension": 44.04
+            },
+            "groups": [
+                {
+                    "brand": {
+                        "brand": "Agilent",
+                        "brandId": [
+                            "204249-100"
+                        ]
+                    },
+                    "metadata": {
+                        "displayCategory": "reservoir",
+                        "displayName": "Agilent 3-Channel Reservoir 95ml",
+                        "wellBottomShape": "v"
+                    },
+                    "wells": [
+                        "A1",
+                        "A2",
+                        "A3"
+                    ]
+                }
+            ],
+            "metadata": {
+                "displayCategory": "reservoir",
+                "displayName": "Agilent 3-Channel Reservoir 95ml",
+                "displayVolumeUnits": "\u00b5L",
+                "tags": []
+            },
+            "namespace": "custom_beta",
+            "ordering": [
+                [
+                    "A1"
+                ],
+                [
+                    "A2"
+                ],
+                [
+                    "A3"
+                ]
+            ],
+            "parameters": {
+                "format": "irregular",
+                "isMagneticModuleCompatible": false,
+                "isTiprack": false,
+                "loadName": "agilent_3_reservoir_95ml",
+                "quirks": [
+                    "centerMultichannelOnWells",
+                    "touchTipDisabled"
+                ]
+            },
+            "schemaVersion": 2,
+            "version": 1,
+            "wells": {
+                "A1": {
+                    "depth": 39.22,
+                    "shape": "rectangular",
+                    "totalLiquidVolume": 95000,
+                    "x": 27.88,
+                    "xDimension": 35.11,
+                    "y": 42.73,
+                    "yDimension": 75,
+                    "z": 4.82
+                },
+                "A2": {
+                    "depth": 39.22,
+                    "shape": "rectangular",
+                    "totalLiquidVolume": 95000,
+                    "x": 63.88,
+                    "xDimension": 35.11,
+                    "y": 42.73,
+                    "yDimension": 75,
+                    "z": 4.82
+                },
+                "A3": {
+                    "depth": 39.22,
+                    "shape": "rectangular",
+                    "totalLiquidVolume": 95000,
+                    "x": 99.88,
+                    "xDimension": 35.11,
+                    "y": 42.73,
+                    "yDimension": 75,
+                    "z": 4.82
+                }
+            }
+        },
+        {
+            "brand": {
                 "brand": "Agilent",
                 "brandId": [
                     "201256-100"
@@ -2593,106 +2693,6 @@
                     "z": 4.82
                 }
             }
-        },
-        {
-            "brand": {
-                "brand": "Agilent",
-                "brandId": [
-                    "204249-100"
-                ]
-            },
-            "cornerOffsetFromSlot": {
-                "x": 0,
-                "y": 0,
-                "z": 0
-            },
-            "dimensions": {
-                "xDimension": 127.76,
-                "yDimension": 85.47,
-                "zDimension": 44.04
-            },
-            "groups": [
-                {
-                    "brand": {
-                        "brand": "Agilent",
-                        "brandId": [
-                            "204249-100"
-                        ]
-                    },
-                    "metadata": {
-                        "displayCategory": "reservoir",
-                        "displayName": "Agilent 3-Channel Reservoir 95ml",
-                        "wellBottomShape": "v"
-                    },
-                    "wells": [
-                        "A1",
-                        "A2",
-                        "A3"
-                    ]
-                }
-            ],
-            "metadata": {
-                "displayCategory": "reservoir",
-                "displayName": "Agilent 3-Channel Reservoir 95ml",
-                "displayVolumeUnits": "\u00b5L",
-                "tags": []
-            },
-            "namespace": "custom_beta",
-            "ordering": [
-                [
-                    "A1"
-                ],
-                [
-                    "A2"
-                ],
-                [
-                    "A3"
-                ]
-            ],
-            "parameters": {
-                "format": "irregular",
-                "isMagneticModuleCompatible": false,
-                "isTiprack": false,
-                "loadName": "agilent_3_reservoir_95ml",
-                "quirks": [
-                    "centerMultichannelOnWells",
-                    "touchTipDisabled"
-                ]
-            },
-            "schemaVersion": 2,
-            "version": 1,
-            "wells": {
-                "A1": {
-                    "depth": 39.22,
-                    "shape": "rectangular",
-                    "totalLiquidVolume": 95000,
-                    "x": 27.88,
-                    "xDimension": 35.11,
-                    "y": 42.73,
-                    "yDimension": 75,
-                    "z": 4.82
-                },
-                "A2": {
-                    "depth": 39.22,
-                    "shape": "rectangular",
-                    "totalLiquidVolume": 95000,
-                    "x": 63.88,
-                    "xDimension": 35.11,
-                    "y": 42.73,
-                    "yDimension": 75,
-                    "z": 4.82
-                },
-                "A3": {
-                    "depth": 39.22,
-                    "shape": "rectangular",
-                    "totalLiquidVolume": 95000,
-                    "x": 99.88,
-                    "xDimension": 35.11,
-                    "y": 42.73,
-                    "yDimension": 75,
-                    "z": 4.82
-                }
-            }
         }
     ],
     "fields": [
@@ -2726,7 +2726,7 @@
     ],
     "labware": [
         {
-            "name": "Greiner Bio-One 96-Deepwell Plate 2ml on Magnetic Module on 1",
+            "name": "Greiner Bio-One 96-Deepwell Plate 2ml on Magnetic Module GEN1 on 1",
             "share": false,
             "slot": "1",
             "type": "greinerbioone_96_wellplate_2ml_deep"

--- a/protoBuilds/343001/343001.ot2.apiv2.py.json
+++ b/protoBuilds/343001/343001.ot2.apiv2.py.json
@@ -2345,7 +2345,7 @@
             "type": "opentrons_6_tuberack_falcon_50ml_conical"
         },
         {
-            "name": "Zymo 96-Well Block on Magnetic Module on 4",
+            "name": "Zymo 96-Well Block on Magnetic Module GEN1 on 4",
             "share": false,
             "slot": "4",
             "type": "zymo_96_wellblock"

--- a/protoBuilds/35b1a9/35b1a9.ot2.apiv2.py.json
+++ b/protoBuilds/35b1a9/35b1a9.ot2.apiv2.py.json
@@ -3,6 +3,1128 @@
     "custom_labware_defs": [
         {
             "brand": {
+                "brand": "generic"
+            },
+            "cornerOffsetFromSlot": {
+                "x": 0,
+                "y": 0,
+                "z": 0
+            },
+            "dimensions": {
+                "xDimension": 127.76,
+                "yDimension": 85.48,
+                "zDimension": 70
+            },
+            "groups": [
+                {
+                    "metadata": {},
+                    "wells": [
+                        "A1",
+                        "B1",
+                        "C1",
+                        "D1",
+                        "E1",
+                        "F1",
+                        "G1",
+                        "H1",
+                        "A2",
+                        "B2",
+                        "C2",
+                        "D2",
+                        "E2",
+                        "F2",
+                        "G2",
+                        "H2",
+                        "A3",
+                        "B3",
+                        "C3",
+                        "D3",
+                        "E3",
+                        "F3",
+                        "G3",
+                        "H3",
+                        "A4",
+                        "B4",
+                        "C4",
+                        "D4",
+                        "E4",
+                        "F4",
+                        "G4",
+                        "H4",
+                        "A5",
+                        "B5",
+                        "C5",
+                        "D5",
+                        "E5",
+                        "F5",
+                        "G5",
+                        "H5",
+                        "A6",
+                        "B6",
+                        "C6",
+                        "D6",
+                        "E6",
+                        "F6",
+                        "G6",
+                        "H6",
+                        "A7",
+                        "B7",
+                        "C7",
+                        "D7",
+                        "E7",
+                        "F7",
+                        "G7",
+                        "H7",
+                        "A8",
+                        "B8",
+                        "C8",
+                        "D8",
+                        "E8",
+                        "F8",
+                        "G8",
+                        "H8",
+                        "A9",
+                        "B9",
+                        "C9",
+                        "D9",
+                        "E9",
+                        "F9",
+                        "G9",
+                        "H9",
+                        "A10",
+                        "B10",
+                        "C10",
+                        "D10",
+                        "E10",
+                        "F10",
+                        "G10",
+                        "H10",
+                        "A11",
+                        "B11",
+                        "C11",
+                        "D11",
+                        "E11",
+                        "F11",
+                        "G11",
+                        "H11",
+                        "A12",
+                        "B12",
+                        "C12",
+                        "D12",
+                        "E12",
+                        "F12",
+                        "G12",
+                        "H12"
+                    ]
+                }
+            ],
+            "metadata": {
+                "displayCategory": "tipRack",
+                "displayName": "Custom 200\u00b5L Tiprack",
+                "displayVolumeUnits": "\u00b5L",
+                "tags": []
+            },
+            "namespace": "custom_beta",
+            "ordering": [
+                [
+                    "A1",
+                    "B1",
+                    "C1",
+                    "D1",
+                    "E1",
+                    "F1",
+                    "G1",
+                    "H1"
+                ],
+                [
+                    "A2",
+                    "B2",
+                    "C2",
+                    "D2",
+                    "E2",
+                    "F2",
+                    "G2",
+                    "H2"
+                ],
+                [
+                    "A3",
+                    "B3",
+                    "C3",
+                    "D3",
+                    "E3",
+                    "F3",
+                    "G3",
+                    "H3"
+                ],
+                [
+                    "A4",
+                    "B4",
+                    "C4",
+                    "D4",
+                    "E4",
+                    "F4",
+                    "G4",
+                    "H4"
+                ],
+                [
+                    "A5",
+                    "B5",
+                    "C5",
+                    "D5",
+                    "E5",
+                    "F5",
+                    "G5",
+                    "H5"
+                ],
+                [
+                    "A6",
+                    "B6",
+                    "C6",
+                    "D6",
+                    "E6",
+                    "F6",
+                    "G6",
+                    "H6"
+                ],
+                [
+                    "A7",
+                    "B7",
+                    "C7",
+                    "D7",
+                    "E7",
+                    "F7",
+                    "G7",
+                    "H7"
+                ],
+                [
+                    "A8",
+                    "B8",
+                    "C8",
+                    "D8",
+                    "E8",
+                    "F8",
+                    "G8",
+                    "H8"
+                ],
+                [
+                    "A9",
+                    "B9",
+                    "C9",
+                    "D9",
+                    "E9",
+                    "F9",
+                    "G9",
+                    "H9"
+                ],
+                [
+                    "A10",
+                    "B10",
+                    "C10",
+                    "D10",
+                    "E10",
+                    "F10",
+                    "G10",
+                    "H10"
+                ],
+                [
+                    "A11",
+                    "B11",
+                    "C11",
+                    "D11",
+                    "E11",
+                    "F11",
+                    "G11",
+                    "H11"
+                ],
+                [
+                    "A12",
+                    "B12",
+                    "C12",
+                    "D12",
+                    "E12",
+                    "F12",
+                    "G12",
+                    "H12"
+                ]
+            ],
+            "parameters": {
+                "format": "96Standard",
+                "isMagneticModuleCompatible": false,
+                "isTiprack": true,
+                "loadName": "generic_96_tiprack_20ul",
+                "tipLength": 32
+            },
+            "schemaVersion": 2,
+            "version": 1,
+            "wells": {
+                "A1": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 14.38,
+                    "y": 74.24,
+                    "z": 38
+                },
+                "A10": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 95.38,
+                    "y": 74.24,
+                    "z": 38
+                },
+                "A11": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 104.38,
+                    "y": 74.24,
+                    "z": 38
+                },
+                "A12": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 113.38,
+                    "y": 74.24,
+                    "z": 38
+                },
+                "A2": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 23.38,
+                    "y": 74.24,
+                    "z": 38
+                },
+                "A3": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 32.38,
+                    "y": 74.24,
+                    "z": 38
+                },
+                "A4": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 41.38,
+                    "y": 74.24,
+                    "z": 38
+                },
+                "A5": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 50.38,
+                    "y": 74.24,
+                    "z": 38
+                },
+                "A6": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 59.38,
+                    "y": 74.24,
+                    "z": 38
+                },
+                "A7": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 68.38,
+                    "y": 74.24,
+                    "z": 38
+                },
+                "A8": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 77.38,
+                    "y": 74.24,
+                    "z": 38
+                },
+                "A9": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 86.38,
+                    "y": 74.24,
+                    "z": 38
+                },
+                "B1": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 14.38,
+                    "y": 65.24,
+                    "z": 38
+                },
+                "B10": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 95.38,
+                    "y": 65.24,
+                    "z": 38
+                },
+                "B11": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 104.38,
+                    "y": 65.24,
+                    "z": 38
+                },
+                "B12": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 113.38,
+                    "y": 65.24,
+                    "z": 38
+                },
+                "B2": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 23.38,
+                    "y": 65.24,
+                    "z": 38
+                },
+                "B3": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 32.38,
+                    "y": 65.24,
+                    "z": 38
+                },
+                "B4": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 41.38,
+                    "y": 65.24,
+                    "z": 38
+                },
+                "B5": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 50.38,
+                    "y": 65.24,
+                    "z": 38
+                },
+                "B6": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 59.38,
+                    "y": 65.24,
+                    "z": 38
+                },
+                "B7": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 68.38,
+                    "y": 65.24,
+                    "z": 38
+                },
+                "B8": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 77.38,
+                    "y": 65.24,
+                    "z": 38
+                },
+                "B9": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 86.38,
+                    "y": 65.24,
+                    "z": 38
+                },
+                "C1": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 14.38,
+                    "y": 56.24,
+                    "z": 38
+                },
+                "C10": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 95.38,
+                    "y": 56.24,
+                    "z": 38
+                },
+                "C11": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 104.38,
+                    "y": 56.24,
+                    "z": 38
+                },
+                "C12": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 113.38,
+                    "y": 56.24,
+                    "z": 38
+                },
+                "C2": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 23.38,
+                    "y": 56.24,
+                    "z": 38
+                },
+                "C3": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 32.38,
+                    "y": 56.24,
+                    "z": 38
+                },
+                "C4": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 41.38,
+                    "y": 56.24,
+                    "z": 38
+                },
+                "C5": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 50.38,
+                    "y": 56.24,
+                    "z": 38
+                },
+                "C6": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 59.38,
+                    "y": 56.24,
+                    "z": 38
+                },
+                "C7": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 68.38,
+                    "y": 56.24,
+                    "z": 38
+                },
+                "C8": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 77.38,
+                    "y": 56.24,
+                    "z": 38
+                },
+                "C9": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 86.38,
+                    "y": 56.24,
+                    "z": 38
+                },
+                "D1": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 14.38,
+                    "y": 47.24,
+                    "z": 38
+                },
+                "D10": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 95.38,
+                    "y": 47.24,
+                    "z": 38
+                },
+                "D11": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 104.38,
+                    "y": 47.24,
+                    "z": 38
+                },
+                "D12": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 113.38,
+                    "y": 47.24,
+                    "z": 38
+                },
+                "D2": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 23.38,
+                    "y": 47.24,
+                    "z": 38
+                },
+                "D3": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 32.38,
+                    "y": 47.24,
+                    "z": 38
+                },
+                "D4": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 41.38,
+                    "y": 47.24,
+                    "z": 38
+                },
+                "D5": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 50.38,
+                    "y": 47.24,
+                    "z": 38
+                },
+                "D6": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 59.38,
+                    "y": 47.24,
+                    "z": 38
+                },
+                "D7": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 68.38,
+                    "y": 47.24,
+                    "z": 38
+                },
+                "D8": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 77.38,
+                    "y": 47.24,
+                    "z": 38
+                },
+                "D9": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 86.38,
+                    "y": 47.24,
+                    "z": 38
+                },
+                "E1": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 14.38,
+                    "y": 38.24,
+                    "z": 38
+                },
+                "E10": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 95.38,
+                    "y": 38.24,
+                    "z": 38
+                },
+                "E11": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 104.38,
+                    "y": 38.24,
+                    "z": 38
+                },
+                "E12": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 113.38,
+                    "y": 38.24,
+                    "z": 38
+                },
+                "E2": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 23.38,
+                    "y": 38.24,
+                    "z": 38
+                },
+                "E3": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 32.38,
+                    "y": 38.24,
+                    "z": 38
+                },
+                "E4": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 41.38,
+                    "y": 38.24,
+                    "z": 38
+                },
+                "E5": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 50.38,
+                    "y": 38.24,
+                    "z": 38
+                },
+                "E6": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 59.38,
+                    "y": 38.24,
+                    "z": 38
+                },
+                "E7": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 68.38,
+                    "y": 38.24,
+                    "z": 38
+                },
+                "E8": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 77.38,
+                    "y": 38.24,
+                    "z": 38
+                },
+                "E9": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 86.38,
+                    "y": 38.24,
+                    "z": 38
+                },
+                "F1": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 14.38,
+                    "y": 29.24,
+                    "z": 38
+                },
+                "F10": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 95.38,
+                    "y": 29.24,
+                    "z": 38
+                },
+                "F11": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 104.38,
+                    "y": 29.24,
+                    "z": 38
+                },
+                "F12": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 113.38,
+                    "y": 29.24,
+                    "z": 38
+                },
+                "F2": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 23.38,
+                    "y": 29.24,
+                    "z": 38
+                },
+                "F3": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 32.38,
+                    "y": 29.24,
+                    "z": 38
+                },
+                "F4": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 41.38,
+                    "y": 29.24,
+                    "z": 38
+                },
+                "F5": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 50.38,
+                    "y": 29.24,
+                    "z": 38
+                },
+                "F6": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 59.38,
+                    "y": 29.24,
+                    "z": 38
+                },
+                "F7": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 68.38,
+                    "y": 29.24,
+                    "z": 38
+                },
+                "F8": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 77.38,
+                    "y": 29.24,
+                    "z": 38
+                },
+                "F9": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 86.38,
+                    "y": 29.24,
+                    "z": 38
+                },
+                "G1": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 14.38,
+                    "y": 20.24,
+                    "z": 38
+                },
+                "G10": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 95.38,
+                    "y": 20.24,
+                    "z": 38
+                },
+                "G11": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 104.38,
+                    "y": 20.24,
+                    "z": 38
+                },
+                "G12": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 113.38,
+                    "y": 20.24,
+                    "z": 38
+                },
+                "G2": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 23.38,
+                    "y": 20.24,
+                    "z": 38
+                },
+                "G3": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 32.38,
+                    "y": 20.24,
+                    "z": 38
+                },
+                "G4": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 41.38,
+                    "y": 20.24,
+                    "z": 38
+                },
+                "G5": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 50.38,
+                    "y": 20.24,
+                    "z": 38
+                },
+                "G6": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 59.38,
+                    "y": 20.24,
+                    "z": 38
+                },
+                "G7": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 68.38,
+                    "y": 20.24,
+                    "z": 38
+                },
+                "G8": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 77.38,
+                    "y": 20.24,
+                    "z": 38
+                },
+                "G9": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 86.38,
+                    "y": 20.24,
+                    "z": 38
+                },
+                "H1": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 14.38,
+                    "y": 11.24,
+                    "z": 38
+                },
+                "H10": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 95.38,
+                    "y": 11.24,
+                    "z": 38
+                },
+                "H11": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 104.38,
+                    "y": 11.24,
+                    "z": 38
+                },
+                "H12": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 113.38,
+                    "y": 11.24,
+                    "z": 38
+                },
+                "H2": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 23.38,
+                    "y": 11.24,
+                    "z": 38
+                },
+                "H3": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 32.38,
+                    "y": 11.24,
+                    "z": 38
+                },
+                "H4": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 41.38,
+                    "y": 11.24,
+                    "z": 38
+                },
+                "H5": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 50.38,
+                    "y": 11.24,
+                    "z": 38
+                },
+                "H6": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 59.38,
+                    "y": 11.24,
+                    "z": 38
+                },
+                "H7": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 68.38,
+                    "y": 11.24,
+                    "z": 38
+                },
+                "H8": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 77.38,
+                    "y": 11.24,
+                    "z": 38
+                },
+                "H9": {
+                    "depth": 32,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 20,
+                    "x": 86.38,
+                    "y": 11.24,
+                    "z": 38
+                }
+            }
+        },
+        {
+            "brand": {
                 "brand": "custom",
                 "brandId": []
             },
@@ -1129,1128 +2251,6 @@
                     "x": 86.38,
                     "y": 11.24,
                     "z": 16
-                }
-            }
-        },
-        {
-            "brand": {
-                "brand": "generic"
-            },
-            "cornerOffsetFromSlot": {
-                "x": 0,
-                "y": 0,
-                "z": 0
-            },
-            "dimensions": {
-                "xDimension": 127.76,
-                "yDimension": 85.48,
-                "zDimension": 70
-            },
-            "groups": [
-                {
-                    "metadata": {},
-                    "wells": [
-                        "A1",
-                        "B1",
-                        "C1",
-                        "D1",
-                        "E1",
-                        "F1",
-                        "G1",
-                        "H1",
-                        "A2",
-                        "B2",
-                        "C2",
-                        "D2",
-                        "E2",
-                        "F2",
-                        "G2",
-                        "H2",
-                        "A3",
-                        "B3",
-                        "C3",
-                        "D3",
-                        "E3",
-                        "F3",
-                        "G3",
-                        "H3",
-                        "A4",
-                        "B4",
-                        "C4",
-                        "D4",
-                        "E4",
-                        "F4",
-                        "G4",
-                        "H4",
-                        "A5",
-                        "B5",
-                        "C5",
-                        "D5",
-                        "E5",
-                        "F5",
-                        "G5",
-                        "H5",
-                        "A6",
-                        "B6",
-                        "C6",
-                        "D6",
-                        "E6",
-                        "F6",
-                        "G6",
-                        "H6",
-                        "A7",
-                        "B7",
-                        "C7",
-                        "D7",
-                        "E7",
-                        "F7",
-                        "G7",
-                        "H7",
-                        "A8",
-                        "B8",
-                        "C8",
-                        "D8",
-                        "E8",
-                        "F8",
-                        "G8",
-                        "H8",
-                        "A9",
-                        "B9",
-                        "C9",
-                        "D9",
-                        "E9",
-                        "F9",
-                        "G9",
-                        "H9",
-                        "A10",
-                        "B10",
-                        "C10",
-                        "D10",
-                        "E10",
-                        "F10",
-                        "G10",
-                        "H10",
-                        "A11",
-                        "B11",
-                        "C11",
-                        "D11",
-                        "E11",
-                        "F11",
-                        "G11",
-                        "H11",
-                        "A12",
-                        "B12",
-                        "C12",
-                        "D12",
-                        "E12",
-                        "F12",
-                        "G12",
-                        "H12"
-                    ]
-                }
-            ],
-            "metadata": {
-                "displayCategory": "tipRack",
-                "displayName": "Custom 200\u00b5L Tiprack",
-                "displayVolumeUnits": "\u00b5L",
-                "tags": []
-            },
-            "namespace": "custom_beta",
-            "ordering": [
-                [
-                    "A1",
-                    "B1",
-                    "C1",
-                    "D1",
-                    "E1",
-                    "F1",
-                    "G1",
-                    "H1"
-                ],
-                [
-                    "A2",
-                    "B2",
-                    "C2",
-                    "D2",
-                    "E2",
-                    "F2",
-                    "G2",
-                    "H2"
-                ],
-                [
-                    "A3",
-                    "B3",
-                    "C3",
-                    "D3",
-                    "E3",
-                    "F3",
-                    "G3",
-                    "H3"
-                ],
-                [
-                    "A4",
-                    "B4",
-                    "C4",
-                    "D4",
-                    "E4",
-                    "F4",
-                    "G4",
-                    "H4"
-                ],
-                [
-                    "A5",
-                    "B5",
-                    "C5",
-                    "D5",
-                    "E5",
-                    "F5",
-                    "G5",
-                    "H5"
-                ],
-                [
-                    "A6",
-                    "B6",
-                    "C6",
-                    "D6",
-                    "E6",
-                    "F6",
-                    "G6",
-                    "H6"
-                ],
-                [
-                    "A7",
-                    "B7",
-                    "C7",
-                    "D7",
-                    "E7",
-                    "F7",
-                    "G7",
-                    "H7"
-                ],
-                [
-                    "A8",
-                    "B8",
-                    "C8",
-                    "D8",
-                    "E8",
-                    "F8",
-                    "G8",
-                    "H8"
-                ],
-                [
-                    "A9",
-                    "B9",
-                    "C9",
-                    "D9",
-                    "E9",
-                    "F9",
-                    "G9",
-                    "H9"
-                ],
-                [
-                    "A10",
-                    "B10",
-                    "C10",
-                    "D10",
-                    "E10",
-                    "F10",
-                    "G10",
-                    "H10"
-                ],
-                [
-                    "A11",
-                    "B11",
-                    "C11",
-                    "D11",
-                    "E11",
-                    "F11",
-                    "G11",
-                    "H11"
-                ],
-                [
-                    "A12",
-                    "B12",
-                    "C12",
-                    "D12",
-                    "E12",
-                    "F12",
-                    "G12",
-                    "H12"
-                ]
-            ],
-            "parameters": {
-                "format": "96Standard",
-                "isMagneticModuleCompatible": false,
-                "isTiprack": true,
-                "loadName": "generic_96_tiprack_20ul",
-                "tipLength": 32
-            },
-            "schemaVersion": 2,
-            "version": 1,
-            "wells": {
-                "A1": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 14.38,
-                    "y": 74.24,
-                    "z": 38
-                },
-                "A10": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 95.38,
-                    "y": 74.24,
-                    "z": 38
-                },
-                "A11": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 104.38,
-                    "y": 74.24,
-                    "z": 38
-                },
-                "A12": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 113.38,
-                    "y": 74.24,
-                    "z": 38
-                },
-                "A2": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 23.38,
-                    "y": 74.24,
-                    "z": 38
-                },
-                "A3": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 32.38,
-                    "y": 74.24,
-                    "z": 38
-                },
-                "A4": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 41.38,
-                    "y": 74.24,
-                    "z": 38
-                },
-                "A5": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 50.38,
-                    "y": 74.24,
-                    "z": 38
-                },
-                "A6": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 59.38,
-                    "y": 74.24,
-                    "z": 38
-                },
-                "A7": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 68.38,
-                    "y": 74.24,
-                    "z": 38
-                },
-                "A8": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 77.38,
-                    "y": 74.24,
-                    "z": 38
-                },
-                "A9": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 86.38,
-                    "y": 74.24,
-                    "z": 38
-                },
-                "B1": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 14.38,
-                    "y": 65.24,
-                    "z": 38
-                },
-                "B10": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 95.38,
-                    "y": 65.24,
-                    "z": 38
-                },
-                "B11": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 104.38,
-                    "y": 65.24,
-                    "z": 38
-                },
-                "B12": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 113.38,
-                    "y": 65.24,
-                    "z": 38
-                },
-                "B2": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 23.38,
-                    "y": 65.24,
-                    "z": 38
-                },
-                "B3": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 32.38,
-                    "y": 65.24,
-                    "z": 38
-                },
-                "B4": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 41.38,
-                    "y": 65.24,
-                    "z": 38
-                },
-                "B5": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 50.38,
-                    "y": 65.24,
-                    "z": 38
-                },
-                "B6": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 59.38,
-                    "y": 65.24,
-                    "z": 38
-                },
-                "B7": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 68.38,
-                    "y": 65.24,
-                    "z": 38
-                },
-                "B8": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 77.38,
-                    "y": 65.24,
-                    "z": 38
-                },
-                "B9": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 86.38,
-                    "y": 65.24,
-                    "z": 38
-                },
-                "C1": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 14.38,
-                    "y": 56.24,
-                    "z": 38
-                },
-                "C10": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 95.38,
-                    "y": 56.24,
-                    "z": 38
-                },
-                "C11": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 104.38,
-                    "y": 56.24,
-                    "z": 38
-                },
-                "C12": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 113.38,
-                    "y": 56.24,
-                    "z": 38
-                },
-                "C2": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 23.38,
-                    "y": 56.24,
-                    "z": 38
-                },
-                "C3": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 32.38,
-                    "y": 56.24,
-                    "z": 38
-                },
-                "C4": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 41.38,
-                    "y": 56.24,
-                    "z": 38
-                },
-                "C5": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 50.38,
-                    "y": 56.24,
-                    "z": 38
-                },
-                "C6": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 59.38,
-                    "y": 56.24,
-                    "z": 38
-                },
-                "C7": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 68.38,
-                    "y": 56.24,
-                    "z": 38
-                },
-                "C8": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 77.38,
-                    "y": 56.24,
-                    "z": 38
-                },
-                "C9": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 86.38,
-                    "y": 56.24,
-                    "z": 38
-                },
-                "D1": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 14.38,
-                    "y": 47.24,
-                    "z": 38
-                },
-                "D10": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 95.38,
-                    "y": 47.24,
-                    "z": 38
-                },
-                "D11": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 104.38,
-                    "y": 47.24,
-                    "z": 38
-                },
-                "D12": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 113.38,
-                    "y": 47.24,
-                    "z": 38
-                },
-                "D2": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 23.38,
-                    "y": 47.24,
-                    "z": 38
-                },
-                "D3": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 32.38,
-                    "y": 47.24,
-                    "z": 38
-                },
-                "D4": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 41.38,
-                    "y": 47.24,
-                    "z": 38
-                },
-                "D5": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 50.38,
-                    "y": 47.24,
-                    "z": 38
-                },
-                "D6": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 59.38,
-                    "y": 47.24,
-                    "z": 38
-                },
-                "D7": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 68.38,
-                    "y": 47.24,
-                    "z": 38
-                },
-                "D8": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 77.38,
-                    "y": 47.24,
-                    "z": 38
-                },
-                "D9": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 86.38,
-                    "y": 47.24,
-                    "z": 38
-                },
-                "E1": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 14.38,
-                    "y": 38.24,
-                    "z": 38
-                },
-                "E10": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 95.38,
-                    "y": 38.24,
-                    "z": 38
-                },
-                "E11": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 104.38,
-                    "y": 38.24,
-                    "z": 38
-                },
-                "E12": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 113.38,
-                    "y": 38.24,
-                    "z": 38
-                },
-                "E2": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 23.38,
-                    "y": 38.24,
-                    "z": 38
-                },
-                "E3": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 32.38,
-                    "y": 38.24,
-                    "z": 38
-                },
-                "E4": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 41.38,
-                    "y": 38.24,
-                    "z": 38
-                },
-                "E5": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 50.38,
-                    "y": 38.24,
-                    "z": 38
-                },
-                "E6": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 59.38,
-                    "y": 38.24,
-                    "z": 38
-                },
-                "E7": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 68.38,
-                    "y": 38.24,
-                    "z": 38
-                },
-                "E8": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 77.38,
-                    "y": 38.24,
-                    "z": 38
-                },
-                "E9": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 86.38,
-                    "y": 38.24,
-                    "z": 38
-                },
-                "F1": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 14.38,
-                    "y": 29.24,
-                    "z": 38
-                },
-                "F10": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 95.38,
-                    "y": 29.24,
-                    "z": 38
-                },
-                "F11": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 104.38,
-                    "y": 29.24,
-                    "z": 38
-                },
-                "F12": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 113.38,
-                    "y": 29.24,
-                    "z": 38
-                },
-                "F2": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 23.38,
-                    "y": 29.24,
-                    "z": 38
-                },
-                "F3": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 32.38,
-                    "y": 29.24,
-                    "z": 38
-                },
-                "F4": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 41.38,
-                    "y": 29.24,
-                    "z": 38
-                },
-                "F5": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 50.38,
-                    "y": 29.24,
-                    "z": 38
-                },
-                "F6": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 59.38,
-                    "y": 29.24,
-                    "z": 38
-                },
-                "F7": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 68.38,
-                    "y": 29.24,
-                    "z": 38
-                },
-                "F8": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 77.38,
-                    "y": 29.24,
-                    "z": 38
-                },
-                "F9": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 86.38,
-                    "y": 29.24,
-                    "z": 38
-                },
-                "G1": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 14.38,
-                    "y": 20.24,
-                    "z": 38
-                },
-                "G10": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 95.38,
-                    "y": 20.24,
-                    "z": 38
-                },
-                "G11": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 104.38,
-                    "y": 20.24,
-                    "z": 38
-                },
-                "G12": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 113.38,
-                    "y": 20.24,
-                    "z": 38
-                },
-                "G2": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 23.38,
-                    "y": 20.24,
-                    "z": 38
-                },
-                "G3": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 32.38,
-                    "y": 20.24,
-                    "z": 38
-                },
-                "G4": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 41.38,
-                    "y": 20.24,
-                    "z": 38
-                },
-                "G5": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 50.38,
-                    "y": 20.24,
-                    "z": 38
-                },
-                "G6": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 59.38,
-                    "y": 20.24,
-                    "z": 38
-                },
-                "G7": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 68.38,
-                    "y": 20.24,
-                    "z": 38
-                },
-                "G8": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 77.38,
-                    "y": 20.24,
-                    "z": 38
-                },
-                "G9": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 86.38,
-                    "y": 20.24,
-                    "z": 38
-                },
-                "H1": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 14.38,
-                    "y": 11.24,
-                    "z": 38
-                },
-                "H10": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 95.38,
-                    "y": 11.24,
-                    "z": 38
-                },
-                "H11": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 104.38,
-                    "y": 11.24,
-                    "z": 38
-                },
-                "H12": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 113.38,
-                    "y": 11.24,
-                    "z": 38
-                },
-                "H2": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 23.38,
-                    "y": 11.24,
-                    "z": 38
-                },
-                "H3": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 32.38,
-                    "y": 11.24,
-                    "z": 38
-                },
-                "H4": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 41.38,
-                    "y": 11.24,
-                    "z": 38
-                },
-                "H5": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 50.38,
-                    "y": 11.24,
-                    "z": 38
-                },
-                "H6": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 59.38,
-                    "y": 11.24,
-                    "z": 38
-                },
-                "H7": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 68.38,
-                    "y": 11.24,
-                    "z": 38
-                },
-                "H8": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 77.38,
-                    "y": 11.24,
-                    "z": 38
-                },
-                "H9": {
-                    "depth": 32,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 20,
-                    "x": 86.38,
-                    "y": 11.24,
-                    "z": 38
                 }
             }
         }

--- a/protoBuilds/42d27b/42d27b.ot2.apiv2.py.json
+++ b/protoBuilds/42d27b/42d27b.ot2.apiv2.py.json
@@ -3,1137 +3,6 @@
     "custom_labware_defs": [
         {
             "brand": {
-                "brand": "Axygen",
-                "brandId": []
-            },
-            "cornerOffsetFromSlot": {
-                "x": 0,
-                "y": 0,
-                "z": 0
-            },
-            "dimensions": {
-                "xDimension": 127.8,
-                "yDimension": 85.4,
-                "zDimension": 15.75
-            },
-            "groups": [
-                {
-                    "brand": {
-                        "brand": "Axygen",
-                        "brandId": []
-                    },
-                    "metadata": {
-                        "displayCategory": "wellPlate",
-                        "displayName": "Axygen 96 Well Plate",
-                        "wellBottomShape": "u"
-                    },
-                    "wells": [
-                        "A1",
-                        "B1",
-                        "C1",
-                        "D1",
-                        "E1",
-                        "F1",
-                        "G1",
-                        "H1",
-                        "A2",
-                        "B2",
-                        "C2",
-                        "D2",
-                        "E2",
-                        "F2",
-                        "G2",
-                        "H2",
-                        "A3",
-                        "B3",
-                        "C3",
-                        "D3",
-                        "E3",
-                        "F3",
-                        "G3",
-                        "H3",
-                        "A4",
-                        "B4",
-                        "C4",
-                        "D4",
-                        "E4",
-                        "F4",
-                        "G4",
-                        "H4",
-                        "A5",
-                        "B5",
-                        "C5",
-                        "D5",
-                        "E5",
-                        "F5",
-                        "G5",
-                        "H5",
-                        "A6",
-                        "B6",
-                        "C6",
-                        "D6",
-                        "E6",
-                        "F6",
-                        "G6",
-                        "H6",
-                        "A7",
-                        "B7",
-                        "C7",
-                        "D7",
-                        "E7",
-                        "F7",
-                        "G7",
-                        "H7",
-                        "A8",
-                        "B8",
-                        "C8",
-                        "D8",
-                        "E8",
-                        "F8",
-                        "G8",
-                        "H8",
-                        "A9",
-                        "B9",
-                        "C9",
-                        "D9",
-                        "E9",
-                        "F9",
-                        "G9",
-                        "H9",
-                        "A10",
-                        "B10",
-                        "C10",
-                        "D10",
-                        "E10",
-                        "F10",
-                        "G10",
-                        "H10",
-                        "A11",
-                        "B11",
-                        "C11",
-                        "D11",
-                        "E11",
-                        "F11",
-                        "G11",
-                        "H11",
-                        "A12",
-                        "B12",
-                        "C12",
-                        "D12",
-                        "E12",
-                        "F12",
-                        "G12",
-                        "H12"
-                    ]
-                }
-            ],
-            "metadata": {
-                "displayCategory": "wellPlate",
-                "displayName": "Axygen 96 Well Plate",
-                "displayVolumeUnits": "\u00b5L",
-                "tags": []
-            },
-            "namespace": "custom_beta",
-            "ordering": [
-                [
-                    "A1",
-                    "B1",
-                    "C1",
-                    "D1",
-                    "E1",
-                    "F1",
-                    "G1",
-                    "H1"
-                ],
-                [
-                    "A2",
-                    "B2",
-                    "C2",
-                    "D2",
-                    "E2",
-                    "F2",
-                    "G2",
-                    "H2"
-                ],
-                [
-                    "A3",
-                    "B3",
-                    "C3",
-                    "D3",
-                    "E3",
-                    "F3",
-                    "G3",
-                    "H3"
-                ],
-                [
-                    "A4",
-                    "B4",
-                    "C4",
-                    "D4",
-                    "E4",
-                    "F4",
-                    "G4",
-                    "H4"
-                ],
-                [
-                    "A5",
-                    "B5",
-                    "C5",
-                    "D5",
-                    "E5",
-                    "F5",
-                    "G5",
-                    "H5"
-                ],
-                [
-                    "A6",
-                    "B6",
-                    "C6",
-                    "D6",
-                    "E6",
-                    "F6",
-                    "G6",
-                    "H6"
-                ],
-                [
-                    "A7",
-                    "B7",
-                    "C7",
-                    "D7",
-                    "E7",
-                    "F7",
-                    "G7",
-                    "H7"
-                ],
-                [
-                    "A8",
-                    "B8",
-                    "C8",
-                    "D8",
-                    "E8",
-                    "F8",
-                    "G8",
-                    "H8"
-                ],
-                [
-                    "A9",
-                    "B9",
-                    "C9",
-                    "D9",
-                    "E9",
-                    "F9",
-                    "G9",
-                    "H9"
-                ],
-                [
-                    "A10",
-                    "B10",
-                    "C10",
-                    "D10",
-                    "E10",
-                    "F10",
-                    "G10",
-                    "H10"
-                ],
-                [
-                    "A11",
-                    "B11",
-                    "C11",
-                    "D11",
-                    "E11",
-                    "F11",
-                    "G11",
-                    "H11"
-                ],
-                [
-                    "A12",
-                    "B12",
-                    "C12",
-                    "D12",
-                    "E12",
-                    "F12",
-                    "G12",
-                    "H12"
-                ]
-            ],
-            "parameters": {
-                "format": "irregular",
-                "isMagneticModuleCompatible": false,
-                "isTiprack": false,
-                "loadName": "axygen_96_wellplate",
-                "quirks": []
-            },
-            "schemaVersion": 2,
-            "version": 1,
-            "wells": {
-                "A1": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 14.38,
-                    "y": 74.22,
-                    "z": 1.75
-                },
-                "A10": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 95.38,
-                    "y": 74.22,
-                    "z": 1.75
-                },
-                "A11": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 104.38,
-                    "y": 74.22,
-                    "z": 1.75
-                },
-                "A12": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 113.38,
-                    "y": 74.22,
-                    "z": 1.75
-                },
-                "A2": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 23.38,
-                    "y": 74.22,
-                    "z": 1.75
-                },
-                "A3": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 32.38,
-                    "y": 74.22,
-                    "z": 1.75
-                },
-                "A4": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 41.38,
-                    "y": 74.22,
-                    "z": 1.75
-                },
-                "A5": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 50.38,
-                    "y": 74.22,
-                    "z": 1.75
-                },
-                "A6": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 59.38,
-                    "y": 74.22,
-                    "z": 1.75
-                },
-                "A7": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 68.38,
-                    "y": 74.22,
-                    "z": 1.75
-                },
-                "A8": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 77.38,
-                    "y": 74.22,
-                    "z": 1.75
-                },
-                "A9": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 86.38,
-                    "y": 74.22,
-                    "z": 1.75
-                },
-                "B1": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 14.38,
-                    "y": 65.22,
-                    "z": 1.75
-                },
-                "B10": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 95.38,
-                    "y": 65.22,
-                    "z": 1.75
-                },
-                "B11": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 104.38,
-                    "y": 65.22,
-                    "z": 1.75
-                },
-                "B12": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 113.38,
-                    "y": 65.22,
-                    "z": 1.75
-                },
-                "B2": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 23.38,
-                    "y": 65.22,
-                    "z": 1.75
-                },
-                "B3": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 32.38,
-                    "y": 65.22,
-                    "z": 1.75
-                },
-                "B4": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 41.38,
-                    "y": 65.22,
-                    "z": 1.75
-                },
-                "B5": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 50.38,
-                    "y": 65.22,
-                    "z": 1.75
-                },
-                "B6": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 59.38,
-                    "y": 65.22,
-                    "z": 1.75
-                },
-                "B7": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 68.38,
-                    "y": 65.22,
-                    "z": 1.75
-                },
-                "B8": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 77.38,
-                    "y": 65.22,
-                    "z": 1.75
-                },
-                "B9": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 86.38,
-                    "y": 65.22,
-                    "z": 1.75
-                },
-                "C1": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 14.38,
-                    "y": 56.22,
-                    "z": 1.75
-                },
-                "C10": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 95.38,
-                    "y": 56.22,
-                    "z": 1.75
-                },
-                "C11": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 104.38,
-                    "y": 56.22,
-                    "z": 1.75
-                },
-                "C12": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 113.38,
-                    "y": 56.22,
-                    "z": 1.75
-                },
-                "C2": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 23.38,
-                    "y": 56.22,
-                    "z": 1.75
-                },
-                "C3": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 32.38,
-                    "y": 56.22,
-                    "z": 1.75
-                },
-                "C4": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 41.38,
-                    "y": 56.22,
-                    "z": 1.75
-                },
-                "C5": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 50.38,
-                    "y": 56.22,
-                    "z": 1.75
-                },
-                "C6": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 59.38,
-                    "y": 56.22,
-                    "z": 1.75
-                },
-                "C7": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 68.38,
-                    "y": 56.22,
-                    "z": 1.75
-                },
-                "C8": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 77.38,
-                    "y": 56.22,
-                    "z": 1.75
-                },
-                "C9": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 86.38,
-                    "y": 56.22,
-                    "z": 1.75
-                },
-                "D1": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 14.38,
-                    "y": 47.22,
-                    "z": 1.75
-                },
-                "D10": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 95.38,
-                    "y": 47.22,
-                    "z": 1.75
-                },
-                "D11": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 104.38,
-                    "y": 47.22,
-                    "z": 1.75
-                },
-                "D12": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 113.38,
-                    "y": 47.22,
-                    "z": 1.75
-                },
-                "D2": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 23.38,
-                    "y": 47.22,
-                    "z": 1.75
-                },
-                "D3": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 32.38,
-                    "y": 47.22,
-                    "z": 1.75
-                },
-                "D4": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 41.38,
-                    "y": 47.22,
-                    "z": 1.75
-                },
-                "D5": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 50.38,
-                    "y": 47.22,
-                    "z": 1.75
-                },
-                "D6": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 59.38,
-                    "y": 47.22,
-                    "z": 1.75
-                },
-                "D7": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 68.38,
-                    "y": 47.22,
-                    "z": 1.75
-                },
-                "D8": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 77.38,
-                    "y": 47.22,
-                    "z": 1.75
-                },
-                "D9": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 86.38,
-                    "y": 47.22,
-                    "z": 1.75
-                },
-                "E1": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 14.38,
-                    "y": 38.22,
-                    "z": 1.75
-                },
-                "E10": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 95.38,
-                    "y": 38.22,
-                    "z": 1.75
-                },
-                "E11": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 104.38,
-                    "y": 38.22,
-                    "z": 1.75
-                },
-                "E12": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 113.38,
-                    "y": 38.22,
-                    "z": 1.75
-                },
-                "E2": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 23.38,
-                    "y": 38.22,
-                    "z": 1.75
-                },
-                "E3": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 32.38,
-                    "y": 38.22,
-                    "z": 1.75
-                },
-                "E4": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 41.38,
-                    "y": 38.22,
-                    "z": 1.75
-                },
-                "E5": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 50.38,
-                    "y": 38.22,
-                    "z": 1.75
-                },
-                "E6": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 59.38,
-                    "y": 38.22,
-                    "z": 1.75
-                },
-                "E7": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 68.38,
-                    "y": 38.22,
-                    "z": 1.75
-                },
-                "E8": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 77.38,
-                    "y": 38.22,
-                    "z": 1.75
-                },
-                "E9": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 86.38,
-                    "y": 38.22,
-                    "z": 1.75
-                },
-                "F1": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 14.38,
-                    "y": 29.22,
-                    "z": 1.75
-                },
-                "F10": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 95.38,
-                    "y": 29.22,
-                    "z": 1.75
-                },
-                "F11": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 104.38,
-                    "y": 29.22,
-                    "z": 1.75
-                },
-                "F12": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 113.38,
-                    "y": 29.22,
-                    "z": 1.75
-                },
-                "F2": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 23.38,
-                    "y": 29.22,
-                    "z": 1.75
-                },
-                "F3": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 32.38,
-                    "y": 29.22,
-                    "z": 1.75
-                },
-                "F4": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 41.38,
-                    "y": 29.22,
-                    "z": 1.75
-                },
-                "F5": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 50.38,
-                    "y": 29.22,
-                    "z": 1.75
-                },
-                "F6": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 59.38,
-                    "y": 29.22,
-                    "z": 1.75
-                },
-                "F7": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 68.38,
-                    "y": 29.22,
-                    "z": 1.75
-                },
-                "F8": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 77.38,
-                    "y": 29.22,
-                    "z": 1.75
-                },
-                "F9": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 86.38,
-                    "y": 29.22,
-                    "z": 1.75
-                },
-                "G1": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 14.38,
-                    "y": 20.22,
-                    "z": 1.75
-                },
-                "G10": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 95.38,
-                    "y": 20.22,
-                    "z": 1.75
-                },
-                "G11": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 104.38,
-                    "y": 20.22,
-                    "z": 1.75
-                },
-                "G12": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 113.38,
-                    "y": 20.22,
-                    "z": 1.75
-                },
-                "G2": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 23.38,
-                    "y": 20.22,
-                    "z": 1.75
-                },
-                "G3": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 32.38,
-                    "y": 20.22,
-                    "z": 1.75
-                },
-                "G4": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 41.38,
-                    "y": 20.22,
-                    "z": 1.75
-                },
-                "G5": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 50.38,
-                    "y": 20.22,
-                    "z": 1.75
-                },
-                "G6": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 59.38,
-                    "y": 20.22,
-                    "z": 1.75
-                },
-                "G7": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 68.38,
-                    "y": 20.22,
-                    "z": 1.75
-                },
-                "G8": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 77.38,
-                    "y": 20.22,
-                    "z": 1.75
-                },
-                "G9": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 86.38,
-                    "y": 20.22,
-                    "z": 1.75
-                },
-                "H1": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 14.38,
-                    "y": 11.22,
-                    "z": 1.75
-                },
-                "H10": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 95.38,
-                    "y": 11.22,
-                    "z": 1.75
-                },
-                "H11": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 104.38,
-                    "y": 11.22,
-                    "z": 1.75
-                },
-                "H12": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 113.38,
-                    "y": 11.22,
-                    "z": 1.75
-                },
-                "H2": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 23.38,
-                    "y": 11.22,
-                    "z": 1.75
-                },
-                "H3": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 32.38,
-                    "y": 11.22,
-                    "z": 1.75
-                },
-                "H4": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 41.38,
-                    "y": 11.22,
-                    "z": 1.75
-                },
-                "H5": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 50.38,
-                    "y": 11.22,
-                    "z": 1.75
-                },
-                "H6": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 59.38,
-                    "y": 11.22,
-                    "z": 1.75
-                },
-                "H7": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 68.38,
-                    "y": 11.22,
-                    "z": 1.75
-                },
-                "H8": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 77.38,
-                    "y": 11.22,
-                    "z": 1.75
-                },
-                "H9": {
-                    "depth": 14,
-                    "diameter": 5.36,
-                    "shape": "circular",
-                    "totalLiquidVolume": 360,
-                    "x": 86.38,
-                    "y": 11.22,
-                    "z": 1.75
-                }
-            }
-        },
-        {
-            "brand": {
                 "brand": "Micronics",
                 "brandId": []
             },
@@ -2260,6 +1129,1137 @@
                     "x": 86.38,
                     "y": 11.26,
                     "z": 7.5
+                }
+            }
+        },
+        {
+            "brand": {
+                "brand": "Axygen",
+                "brandId": []
+            },
+            "cornerOffsetFromSlot": {
+                "x": 0,
+                "y": 0,
+                "z": 0
+            },
+            "dimensions": {
+                "xDimension": 127.8,
+                "yDimension": 85.4,
+                "zDimension": 15.75
+            },
+            "groups": [
+                {
+                    "brand": {
+                        "brand": "Axygen",
+                        "brandId": []
+                    },
+                    "metadata": {
+                        "displayCategory": "wellPlate",
+                        "displayName": "Axygen 96 Well Plate",
+                        "wellBottomShape": "u"
+                    },
+                    "wells": [
+                        "A1",
+                        "B1",
+                        "C1",
+                        "D1",
+                        "E1",
+                        "F1",
+                        "G1",
+                        "H1",
+                        "A2",
+                        "B2",
+                        "C2",
+                        "D2",
+                        "E2",
+                        "F2",
+                        "G2",
+                        "H2",
+                        "A3",
+                        "B3",
+                        "C3",
+                        "D3",
+                        "E3",
+                        "F3",
+                        "G3",
+                        "H3",
+                        "A4",
+                        "B4",
+                        "C4",
+                        "D4",
+                        "E4",
+                        "F4",
+                        "G4",
+                        "H4",
+                        "A5",
+                        "B5",
+                        "C5",
+                        "D5",
+                        "E5",
+                        "F5",
+                        "G5",
+                        "H5",
+                        "A6",
+                        "B6",
+                        "C6",
+                        "D6",
+                        "E6",
+                        "F6",
+                        "G6",
+                        "H6",
+                        "A7",
+                        "B7",
+                        "C7",
+                        "D7",
+                        "E7",
+                        "F7",
+                        "G7",
+                        "H7",
+                        "A8",
+                        "B8",
+                        "C8",
+                        "D8",
+                        "E8",
+                        "F8",
+                        "G8",
+                        "H8",
+                        "A9",
+                        "B9",
+                        "C9",
+                        "D9",
+                        "E9",
+                        "F9",
+                        "G9",
+                        "H9",
+                        "A10",
+                        "B10",
+                        "C10",
+                        "D10",
+                        "E10",
+                        "F10",
+                        "G10",
+                        "H10",
+                        "A11",
+                        "B11",
+                        "C11",
+                        "D11",
+                        "E11",
+                        "F11",
+                        "G11",
+                        "H11",
+                        "A12",
+                        "B12",
+                        "C12",
+                        "D12",
+                        "E12",
+                        "F12",
+                        "G12",
+                        "H12"
+                    ]
+                }
+            ],
+            "metadata": {
+                "displayCategory": "wellPlate",
+                "displayName": "Axygen 96 Well Plate",
+                "displayVolumeUnits": "\u00b5L",
+                "tags": []
+            },
+            "namespace": "custom_beta",
+            "ordering": [
+                [
+                    "A1",
+                    "B1",
+                    "C1",
+                    "D1",
+                    "E1",
+                    "F1",
+                    "G1",
+                    "H1"
+                ],
+                [
+                    "A2",
+                    "B2",
+                    "C2",
+                    "D2",
+                    "E2",
+                    "F2",
+                    "G2",
+                    "H2"
+                ],
+                [
+                    "A3",
+                    "B3",
+                    "C3",
+                    "D3",
+                    "E3",
+                    "F3",
+                    "G3",
+                    "H3"
+                ],
+                [
+                    "A4",
+                    "B4",
+                    "C4",
+                    "D4",
+                    "E4",
+                    "F4",
+                    "G4",
+                    "H4"
+                ],
+                [
+                    "A5",
+                    "B5",
+                    "C5",
+                    "D5",
+                    "E5",
+                    "F5",
+                    "G5",
+                    "H5"
+                ],
+                [
+                    "A6",
+                    "B6",
+                    "C6",
+                    "D6",
+                    "E6",
+                    "F6",
+                    "G6",
+                    "H6"
+                ],
+                [
+                    "A7",
+                    "B7",
+                    "C7",
+                    "D7",
+                    "E7",
+                    "F7",
+                    "G7",
+                    "H7"
+                ],
+                [
+                    "A8",
+                    "B8",
+                    "C8",
+                    "D8",
+                    "E8",
+                    "F8",
+                    "G8",
+                    "H8"
+                ],
+                [
+                    "A9",
+                    "B9",
+                    "C9",
+                    "D9",
+                    "E9",
+                    "F9",
+                    "G9",
+                    "H9"
+                ],
+                [
+                    "A10",
+                    "B10",
+                    "C10",
+                    "D10",
+                    "E10",
+                    "F10",
+                    "G10",
+                    "H10"
+                ],
+                [
+                    "A11",
+                    "B11",
+                    "C11",
+                    "D11",
+                    "E11",
+                    "F11",
+                    "G11",
+                    "H11"
+                ],
+                [
+                    "A12",
+                    "B12",
+                    "C12",
+                    "D12",
+                    "E12",
+                    "F12",
+                    "G12",
+                    "H12"
+                ]
+            ],
+            "parameters": {
+                "format": "irregular",
+                "isMagneticModuleCompatible": false,
+                "isTiprack": false,
+                "loadName": "axygen_96_wellplate",
+                "quirks": []
+            },
+            "schemaVersion": 2,
+            "version": 1,
+            "wells": {
+                "A1": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 14.38,
+                    "y": 74.22,
+                    "z": 1.75
+                },
+                "A10": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 95.38,
+                    "y": 74.22,
+                    "z": 1.75
+                },
+                "A11": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 104.38,
+                    "y": 74.22,
+                    "z": 1.75
+                },
+                "A12": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 113.38,
+                    "y": 74.22,
+                    "z": 1.75
+                },
+                "A2": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 23.38,
+                    "y": 74.22,
+                    "z": 1.75
+                },
+                "A3": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 32.38,
+                    "y": 74.22,
+                    "z": 1.75
+                },
+                "A4": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 41.38,
+                    "y": 74.22,
+                    "z": 1.75
+                },
+                "A5": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 50.38,
+                    "y": 74.22,
+                    "z": 1.75
+                },
+                "A6": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 59.38,
+                    "y": 74.22,
+                    "z": 1.75
+                },
+                "A7": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 68.38,
+                    "y": 74.22,
+                    "z": 1.75
+                },
+                "A8": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 77.38,
+                    "y": 74.22,
+                    "z": 1.75
+                },
+                "A9": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 86.38,
+                    "y": 74.22,
+                    "z": 1.75
+                },
+                "B1": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 14.38,
+                    "y": 65.22,
+                    "z": 1.75
+                },
+                "B10": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 95.38,
+                    "y": 65.22,
+                    "z": 1.75
+                },
+                "B11": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 104.38,
+                    "y": 65.22,
+                    "z": 1.75
+                },
+                "B12": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 113.38,
+                    "y": 65.22,
+                    "z": 1.75
+                },
+                "B2": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 23.38,
+                    "y": 65.22,
+                    "z": 1.75
+                },
+                "B3": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 32.38,
+                    "y": 65.22,
+                    "z": 1.75
+                },
+                "B4": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 41.38,
+                    "y": 65.22,
+                    "z": 1.75
+                },
+                "B5": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 50.38,
+                    "y": 65.22,
+                    "z": 1.75
+                },
+                "B6": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 59.38,
+                    "y": 65.22,
+                    "z": 1.75
+                },
+                "B7": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 68.38,
+                    "y": 65.22,
+                    "z": 1.75
+                },
+                "B8": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 77.38,
+                    "y": 65.22,
+                    "z": 1.75
+                },
+                "B9": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 86.38,
+                    "y": 65.22,
+                    "z": 1.75
+                },
+                "C1": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 14.38,
+                    "y": 56.22,
+                    "z": 1.75
+                },
+                "C10": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 95.38,
+                    "y": 56.22,
+                    "z": 1.75
+                },
+                "C11": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 104.38,
+                    "y": 56.22,
+                    "z": 1.75
+                },
+                "C12": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 113.38,
+                    "y": 56.22,
+                    "z": 1.75
+                },
+                "C2": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 23.38,
+                    "y": 56.22,
+                    "z": 1.75
+                },
+                "C3": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 32.38,
+                    "y": 56.22,
+                    "z": 1.75
+                },
+                "C4": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 41.38,
+                    "y": 56.22,
+                    "z": 1.75
+                },
+                "C5": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 50.38,
+                    "y": 56.22,
+                    "z": 1.75
+                },
+                "C6": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 59.38,
+                    "y": 56.22,
+                    "z": 1.75
+                },
+                "C7": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 68.38,
+                    "y": 56.22,
+                    "z": 1.75
+                },
+                "C8": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 77.38,
+                    "y": 56.22,
+                    "z": 1.75
+                },
+                "C9": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 86.38,
+                    "y": 56.22,
+                    "z": 1.75
+                },
+                "D1": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 14.38,
+                    "y": 47.22,
+                    "z": 1.75
+                },
+                "D10": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 95.38,
+                    "y": 47.22,
+                    "z": 1.75
+                },
+                "D11": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 104.38,
+                    "y": 47.22,
+                    "z": 1.75
+                },
+                "D12": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 113.38,
+                    "y": 47.22,
+                    "z": 1.75
+                },
+                "D2": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 23.38,
+                    "y": 47.22,
+                    "z": 1.75
+                },
+                "D3": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 32.38,
+                    "y": 47.22,
+                    "z": 1.75
+                },
+                "D4": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 41.38,
+                    "y": 47.22,
+                    "z": 1.75
+                },
+                "D5": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 50.38,
+                    "y": 47.22,
+                    "z": 1.75
+                },
+                "D6": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 59.38,
+                    "y": 47.22,
+                    "z": 1.75
+                },
+                "D7": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 68.38,
+                    "y": 47.22,
+                    "z": 1.75
+                },
+                "D8": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 77.38,
+                    "y": 47.22,
+                    "z": 1.75
+                },
+                "D9": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 86.38,
+                    "y": 47.22,
+                    "z": 1.75
+                },
+                "E1": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 14.38,
+                    "y": 38.22,
+                    "z": 1.75
+                },
+                "E10": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 95.38,
+                    "y": 38.22,
+                    "z": 1.75
+                },
+                "E11": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 104.38,
+                    "y": 38.22,
+                    "z": 1.75
+                },
+                "E12": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 113.38,
+                    "y": 38.22,
+                    "z": 1.75
+                },
+                "E2": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 23.38,
+                    "y": 38.22,
+                    "z": 1.75
+                },
+                "E3": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 32.38,
+                    "y": 38.22,
+                    "z": 1.75
+                },
+                "E4": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 41.38,
+                    "y": 38.22,
+                    "z": 1.75
+                },
+                "E5": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 50.38,
+                    "y": 38.22,
+                    "z": 1.75
+                },
+                "E6": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 59.38,
+                    "y": 38.22,
+                    "z": 1.75
+                },
+                "E7": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 68.38,
+                    "y": 38.22,
+                    "z": 1.75
+                },
+                "E8": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 77.38,
+                    "y": 38.22,
+                    "z": 1.75
+                },
+                "E9": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 86.38,
+                    "y": 38.22,
+                    "z": 1.75
+                },
+                "F1": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 14.38,
+                    "y": 29.22,
+                    "z": 1.75
+                },
+                "F10": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 95.38,
+                    "y": 29.22,
+                    "z": 1.75
+                },
+                "F11": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 104.38,
+                    "y": 29.22,
+                    "z": 1.75
+                },
+                "F12": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 113.38,
+                    "y": 29.22,
+                    "z": 1.75
+                },
+                "F2": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 23.38,
+                    "y": 29.22,
+                    "z": 1.75
+                },
+                "F3": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 32.38,
+                    "y": 29.22,
+                    "z": 1.75
+                },
+                "F4": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 41.38,
+                    "y": 29.22,
+                    "z": 1.75
+                },
+                "F5": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 50.38,
+                    "y": 29.22,
+                    "z": 1.75
+                },
+                "F6": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 59.38,
+                    "y": 29.22,
+                    "z": 1.75
+                },
+                "F7": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 68.38,
+                    "y": 29.22,
+                    "z": 1.75
+                },
+                "F8": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 77.38,
+                    "y": 29.22,
+                    "z": 1.75
+                },
+                "F9": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 86.38,
+                    "y": 29.22,
+                    "z": 1.75
+                },
+                "G1": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 14.38,
+                    "y": 20.22,
+                    "z": 1.75
+                },
+                "G10": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 95.38,
+                    "y": 20.22,
+                    "z": 1.75
+                },
+                "G11": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 104.38,
+                    "y": 20.22,
+                    "z": 1.75
+                },
+                "G12": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 113.38,
+                    "y": 20.22,
+                    "z": 1.75
+                },
+                "G2": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 23.38,
+                    "y": 20.22,
+                    "z": 1.75
+                },
+                "G3": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 32.38,
+                    "y": 20.22,
+                    "z": 1.75
+                },
+                "G4": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 41.38,
+                    "y": 20.22,
+                    "z": 1.75
+                },
+                "G5": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 50.38,
+                    "y": 20.22,
+                    "z": 1.75
+                },
+                "G6": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 59.38,
+                    "y": 20.22,
+                    "z": 1.75
+                },
+                "G7": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 68.38,
+                    "y": 20.22,
+                    "z": 1.75
+                },
+                "G8": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 77.38,
+                    "y": 20.22,
+                    "z": 1.75
+                },
+                "G9": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 86.38,
+                    "y": 20.22,
+                    "z": 1.75
+                },
+                "H1": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 14.38,
+                    "y": 11.22,
+                    "z": 1.75
+                },
+                "H10": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 95.38,
+                    "y": 11.22,
+                    "z": 1.75
+                },
+                "H11": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 104.38,
+                    "y": 11.22,
+                    "z": 1.75
+                },
+                "H12": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 113.38,
+                    "y": 11.22,
+                    "z": 1.75
+                },
+                "H2": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 23.38,
+                    "y": 11.22,
+                    "z": 1.75
+                },
+                "H3": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 32.38,
+                    "y": 11.22,
+                    "z": 1.75
+                },
+                "H4": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 41.38,
+                    "y": 11.22,
+                    "z": 1.75
+                },
+                "H5": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 50.38,
+                    "y": 11.22,
+                    "z": 1.75
+                },
+                "H6": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 59.38,
+                    "y": 11.22,
+                    "z": 1.75
+                },
+                "H7": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 68.38,
+                    "y": 11.22,
+                    "z": 1.75
+                },
+                "H8": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 77.38,
+                    "y": 11.22,
+                    "z": 1.75
+                },
+                "H9": {
+                    "depth": 14,
+                    "diameter": 5.36,
+                    "shape": "circular",
+                    "totalLiquidVolume": 360,
+                    "x": 86.38,
+                    "y": 11.22,
+                    "z": 1.75
                 }
             }
         }

--- a/protoBuilds/44b43c/covid_pcr_test.ot2.apiv2.py.json
+++ b/protoBuilds/44b43c/covid_pcr_test.ot2.apiv2.py.json
@@ -3,6 +3,1141 @@
     "custom_labware_defs": [
         {
             "brand": {
+                "brand": "ThermoFisher MicroAmp Fast 96-well 0.1",
+                "brandId": [
+                    "4346907"
+                ]
+            },
+            "cornerOffsetFromSlot": {
+                "x": 0,
+                "y": 0,
+                "z": 0
+            },
+            "dimensions": {
+                "xDimension": 127.76,
+                "yDimension": 85.48,
+                "zDimension": 17.88
+            },
+            "groups": [
+                {
+                    "brand": {
+                        "brand": "ThermoFisher MicroAmp Fast 96-well 0.1",
+                        "brandId": [
+                            "4346907"
+                        ]
+                    },
+                    "metadata": {
+                        "displayCategory": "wellPlate",
+                        "displayName": "ThermoFisher MicroAmp Fast 96-well 0.1 96 Well Plate 100 \u00b5L",
+                        "wellBottomShape": "v"
+                    },
+                    "wells": [
+                        "A1",
+                        "B1",
+                        "C1",
+                        "D1",
+                        "E1",
+                        "F1",
+                        "G1",
+                        "H1",
+                        "A2",
+                        "B2",
+                        "C2",
+                        "D2",
+                        "E2",
+                        "F2",
+                        "G2",
+                        "H2",
+                        "A3",
+                        "B3",
+                        "C3",
+                        "D3",
+                        "E3",
+                        "F3",
+                        "G3",
+                        "H3",
+                        "A4",
+                        "B4",
+                        "C4",
+                        "D4",
+                        "E4",
+                        "F4",
+                        "G4",
+                        "H4",
+                        "A5",
+                        "B5",
+                        "C5",
+                        "D5",
+                        "E5",
+                        "F5",
+                        "G5",
+                        "H5",
+                        "A6",
+                        "B6",
+                        "C6",
+                        "D6",
+                        "E6",
+                        "F6",
+                        "G6",
+                        "H6",
+                        "A7",
+                        "B7",
+                        "C7",
+                        "D7",
+                        "E7",
+                        "F7",
+                        "G7",
+                        "H7",
+                        "A8",
+                        "B8",
+                        "C8",
+                        "D8",
+                        "E8",
+                        "F8",
+                        "G8",
+                        "H8",
+                        "A9",
+                        "B9",
+                        "C9",
+                        "D9",
+                        "E9",
+                        "F9",
+                        "G9",
+                        "H9",
+                        "A10",
+                        "B10",
+                        "C10",
+                        "D10",
+                        "E10",
+                        "F10",
+                        "G10",
+                        "H10",
+                        "A11",
+                        "B11",
+                        "C11",
+                        "D11",
+                        "E11",
+                        "F11",
+                        "G11",
+                        "H11",
+                        "A12",
+                        "B12",
+                        "C12",
+                        "D12",
+                        "E12",
+                        "F12",
+                        "G12",
+                        "H12"
+                    ]
+                }
+            ],
+            "metadata": {
+                "displayCategory": "wellPlate",
+                "displayName": "ThermoFisher MicroAmp Fast 96-well 0.1 96 Well Plate 100 \u00b5L",
+                "displayVolumeUnits": "\u00b5L",
+                "tags": []
+            },
+            "namespace": "custom_beta",
+            "ordering": [
+                [
+                    "A1",
+                    "B1",
+                    "C1",
+                    "D1",
+                    "E1",
+                    "F1",
+                    "G1",
+                    "H1"
+                ],
+                [
+                    "A2",
+                    "B2",
+                    "C2",
+                    "D2",
+                    "E2",
+                    "F2",
+                    "G2",
+                    "H2"
+                ],
+                [
+                    "A3",
+                    "B3",
+                    "C3",
+                    "D3",
+                    "E3",
+                    "F3",
+                    "G3",
+                    "H3"
+                ],
+                [
+                    "A4",
+                    "B4",
+                    "C4",
+                    "D4",
+                    "E4",
+                    "F4",
+                    "G4",
+                    "H4"
+                ],
+                [
+                    "A5",
+                    "B5",
+                    "C5",
+                    "D5",
+                    "E5",
+                    "F5",
+                    "G5",
+                    "H5"
+                ],
+                [
+                    "A6",
+                    "B6",
+                    "C6",
+                    "D6",
+                    "E6",
+                    "F6",
+                    "G6",
+                    "H6"
+                ],
+                [
+                    "A7",
+                    "B7",
+                    "C7",
+                    "D7",
+                    "E7",
+                    "F7",
+                    "G7",
+                    "H7"
+                ],
+                [
+                    "A8",
+                    "B8",
+                    "C8",
+                    "D8",
+                    "E8",
+                    "F8",
+                    "G8",
+                    "H8"
+                ],
+                [
+                    "A9",
+                    "B9",
+                    "C9",
+                    "D9",
+                    "E9",
+                    "F9",
+                    "G9",
+                    "H9"
+                ],
+                [
+                    "A10",
+                    "B10",
+                    "C10",
+                    "D10",
+                    "E10",
+                    "F10",
+                    "G10",
+                    "H10"
+                ],
+                [
+                    "A11",
+                    "B11",
+                    "C11",
+                    "D11",
+                    "E11",
+                    "F11",
+                    "G11",
+                    "H11"
+                ],
+                [
+                    "A12",
+                    "B12",
+                    "C12",
+                    "D12",
+                    "E12",
+                    "F12",
+                    "G12",
+                    "H12"
+                ]
+            ],
+            "parameters": {
+                "format": "irregular",
+                "isMagneticModuleCompatible": false,
+                "isTiprack": false,
+                "loadName": "thermofishermicroampfast96well0.1_96_wellplate_100ul",
+                "quirks": []
+            },
+            "schemaVersion": 2,
+            "version": 1,
+            "wells": {
+                "A1": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 14.38,
+                    "y": 74.24,
+                    "z": 0.74
+                },
+                "A10": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 95.38,
+                    "y": 74.24,
+                    "z": 0.74
+                },
+                "A11": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 104.38,
+                    "y": 74.24,
+                    "z": 0.74
+                },
+                "A12": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 113.38,
+                    "y": 74.24,
+                    "z": 0.74
+                },
+                "A2": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 23.38,
+                    "y": 74.24,
+                    "z": 0.74
+                },
+                "A3": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 32.38,
+                    "y": 74.24,
+                    "z": 0.74
+                },
+                "A4": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 41.38,
+                    "y": 74.24,
+                    "z": 0.74
+                },
+                "A5": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 50.38,
+                    "y": 74.24,
+                    "z": 0.74
+                },
+                "A6": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 59.38,
+                    "y": 74.24,
+                    "z": 0.74
+                },
+                "A7": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 68.38,
+                    "y": 74.24,
+                    "z": 0.74
+                },
+                "A8": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 77.38,
+                    "y": 74.24,
+                    "z": 0.74
+                },
+                "A9": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 86.38,
+                    "y": 74.24,
+                    "z": 0.74
+                },
+                "B1": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 14.38,
+                    "y": 65.24,
+                    "z": 0.74
+                },
+                "B10": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 95.38,
+                    "y": 65.24,
+                    "z": 0.74
+                },
+                "B11": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 104.38,
+                    "y": 65.24,
+                    "z": 0.74
+                },
+                "B12": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 113.38,
+                    "y": 65.24,
+                    "z": 0.74
+                },
+                "B2": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 23.38,
+                    "y": 65.24,
+                    "z": 0.74
+                },
+                "B3": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 32.38,
+                    "y": 65.24,
+                    "z": 0.74
+                },
+                "B4": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 41.38,
+                    "y": 65.24,
+                    "z": 0.74
+                },
+                "B5": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 50.38,
+                    "y": 65.24,
+                    "z": 0.74
+                },
+                "B6": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 59.38,
+                    "y": 65.24,
+                    "z": 0.74
+                },
+                "B7": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 68.38,
+                    "y": 65.24,
+                    "z": 0.74
+                },
+                "B8": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 77.38,
+                    "y": 65.24,
+                    "z": 0.74
+                },
+                "B9": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 86.38,
+                    "y": 65.24,
+                    "z": 0.74
+                },
+                "C1": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 14.38,
+                    "y": 56.24,
+                    "z": 0.74
+                },
+                "C10": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 95.38,
+                    "y": 56.24,
+                    "z": 0.74
+                },
+                "C11": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 104.38,
+                    "y": 56.24,
+                    "z": 0.74
+                },
+                "C12": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 113.38,
+                    "y": 56.24,
+                    "z": 0.74
+                },
+                "C2": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 23.38,
+                    "y": 56.24,
+                    "z": 0.74
+                },
+                "C3": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 32.38,
+                    "y": 56.24,
+                    "z": 0.74
+                },
+                "C4": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 41.38,
+                    "y": 56.24,
+                    "z": 0.74
+                },
+                "C5": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 50.38,
+                    "y": 56.24,
+                    "z": 0.74
+                },
+                "C6": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 59.38,
+                    "y": 56.24,
+                    "z": 0.74
+                },
+                "C7": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 68.38,
+                    "y": 56.24,
+                    "z": 0.74
+                },
+                "C8": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 77.38,
+                    "y": 56.24,
+                    "z": 0.74
+                },
+                "C9": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 86.38,
+                    "y": 56.24,
+                    "z": 0.74
+                },
+                "D1": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 14.38,
+                    "y": 47.24,
+                    "z": 0.74
+                },
+                "D10": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 95.38,
+                    "y": 47.24,
+                    "z": 0.74
+                },
+                "D11": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 104.38,
+                    "y": 47.24,
+                    "z": 0.74
+                },
+                "D12": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 113.38,
+                    "y": 47.24,
+                    "z": 0.74
+                },
+                "D2": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 23.38,
+                    "y": 47.24,
+                    "z": 0.74
+                },
+                "D3": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 32.38,
+                    "y": 47.24,
+                    "z": 0.74
+                },
+                "D4": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 41.38,
+                    "y": 47.24,
+                    "z": 0.74
+                },
+                "D5": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 50.38,
+                    "y": 47.24,
+                    "z": 0.74
+                },
+                "D6": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 59.38,
+                    "y": 47.24,
+                    "z": 0.74
+                },
+                "D7": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 68.38,
+                    "y": 47.24,
+                    "z": 0.74
+                },
+                "D8": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 77.38,
+                    "y": 47.24,
+                    "z": 0.74
+                },
+                "D9": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 86.38,
+                    "y": 47.24,
+                    "z": 0.74
+                },
+                "E1": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 14.38,
+                    "y": 38.24,
+                    "z": 0.74
+                },
+                "E10": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 95.38,
+                    "y": 38.24,
+                    "z": 0.74
+                },
+                "E11": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 104.38,
+                    "y": 38.24,
+                    "z": 0.74
+                },
+                "E12": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 113.38,
+                    "y": 38.24,
+                    "z": 0.74
+                },
+                "E2": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 23.38,
+                    "y": 38.24,
+                    "z": 0.74
+                },
+                "E3": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 32.38,
+                    "y": 38.24,
+                    "z": 0.74
+                },
+                "E4": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 41.38,
+                    "y": 38.24,
+                    "z": 0.74
+                },
+                "E5": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 50.38,
+                    "y": 38.24,
+                    "z": 0.74
+                },
+                "E6": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 59.38,
+                    "y": 38.24,
+                    "z": 0.74
+                },
+                "E7": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 68.38,
+                    "y": 38.24,
+                    "z": 0.74
+                },
+                "E8": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 77.38,
+                    "y": 38.24,
+                    "z": 0.74
+                },
+                "E9": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 86.38,
+                    "y": 38.24,
+                    "z": 0.74
+                },
+                "F1": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 14.38,
+                    "y": 29.24,
+                    "z": 0.74
+                },
+                "F10": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 95.38,
+                    "y": 29.24,
+                    "z": 0.74
+                },
+                "F11": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 104.38,
+                    "y": 29.24,
+                    "z": 0.74
+                },
+                "F12": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 113.38,
+                    "y": 29.24,
+                    "z": 0.74
+                },
+                "F2": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 23.38,
+                    "y": 29.24,
+                    "z": 0.74
+                },
+                "F3": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 32.38,
+                    "y": 29.24,
+                    "z": 0.74
+                },
+                "F4": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 41.38,
+                    "y": 29.24,
+                    "z": 0.74
+                },
+                "F5": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 50.38,
+                    "y": 29.24,
+                    "z": 0.74
+                },
+                "F6": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 59.38,
+                    "y": 29.24,
+                    "z": 0.74
+                },
+                "F7": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 68.38,
+                    "y": 29.24,
+                    "z": 0.74
+                },
+                "F8": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 77.38,
+                    "y": 29.24,
+                    "z": 0.74
+                },
+                "F9": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 86.38,
+                    "y": 29.24,
+                    "z": 0.74
+                },
+                "G1": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 14.38,
+                    "y": 20.24,
+                    "z": 0.74
+                },
+                "G10": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 95.38,
+                    "y": 20.24,
+                    "z": 0.74
+                },
+                "G11": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 104.38,
+                    "y": 20.24,
+                    "z": 0.74
+                },
+                "G12": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 113.38,
+                    "y": 20.24,
+                    "z": 0.74
+                },
+                "G2": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 23.38,
+                    "y": 20.24,
+                    "z": 0.74
+                },
+                "G3": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 32.38,
+                    "y": 20.24,
+                    "z": 0.74
+                },
+                "G4": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 41.38,
+                    "y": 20.24,
+                    "z": 0.74
+                },
+                "G5": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 50.38,
+                    "y": 20.24,
+                    "z": 0.74
+                },
+                "G6": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 59.38,
+                    "y": 20.24,
+                    "z": 0.74
+                },
+                "G7": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 68.38,
+                    "y": 20.24,
+                    "z": 0.74
+                },
+                "G8": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 77.38,
+                    "y": 20.24,
+                    "z": 0.74
+                },
+                "G9": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 86.38,
+                    "y": 20.24,
+                    "z": 0.74
+                },
+                "H1": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 14.38,
+                    "y": 11.24,
+                    "z": 0.74
+                },
+                "H10": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 95.38,
+                    "y": 11.24,
+                    "z": 0.74
+                },
+                "H11": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 104.38,
+                    "y": 11.24,
+                    "z": 0.74
+                },
+                "H12": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 113.38,
+                    "y": 11.24,
+                    "z": 0.74
+                },
+                "H2": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 23.38,
+                    "y": 11.24,
+                    "z": 0.74
+                },
+                "H3": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 32.38,
+                    "y": 11.24,
+                    "z": 0.74
+                },
+                "H4": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 41.38,
+                    "y": 11.24,
+                    "z": 0.74
+                },
+                "H5": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 50.38,
+                    "y": 11.24,
+                    "z": 0.74
+                },
+                "H6": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 59.38,
+                    "y": 11.24,
+                    "z": 0.74
+                },
+                "H7": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 68.38,
+                    "y": 11.24,
+                    "z": 0.74
+                },
+                "H8": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 77.38,
+                    "y": 11.24,
+                    "z": 0.74
+                },
+                "H9": {
+                    "depth": 17.14,
+                    "diameter": 5.49,
+                    "shape": "circular",
+                    "totalLiquidVolume": 100,
+                    "x": 86.38,
+                    "y": 11.24,
+                    "z": 0.74
+                }
+            }
+        },
+        {
+            "brand": {
                 "brand": "ThermoFisher DW plate",
                 "brandId": [
                     "95040450"
@@ -1229,1141 +2364,6 @@
                     "y": 11.2,
                     "yDimension": 8.3,
                     "z": 1.7
-                }
-            }
-        },
-        {
-            "brand": {
-                "brand": "ThermoFisher MicroAmp Fast 96-well 0.1",
-                "brandId": [
-                    "4346907"
-                ]
-            },
-            "cornerOffsetFromSlot": {
-                "x": 0,
-                "y": 0,
-                "z": 0
-            },
-            "dimensions": {
-                "xDimension": 127.76,
-                "yDimension": 85.48,
-                "zDimension": 17.88
-            },
-            "groups": [
-                {
-                    "brand": {
-                        "brand": "ThermoFisher MicroAmp Fast 96-well 0.1",
-                        "brandId": [
-                            "4346907"
-                        ]
-                    },
-                    "metadata": {
-                        "displayCategory": "wellPlate",
-                        "displayName": "ThermoFisher MicroAmp Fast 96-well 0.1 96 Well Plate 100 \u00b5L",
-                        "wellBottomShape": "v"
-                    },
-                    "wells": [
-                        "A1",
-                        "B1",
-                        "C1",
-                        "D1",
-                        "E1",
-                        "F1",
-                        "G1",
-                        "H1",
-                        "A2",
-                        "B2",
-                        "C2",
-                        "D2",
-                        "E2",
-                        "F2",
-                        "G2",
-                        "H2",
-                        "A3",
-                        "B3",
-                        "C3",
-                        "D3",
-                        "E3",
-                        "F3",
-                        "G3",
-                        "H3",
-                        "A4",
-                        "B4",
-                        "C4",
-                        "D4",
-                        "E4",
-                        "F4",
-                        "G4",
-                        "H4",
-                        "A5",
-                        "B5",
-                        "C5",
-                        "D5",
-                        "E5",
-                        "F5",
-                        "G5",
-                        "H5",
-                        "A6",
-                        "B6",
-                        "C6",
-                        "D6",
-                        "E6",
-                        "F6",
-                        "G6",
-                        "H6",
-                        "A7",
-                        "B7",
-                        "C7",
-                        "D7",
-                        "E7",
-                        "F7",
-                        "G7",
-                        "H7",
-                        "A8",
-                        "B8",
-                        "C8",
-                        "D8",
-                        "E8",
-                        "F8",
-                        "G8",
-                        "H8",
-                        "A9",
-                        "B9",
-                        "C9",
-                        "D9",
-                        "E9",
-                        "F9",
-                        "G9",
-                        "H9",
-                        "A10",
-                        "B10",
-                        "C10",
-                        "D10",
-                        "E10",
-                        "F10",
-                        "G10",
-                        "H10",
-                        "A11",
-                        "B11",
-                        "C11",
-                        "D11",
-                        "E11",
-                        "F11",
-                        "G11",
-                        "H11",
-                        "A12",
-                        "B12",
-                        "C12",
-                        "D12",
-                        "E12",
-                        "F12",
-                        "G12",
-                        "H12"
-                    ]
-                }
-            ],
-            "metadata": {
-                "displayCategory": "wellPlate",
-                "displayName": "ThermoFisher MicroAmp Fast 96-well 0.1 96 Well Plate 100 \u00b5L",
-                "displayVolumeUnits": "\u00b5L",
-                "tags": []
-            },
-            "namespace": "custom_beta",
-            "ordering": [
-                [
-                    "A1",
-                    "B1",
-                    "C1",
-                    "D1",
-                    "E1",
-                    "F1",
-                    "G1",
-                    "H1"
-                ],
-                [
-                    "A2",
-                    "B2",
-                    "C2",
-                    "D2",
-                    "E2",
-                    "F2",
-                    "G2",
-                    "H2"
-                ],
-                [
-                    "A3",
-                    "B3",
-                    "C3",
-                    "D3",
-                    "E3",
-                    "F3",
-                    "G3",
-                    "H3"
-                ],
-                [
-                    "A4",
-                    "B4",
-                    "C4",
-                    "D4",
-                    "E4",
-                    "F4",
-                    "G4",
-                    "H4"
-                ],
-                [
-                    "A5",
-                    "B5",
-                    "C5",
-                    "D5",
-                    "E5",
-                    "F5",
-                    "G5",
-                    "H5"
-                ],
-                [
-                    "A6",
-                    "B6",
-                    "C6",
-                    "D6",
-                    "E6",
-                    "F6",
-                    "G6",
-                    "H6"
-                ],
-                [
-                    "A7",
-                    "B7",
-                    "C7",
-                    "D7",
-                    "E7",
-                    "F7",
-                    "G7",
-                    "H7"
-                ],
-                [
-                    "A8",
-                    "B8",
-                    "C8",
-                    "D8",
-                    "E8",
-                    "F8",
-                    "G8",
-                    "H8"
-                ],
-                [
-                    "A9",
-                    "B9",
-                    "C9",
-                    "D9",
-                    "E9",
-                    "F9",
-                    "G9",
-                    "H9"
-                ],
-                [
-                    "A10",
-                    "B10",
-                    "C10",
-                    "D10",
-                    "E10",
-                    "F10",
-                    "G10",
-                    "H10"
-                ],
-                [
-                    "A11",
-                    "B11",
-                    "C11",
-                    "D11",
-                    "E11",
-                    "F11",
-                    "G11",
-                    "H11"
-                ],
-                [
-                    "A12",
-                    "B12",
-                    "C12",
-                    "D12",
-                    "E12",
-                    "F12",
-                    "G12",
-                    "H12"
-                ]
-            ],
-            "parameters": {
-                "format": "irregular",
-                "isMagneticModuleCompatible": false,
-                "isTiprack": false,
-                "loadName": "thermofishermicroampfast96well0.1_96_wellplate_100ul",
-                "quirks": []
-            },
-            "schemaVersion": 2,
-            "version": 1,
-            "wells": {
-                "A1": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 14.38,
-                    "y": 74.24,
-                    "z": 0.74
-                },
-                "A10": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 95.38,
-                    "y": 74.24,
-                    "z": 0.74
-                },
-                "A11": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 104.38,
-                    "y": 74.24,
-                    "z": 0.74
-                },
-                "A12": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 113.38,
-                    "y": 74.24,
-                    "z": 0.74
-                },
-                "A2": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 23.38,
-                    "y": 74.24,
-                    "z": 0.74
-                },
-                "A3": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 32.38,
-                    "y": 74.24,
-                    "z": 0.74
-                },
-                "A4": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 41.38,
-                    "y": 74.24,
-                    "z": 0.74
-                },
-                "A5": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 50.38,
-                    "y": 74.24,
-                    "z": 0.74
-                },
-                "A6": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 59.38,
-                    "y": 74.24,
-                    "z": 0.74
-                },
-                "A7": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 68.38,
-                    "y": 74.24,
-                    "z": 0.74
-                },
-                "A8": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 77.38,
-                    "y": 74.24,
-                    "z": 0.74
-                },
-                "A9": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 86.38,
-                    "y": 74.24,
-                    "z": 0.74
-                },
-                "B1": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 14.38,
-                    "y": 65.24,
-                    "z": 0.74
-                },
-                "B10": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 95.38,
-                    "y": 65.24,
-                    "z": 0.74
-                },
-                "B11": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 104.38,
-                    "y": 65.24,
-                    "z": 0.74
-                },
-                "B12": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 113.38,
-                    "y": 65.24,
-                    "z": 0.74
-                },
-                "B2": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 23.38,
-                    "y": 65.24,
-                    "z": 0.74
-                },
-                "B3": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 32.38,
-                    "y": 65.24,
-                    "z": 0.74
-                },
-                "B4": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 41.38,
-                    "y": 65.24,
-                    "z": 0.74
-                },
-                "B5": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 50.38,
-                    "y": 65.24,
-                    "z": 0.74
-                },
-                "B6": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 59.38,
-                    "y": 65.24,
-                    "z": 0.74
-                },
-                "B7": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 68.38,
-                    "y": 65.24,
-                    "z": 0.74
-                },
-                "B8": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 77.38,
-                    "y": 65.24,
-                    "z": 0.74
-                },
-                "B9": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 86.38,
-                    "y": 65.24,
-                    "z": 0.74
-                },
-                "C1": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 14.38,
-                    "y": 56.24,
-                    "z": 0.74
-                },
-                "C10": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 95.38,
-                    "y": 56.24,
-                    "z": 0.74
-                },
-                "C11": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 104.38,
-                    "y": 56.24,
-                    "z": 0.74
-                },
-                "C12": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 113.38,
-                    "y": 56.24,
-                    "z": 0.74
-                },
-                "C2": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 23.38,
-                    "y": 56.24,
-                    "z": 0.74
-                },
-                "C3": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 32.38,
-                    "y": 56.24,
-                    "z": 0.74
-                },
-                "C4": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 41.38,
-                    "y": 56.24,
-                    "z": 0.74
-                },
-                "C5": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 50.38,
-                    "y": 56.24,
-                    "z": 0.74
-                },
-                "C6": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 59.38,
-                    "y": 56.24,
-                    "z": 0.74
-                },
-                "C7": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 68.38,
-                    "y": 56.24,
-                    "z": 0.74
-                },
-                "C8": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 77.38,
-                    "y": 56.24,
-                    "z": 0.74
-                },
-                "C9": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 86.38,
-                    "y": 56.24,
-                    "z": 0.74
-                },
-                "D1": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 14.38,
-                    "y": 47.24,
-                    "z": 0.74
-                },
-                "D10": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 95.38,
-                    "y": 47.24,
-                    "z": 0.74
-                },
-                "D11": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 104.38,
-                    "y": 47.24,
-                    "z": 0.74
-                },
-                "D12": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 113.38,
-                    "y": 47.24,
-                    "z": 0.74
-                },
-                "D2": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 23.38,
-                    "y": 47.24,
-                    "z": 0.74
-                },
-                "D3": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 32.38,
-                    "y": 47.24,
-                    "z": 0.74
-                },
-                "D4": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 41.38,
-                    "y": 47.24,
-                    "z": 0.74
-                },
-                "D5": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 50.38,
-                    "y": 47.24,
-                    "z": 0.74
-                },
-                "D6": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 59.38,
-                    "y": 47.24,
-                    "z": 0.74
-                },
-                "D7": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 68.38,
-                    "y": 47.24,
-                    "z": 0.74
-                },
-                "D8": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 77.38,
-                    "y": 47.24,
-                    "z": 0.74
-                },
-                "D9": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 86.38,
-                    "y": 47.24,
-                    "z": 0.74
-                },
-                "E1": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 14.38,
-                    "y": 38.24,
-                    "z": 0.74
-                },
-                "E10": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 95.38,
-                    "y": 38.24,
-                    "z": 0.74
-                },
-                "E11": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 104.38,
-                    "y": 38.24,
-                    "z": 0.74
-                },
-                "E12": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 113.38,
-                    "y": 38.24,
-                    "z": 0.74
-                },
-                "E2": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 23.38,
-                    "y": 38.24,
-                    "z": 0.74
-                },
-                "E3": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 32.38,
-                    "y": 38.24,
-                    "z": 0.74
-                },
-                "E4": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 41.38,
-                    "y": 38.24,
-                    "z": 0.74
-                },
-                "E5": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 50.38,
-                    "y": 38.24,
-                    "z": 0.74
-                },
-                "E6": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 59.38,
-                    "y": 38.24,
-                    "z": 0.74
-                },
-                "E7": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 68.38,
-                    "y": 38.24,
-                    "z": 0.74
-                },
-                "E8": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 77.38,
-                    "y": 38.24,
-                    "z": 0.74
-                },
-                "E9": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 86.38,
-                    "y": 38.24,
-                    "z": 0.74
-                },
-                "F1": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 14.38,
-                    "y": 29.24,
-                    "z": 0.74
-                },
-                "F10": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 95.38,
-                    "y": 29.24,
-                    "z": 0.74
-                },
-                "F11": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 104.38,
-                    "y": 29.24,
-                    "z": 0.74
-                },
-                "F12": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 113.38,
-                    "y": 29.24,
-                    "z": 0.74
-                },
-                "F2": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 23.38,
-                    "y": 29.24,
-                    "z": 0.74
-                },
-                "F3": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 32.38,
-                    "y": 29.24,
-                    "z": 0.74
-                },
-                "F4": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 41.38,
-                    "y": 29.24,
-                    "z": 0.74
-                },
-                "F5": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 50.38,
-                    "y": 29.24,
-                    "z": 0.74
-                },
-                "F6": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 59.38,
-                    "y": 29.24,
-                    "z": 0.74
-                },
-                "F7": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 68.38,
-                    "y": 29.24,
-                    "z": 0.74
-                },
-                "F8": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 77.38,
-                    "y": 29.24,
-                    "z": 0.74
-                },
-                "F9": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 86.38,
-                    "y": 29.24,
-                    "z": 0.74
-                },
-                "G1": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 14.38,
-                    "y": 20.24,
-                    "z": 0.74
-                },
-                "G10": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 95.38,
-                    "y": 20.24,
-                    "z": 0.74
-                },
-                "G11": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 104.38,
-                    "y": 20.24,
-                    "z": 0.74
-                },
-                "G12": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 113.38,
-                    "y": 20.24,
-                    "z": 0.74
-                },
-                "G2": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 23.38,
-                    "y": 20.24,
-                    "z": 0.74
-                },
-                "G3": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 32.38,
-                    "y": 20.24,
-                    "z": 0.74
-                },
-                "G4": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 41.38,
-                    "y": 20.24,
-                    "z": 0.74
-                },
-                "G5": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 50.38,
-                    "y": 20.24,
-                    "z": 0.74
-                },
-                "G6": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 59.38,
-                    "y": 20.24,
-                    "z": 0.74
-                },
-                "G7": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 68.38,
-                    "y": 20.24,
-                    "z": 0.74
-                },
-                "G8": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 77.38,
-                    "y": 20.24,
-                    "z": 0.74
-                },
-                "G9": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 86.38,
-                    "y": 20.24,
-                    "z": 0.74
-                },
-                "H1": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 14.38,
-                    "y": 11.24,
-                    "z": 0.74
-                },
-                "H10": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 95.38,
-                    "y": 11.24,
-                    "z": 0.74
-                },
-                "H11": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 104.38,
-                    "y": 11.24,
-                    "z": 0.74
-                },
-                "H12": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 113.38,
-                    "y": 11.24,
-                    "z": 0.74
-                },
-                "H2": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 23.38,
-                    "y": 11.24,
-                    "z": 0.74
-                },
-                "H3": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 32.38,
-                    "y": 11.24,
-                    "z": 0.74
-                },
-                "H4": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 41.38,
-                    "y": 11.24,
-                    "z": 0.74
-                },
-                "H5": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 50.38,
-                    "y": 11.24,
-                    "z": 0.74
-                },
-                "H6": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 59.38,
-                    "y": 11.24,
-                    "z": 0.74
-                },
-                "H7": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 68.38,
-                    "y": 11.24,
-                    "z": 0.74
-                },
-                "H8": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 77.38,
-                    "y": 11.24,
-                    "z": 0.74
-                },
-                "H9": {
-                    "depth": 17.14,
-                    "diameter": 5.49,
-                    "shape": "circular",
-                    "totalLiquidVolume": 100,
-                    "x": 86.38,
-                    "y": 11.24,
-                    "z": 0.74
                 }
             }
         }

--- a/protoBuilds/453b5a/nuc_acid_pcr_prep.ot2.apiv2.py.json
+++ b/protoBuilds/453b5a/nuc_acid_pcr_prep.ot2.apiv2.py.json
@@ -1620,7 +1620,7 @@
             "type": "opentrons_96_tiprack_300ul"
         },
         {
-            "name": "PCR plate on Temperature Module on 10",
+            "name": "PCR plate on Temperature Module GEN1 on 10",
             "share": false,
             "slot": "10",
             "type": "biozym_96_aluminumblock_200ul"

--- a/protoBuilds/459a55/mass_spec_prep.ot2.apiv2.py.json
+++ b/protoBuilds/459a55/mass_spec_prep.ot2.apiv2.py.json
@@ -51,7 +51,7 @@
     ],
     "labware": [
         {
-            "name": "Opentrons 96 Well Aluminum Block with NEST Well Plate 100 \u00b5L on Temperature Module on 1",
+            "name": "Opentrons 96 Well Aluminum Block with NEST Well Plate 100 \u00b5L on Temperature Module GEN1 on 1",
             "share": false,
             "slot": "1",
             "type": "opentrons_96_aluminumblock_nest_wellplate_100ul"

--- a/protoBuilds/53e6bc_mastermix_creation/antibody_mm_creation.ot2.apiv2.py.json
+++ b/protoBuilds/53e6bc_mastermix_creation/antibody_mm_creation.ot2.apiv2.py.json
@@ -1415,7 +1415,7 @@
     ],
     "labware": [
         {
-            "name": "Eppendorf Twin.tec 96 Well Plate 150 \u00b5L on Temperature Module on 1",
+            "name": "Eppendorf Twin.tec 96 Well Plate 150 \u00b5L on Temperature Module GEN1 on 1",
             "share": false,
             "slot": "1",
             "type": "eppendorftwin.tec_96_wellplate_150ul"

--- a/protoBuilds/558d02/peptide_enrichment.ot2.apiv2.py.json
+++ b/protoBuilds/558d02/peptide_enrichment.ot2.apiv2.py.json
@@ -1187,7 +1187,7 @@
     ],
     "labware": [
         {
-            "name": "USA Scientific 96 Deep Well Plate 2.4 mL on Magnetic Module on 1",
+            "name": "USA Scientific 96 Deep Well Plate 2.4 mL on Magnetic Module GEN1 on 1",
             "share": false,
             "slot": "1",
             "type": "usascientific_96_wellplate_2.4ml_deep"

--- a/protoBuilds/56b4ec/56b4ec.ot2.apiv2.py.json
+++ b/protoBuilds/56b4ec/56b4ec.ot2.apiv2.py.json
@@ -3,6 +3,236 @@
     "custom_labware_defs": [
         {
             "brand": {
+                "brand": "Charles river",
+                "brandId": [
+                    "TL700"
+                ]
+            },
+            "cornerOffsetFromSlot": {
+                "x": 0,
+                "y": 0,
+                "z": 0
+            },
+            "dimensions": {
+                "xDimension": 127.76,
+                "yDimension": 85.48,
+                "zDimension": 96.56
+            },
+            "groups": [
+                {
+                    "brand": {
+                        "brand": "Charles river",
+                        "brandId": [
+                            "TL700"
+                        ]
+                    },
+                    "metadata": {
+                        "displayCategory": "tubeRack",
+                        "displayName": "Charles River 15 Tube Rack 10000 \u00b5L",
+                        "wellBottomShape": "flat"
+                    },
+                    "wells": [
+                        "A1",
+                        "B1",
+                        "C1",
+                        "A2",
+                        "B2",
+                        "C2",
+                        "A3",
+                        "B3",
+                        "C3",
+                        "A4",
+                        "B4",
+                        "C4",
+                        "A5",
+                        "B5",
+                        "C5"
+                    ]
+                }
+            ],
+            "metadata": {
+                "displayCategory": "tubeRack",
+                "displayName": "Charles River 15 Tube Rack 10000 \u00b5L",
+                "displayVolumeUnits": "\u00b5L",
+                "tags": []
+            },
+            "namespace": "custom_beta",
+            "ordering": [
+                [
+                    "A1",
+                    "B1",
+                    "C1"
+                ],
+                [
+                    "A2",
+                    "B2",
+                    "C2"
+                ],
+                [
+                    "A3",
+                    "B3",
+                    "C3"
+                ],
+                [
+                    "A4",
+                    "B4",
+                    "C4"
+                ],
+                [
+                    "A5",
+                    "B5",
+                    "C5"
+                ]
+            ],
+            "parameters": {
+                "format": "irregular",
+                "isMagneticModuleCompatible": false,
+                "isTiprack": false,
+                "loadName": "charlesriver_15_tuberack_10000ul",
+                "quirks": []
+            },
+            "schemaVersion": 2,
+            "version": 1,
+            "wells": {
+                "A1": {
+                    "depth": 89.85,
+                    "diameter": 11.31,
+                    "shape": "circular",
+                    "totalLiquidVolume": 10000,
+                    "x": 13.88,
+                    "y": 67.74,
+                    "z": 6.71
+                },
+                "A2": {
+                    "depth": 89.85,
+                    "diameter": 11.31,
+                    "shape": "circular",
+                    "totalLiquidVolume": 10000,
+                    "x": 38.88,
+                    "y": 67.74,
+                    "z": 6.71
+                },
+                "A3": {
+                    "depth": 89.85,
+                    "diameter": 11.31,
+                    "shape": "circular",
+                    "totalLiquidVolume": 10000,
+                    "x": 63.88,
+                    "y": 67.74,
+                    "z": 6.71
+                },
+                "A4": {
+                    "depth": 89.85,
+                    "diameter": 11.31,
+                    "shape": "circular",
+                    "totalLiquidVolume": 10000,
+                    "x": 88.88,
+                    "y": 67.74,
+                    "z": 6.71
+                },
+                "A5": {
+                    "depth": 89.85,
+                    "diameter": 11.31,
+                    "shape": "circular",
+                    "totalLiquidVolume": 10000,
+                    "x": 113.88,
+                    "y": 67.74,
+                    "z": 6.71
+                },
+                "B1": {
+                    "depth": 89.85,
+                    "diameter": 11.31,
+                    "shape": "circular",
+                    "totalLiquidVolume": 10000,
+                    "x": 13.88,
+                    "y": 42.74,
+                    "z": 6.71
+                },
+                "B2": {
+                    "depth": 89.85,
+                    "diameter": 11.31,
+                    "shape": "circular",
+                    "totalLiquidVolume": 10000,
+                    "x": 38.88,
+                    "y": 42.74,
+                    "z": 6.71
+                },
+                "B3": {
+                    "depth": 89.85,
+                    "diameter": 11.31,
+                    "shape": "circular",
+                    "totalLiquidVolume": 10000,
+                    "x": 63.88,
+                    "y": 42.74,
+                    "z": 6.71
+                },
+                "B4": {
+                    "depth": 89.85,
+                    "diameter": 11.31,
+                    "shape": "circular",
+                    "totalLiquidVolume": 10000,
+                    "x": 88.88,
+                    "y": 42.74,
+                    "z": 6.71
+                },
+                "B5": {
+                    "depth": 89.85,
+                    "diameter": 11.31,
+                    "shape": "circular",
+                    "totalLiquidVolume": 10000,
+                    "x": 113.88,
+                    "y": 42.74,
+                    "z": 6.71
+                },
+                "C1": {
+                    "depth": 89.85,
+                    "diameter": 11.31,
+                    "shape": "circular",
+                    "totalLiquidVolume": 10000,
+                    "x": 13.88,
+                    "y": 17.74,
+                    "z": 6.71
+                },
+                "C2": {
+                    "depth": 89.85,
+                    "diameter": 11.31,
+                    "shape": "circular",
+                    "totalLiquidVolume": 10000,
+                    "x": 38.88,
+                    "y": 17.74,
+                    "z": 6.71
+                },
+                "C3": {
+                    "depth": 89.85,
+                    "diameter": 11.31,
+                    "shape": "circular",
+                    "totalLiquidVolume": 10000,
+                    "x": 63.88,
+                    "y": 17.74,
+                    "z": 6.71
+                },
+                "C4": {
+                    "depth": 89.85,
+                    "diameter": 11.31,
+                    "shape": "circular",
+                    "totalLiquidVolume": 10000,
+                    "x": 88.88,
+                    "y": 17.74,
+                    "z": 6.71
+                },
+                "C5": {
+                    "depth": 89.85,
+                    "diameter": 11.31,
+                    "shape": "circular",
+                    "totalLiquidVolume": 10000,
+                    "x": 113.88,
+                    "y": 17.74,
+                    "z": 6.71
+                }
+            }
+        },
+        {
+            "brand": {
                 "brand": "generic"
             },
             "cornerOffsetFromSlot": {
@@ -1120,236 +1350,6 @@
                     "x": 84.4,
                     "y": 10.25,
                     "z": 7.4
-                }
-            }
-        },
-        {
-            "brand": {
-                "brand": "Charles river",
-                "brandId": [
-                    "TL700"
-                ]
-            },
-            "cornerOffsetFromSlot": {
-                "x": 0,
-                "y": 0,
-                "z": 0
-            },
-            "dimensions": {
-                "xDimension": 127.76,
-                "yDimension": 85.48,
-                "zDimension": 96.56
-            },
-            "groups": [
-                {
-                    "brand": {
-                        "brand": "Charles river",
-                        "brandId": [
-                            "TL700"
-                        ]
-                    },
-                    "metadata": {
-                        "displayCategory": "tubeRack",
-                        "displayName": "Charles River 15 Tube Rack 10000 \u00b5L",
-                        "wellBottomShape": "flat"
-                    },
-                    "wells": [
-                        "A1",
-                        "B1",
-                        "C1",
-                        "A2",
-                        "B2",
-                        "C2",
-                        "A3",
-                        "B3",
-                        "C3",
-                        "A4",
-                        "B4",
-                        "C4",
-                        "A5",
-                        "B5",
-                        "C5"
-                    ]
-                }
-            ],
-            "metadata": {
-                "displayCategory": "tubeRack",
-                "displayName": "Charles River 15 Tube Rack 10000 \u00b5L",
-                "displayVolumeUnits": "\u00b5L",
-                "tags": []
-            },
-            "namespace": "custom_beta",
-            "ordering": [
-                [
-                    "A1",
-                    "B1",
-                    "C1"
-                ],
-                [
-                    "A2",
-                    "B2",
-                    "C2"
-                ],
-                [
-                    "A3",
-                    "B3",
-                    "C3"
-                ],
-                [
-                    "A4",
-                    "B4",
-                    "C4"
-                ],
-                [
-                    "A5",
-                    "B5",
-                    "C5"
-                ]
-            ],
-            "parameters": {
-                "format": "irregular",
-                "isMagneticModuleCompatible": false,
-                "isTiprack": false,
-                "loadName": "charlesriver_15_tuberack_10000ul",
-                "quirks": []
-            },
-            "schemaVersion": 2,
-            "version": 1,
-            "wells": {
-                "A1": {
-                    "depth": 89.85,
-                    "diameter": 11.31,
-                    "shape": "circular",
-                    "totalLiquidVolume": 10000,
-                    "x": 13.88,
-                    "y": 67.74,
-                    "z": 6.71
-                },
-                "A2": {
-                    "depth": 89.85,
-                    "diameter": 11.31,
-                    "shape": "circular",
-                    "totalLiquidVolume": 10000,
-                    "x": 38.88,
-                    "y": 67.74,
-                    "z": 6.71
-                },
-                "A3": {
-                    "depth": 89.85,
-                    "diameter": 11.31,
-                    "shape": "circular",
-                    "totalLiquidVolume": 10000,
-                    "x": 63.88,
-                    "y": 67.74,
-                    "z": 6.71
-                },
-                "A4": {
-                    "depth": 89.85,
-                    "diameter": 11.31,
-                    "shape": "circular",
-                    "totalLiquidVolume": 10000,
-                    "x": 88.88,
-                    "y": 67.74,
-                    "z": 6.71
-                },
-                "A5": {
-                    "depth": 89.85,
-                    "diameter": 11.31,
-                    "shape": "circular",
-                    "totalLiquidVolume": 10000,
-                    "x": 113.88,
-                    "y": 67.74,
-                    "z": 6.71
-                },
-                "B1": {
-                    "depth": 89.85,
-                    "diameter": 11.31,
-                    "shape": "circular",
-                    "totalLiquidVolume": 10000,
-                    "x": 13.88,
-                    "y": 42.74,
-                    "z": 6.71
-                },
-                "B2": {
-                    "depth": 89.85,
-                    "diameter": 11.31,
-                    "shape": "circular",
-                    "totalLiquidVolume": 10000,
-                    "x": 38.88,
-                    "y": 42.74,
-                    "z": 6.71
-                },
-                "B3": {
-                    "depth": 89.85,
-                    "diameter": 11.31,
-                    "shape": "circular",
-                    "totalLiquidVolume": 10000,
-                    "x": 63.88,
-                    "y": 42.74,
-                    "z": 6.71
-                },
-                "B4": {
-                    "depth": 89.85,
-                    "diameter": 11.31,
-                    "shape": "circular",
-                    "totalLiquidVolume": 10000,
-                    "x": 88.88,
-                    "y": 42.74,
-                    "z": 6.71
-                },
-                "B5": {
-                    "depth": 89.85,
-                    "diameter": 11.31,
-                    "shape": "circular",
-                    "totalLiquidVolume": 10000,
-                    "x": 113.88,
-                    "y": 42.74,
-                    "z": 6.71
-                },
-                "C1": {
-                    "depth": 89.85,
-                    "diameter": 11.31,
-                    "shape": "circular",
-                    "totalLiquidVolume": 10000,
-                    "x": 13.88,
-                    "y": 17.74,
-                    "z": 6.71
-                },
-                "C2": {
-                    "depth": 89.85,
-                    "diameter": 11.31,
-                    "shape": "circular",
-                    "totalLiquidVolume": 10000,
-                    "x": 38.88,
-                    "y": 17.74,
-                    "z": 6.71
-                },
-                "C3": {
-                    "depth": 89.85,
-                    "diameter": 11.31,
-                    "shape": "circular",
-                    "totalLiquidVolume": 10000,
-                    "x": 63.88,
-                    "y": 17.74,
-                    "z": 6.71
-                },
-                "C4": {
-                    "depth": 89.85,
-                    "diameter": 11.31,
-                    "shape": "circular",
-                    "totalLiquidVolume": 10000,
-                    "x": 88.88,
-                    "y": 17.74,
-                    "z": 6.71
-                },
-                "C5": {
-                    "depth": 89.85,
-                    "diameter": 11.31,
-                    "shape": "circular",
-                    "totalLiquidVolume": 10000,
-                    "x": 113.88,
-                    "y": 17.74,
-                    "z": 6.71
                 }
             }
         }

--- a/protoBuilds/5c14ad/5c14ad.ot2.apiv2.py.json
+++ b/protoBuilds/5c14ad/5c14ad.ot2.apiv2.py.json
@@ -3,1128 +3,6 @@
     "custom_labware_defs": [
         {
             "brand": {
-                "brand": "generic"
-            },
-            "cornerOffsetFromSlot": {
-                "x": 0,
-                "y": 0,
-                "z": 0
-            },
-            "dimensions": {
-                "xDimension": 127.76,
-                "yDimension": 85.48,
-                "zDimension": 70
-            },
-            "groups": [
-                {
-                    "metadata": {},
-                    "wells": [
-                        "A1",
-                        "B1",
-                        "C1",
-                        "D1",
-                        "E1",
-                        "F1",
-                        "G1",
-                        "H1",
-                        "A2",
-                        "B2",
-                        "C2",
-                        "D2",
-                        "E2",
-                        "F2",
-                        "G2",
-                        "H2",
-                        "A3",
-                        "B3",
-                        "C3",
-                        "D3",
-                        "E3",
-                        "F3",
-                        "G3",
-                        "H3",
-                        "A4",
-                        "B4",
-                        "C4",
-                        "D4",
-                        "E4",
-                        "F4",
-                        "G4",
-                        "H4",
-                        "A5",
-                        "B5",
-                        "C5",
-                        "D5",
-                        "E5",
-                        "F5",
-                        "G5",
-                        "H5",
-                        "A6",
-                        "B6",
-                        "C6",
-                        "D6",
-                        "E6",
-                        "F6",
-                        "G6",
-                        "H6",
-                        "A7",
-                        "B7",
-                        "C7",
-                        "D7",
-                        "E7",
-                        "F7",
-                        "G7",
-                        "H7",
-                        "A8",
-                        "B8",
-                        "C8",
-                        "D8",
-                        "E8",
-                        "F8",
-                        "G8",
-                        "H8",
-                        "A9",
-                        "B9",
-                        "C9",
-                        "D9",
-                        "E9",
-                        "F9",
-                        "G9",
-                        "H9",
-                        "A10",
-                        "B10",
-                        "C10",
-                        "D10",
-                        "E10",
-                        "F10",
-                        "G10",
-                        "H10",
-                        "A11",
-                        "B11",
-                        "C11",
-                        "D11",
-                        "E11",
-                        "F11",
-                        "G11",
-                        "H11",
-                        "A12",
-                        "B12",
-                        "C12",
-                        "D12",
-                        "E12",
-                        "F12",
-                        "G12",
-                        "H12"
-                    ]
-                }
-            ],
-            "metadata": {
-                "displayCategory": "tipRack",
-                "displayName": "Custom 200\u00b5L Tiprack",
-                "displayVolumeUnits": "\u00b5L",
-                "tags": []
-            },
-            "namespace": "custom_beta",
-            "ordering": [
-                [
-                    "A1",
-                    "B1",
-                    "C1",
-                    "D1",
-                    "E1",
-                    "F1",
-                    "G1",
-                    "H1"
-                ],
-                [
-                    "A2",
-                    "B2",
-                    "C2",
-                    "D2",
-                    "E2",
-                    "F2",
-                    "G2",
-                    "H2"
-                ],
-                [
-                    "A3",
-                    "B3",
-                    "C3",
-                    "D3",
-                    "E3",
-                    "F3",
-                    "G3",
-                    "H3"
-                ],
-                [
-                    "A4",
-                    "B4",
-                    "C4",
-                    "D4",
-                    "E4",
-                    "F4",
-                    "G4",
-                    "H4"
-                ],
-                [
-                    "A5",
-                    "B5",
-                    "C5",
-                    "D5",
-                    "E5",
-                    "F5",
-                    "G5",
-                    "H5"
-                ],
-                [
-                    "A6",
-                    "B6",
-                    "C6",
-                    "D6",
-                    "E6",
-                    "F6",
-                    "G6",
-                    "H6"
-                ],
-                [
-                    "A7",
-                    "B7",
-                    "C7",
-                    "D7",
-                    "E7",
-                    "F7",
-                    "G7",
-                    "H7"
-                ],
-                [
-                    "A8",
-                    "B8",
-                    "C8",
-                    "D8",
-                    "E8",
-                    "F8",
-                    "G8",
-                    "H8"
-                ],
-                [
-                    "A9",
-                    "B9",
-                    "C9",
-                    "D9",
-                    "E9",
-                    "F9",
-                    "G9",
-                    "H9"
-                ],
-                [
-                    "A10",
-                    "B10",
-                    "C10",
-                    "D10",
-                    "E10",
-                    "F10",
-                    "G10",
-                    "H10"
-                ],
-                [
-                    "A11",
-                    "B11",
-                    "C11",
-                    "D11",
-                    "E11",
-                    "F11",
-                    "G11",
-                    "H11"
-                ],
-                [
-                    "A12",
-                    "B12",
-                    "C12",
-                    "D12",
-                    "E12",
-                    "F12",
-                    "G12",
-                    "H12"
-                ]
-            ],
-            "parameters": {
-                "format": "96Standard",
-                "isMagneticModuleCompatible": false,
-                "isTiprack": true,
-                "loadName": "generic_96_tiprack_200ul",
-                "tipLength": 50
-            },
-            "schemaVersion": 2,
-            "version": 1,
-            "wells": {
-                "A1": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 14.38,
-                    "y": 74.24,
-                    "z": 20
-                },
-                "A10": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 95.38,
-                    "y": 74.24,
-                    "z": 20
-                },
-                "A11": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 104.38,
-                    "y": 74.24,
-                    "z": 20
-                },
-                "A12": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 113.38,
-                    "y": 74.24,
-                    "z": 20
-                },
-                "A2": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 23.38,
-                    "y": 74.24,
-                    "z": 20
-                },
-                "A3": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 32.38,
-                    "y": 74.24,
-                    "z": 20
-                },
-                "A4": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 41.38,
-                    "y": 74.24,
-                    "z": 20
-                },
-                "A5": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 50.38,
-                    "y": 74.24,
-                    "z": 20
-                },
-                "A6": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 59.38,
-                    "y": 74.24,
-                    "z": 20
-                },
-                "A7": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 68.38,
-                    "y": 74.24,
-                    "z": 20
-                },
-                "A8": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 77.38,
-                    "y": 74.24,
-                    "z": 20
-                },
-                "A9": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 86.38,
-                    "y": 74.24,
-                    "z": 20
-                },
-                "B1": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 14.38,
-                    "y": 65.24,
-                    "z": 20
-                },
-                "B10": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 95.38,
-                    "y": 65.24,
-                    "z": 20
-                },
-                "B11": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 104.38,
-                    "y": 65.24,
-                    "z": 20
-                },
-                "B12": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 113.38,
-                    "y": 65.24,
-                    "z": 20
-                },
-                "B2": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 23.38,
-                    "y": 65.24,
-                    "z": 20
-                },
-                "B3": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 32.38,
-                    "y": 65.24,
-                    "z": 20
-                },
-                "B4": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 41.38,
-                    "y": 65.24,
-                    "z": 20
-                },
-                "B5": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 50.38,
-                    "y": 65.24,
-                    "z": 20
-                },
-                "B6": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 59.38,
-                    "y": 65.24,
-                    "z": 20
-                },
-                "B7": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 68.38,
-                    "y": 65.24,
-                    "z": 20
-                },
-                "B8": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 77.38,
-                    "y": 65.24,
-                    "z": 20
-                },
-                "B9": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 86.38,
-                    "y": 65.24,
-                    "z": 20
-                },
-                "C1": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 14.38,
-                    "y": 56.24,
-                    "z": 20
-                },
-                "C10": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 95.38,
-                    "y": 56.24,
-                    "z": 20
-                },
-                "C11": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 104.38,
-                    "y": 56.24,
-                    "z": 20
-                },
-                "C12": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 113.38,
-                    "y": 56.24,
-                    "z": 20
-                },
-                "C2": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 23.38,
-                    "y": 56.24,
-                    "z": 20
-                },
-                "C3": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 32.38,
-                    "y": 56.24,
-                    "z": 20
-                },
-                "C4": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 41.38,
-                    "y": 56.24,
-                    "z": 20
-                },
-                "C5": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 50.38,
-                    "y": 56.24,
-                    "z": 20
-                },
-                "C6": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 59.38,
-                    "y": 56.24,
-                    "z": 20
-                },
-                "C7": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 68.38,
-                    "y": 56.24,
-                    "z": 20
-                },
-                "C8": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 77.38,
-                    "y": 56.24,
-                    "z": 20
-                },
-                "C9": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 86.38,
-                    "y": 56.24,
-                    "z": 20
-                },
-                "D1": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 14.38,
-                    "y": 47.24,
-                    "z": 20
-                },
-                "D10": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 95.38,
-                    "y": 47.24,
-                    "z": 20
-                },
-                "D11": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 104.38,
-                    "y": 47.24,
-                    "z": 20
-                },
-                "D12": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 113.38,
-                    "y": 47.24,
-                    "z": 20
-                },
-                "D2": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 23.38,
-                    "y": 47.24,
-                    "z": 20
-                },
-                "D3": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 32.38,
-                    "y": 47.24,
-                    "z": 20
-                },
-                "D4": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 41.38,
-                    "y": 47.24,
-                    "z": 20
-                },
-                "D5": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 50.38,
-                    "y": 47.24,
-                    "z": 20
-                },
-                "D6": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 59.38,
-                    "y": 47.24,
-                    "z": 20
-                },
-                "D7": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 68.38,
-                    "y": 47.24,
-                    "z": 20
-                },
-                "D8": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 77.38,
-                    "y": 47.24,
-                    "z": 20
-                },
-                "D9": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 86.38,
-                    "y": 47.24,
-                    "z": 20
-                },
-                "E1": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 14.38,
-                    "y": 38.24,
-                    "z": 20
-                },
-                "E10": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 95.38,
-                    "y": 38.24,
-                    "z": 20
-                },
-                "E11": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 104.38,
-                    "y": 38.24,
-                    "z": 20
-                },
-                "E12": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 113.38,
-                    "y": 38.24,
-                    "z": 20
-                },
-                "E2": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 23.38,
-                    "y": 38.24,
-                    "z": 20
-                },
-                "E3": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 32.38,
-                    "y": 38.24,
-                    "z": 20
-                },
-                "E4": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 41.38,
-                    "y": 38.24,
-                    "z": 20
-                },
-                "E5": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 50.38,
-                    "y": 38.24,
-                    "z": 20
-                },
-                "E6": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 59.38,
-                    "y": 38.24,
-                    "z": 20
-                },
-                "E7": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 68.38,
-                    "y": 38.24,
-                    "z": 20
-                },
-                "E8": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 77.38,
-                    "y": 38.24,
-                    "z": 20
-                },
-                "E9": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 86.38,
-                    "y": 38.24,
-                    "z": 20
-                },
-                "F1": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 14.38,
-                    "y": 29.24,
-                    "z": 20
-                },
-                "F10": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 95.38,
-                    "y": 29.24,
-                    "z": 20
-                },
-                "F11": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 104.38,
-                    "y": 29.24,
-                    "z": 20
-                },
-                "F12": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 113.38,
-                    "y": 29.24,
-                    "z": 20
-                },
-                "F2": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 23.38,
-                    "y": 29.24,
-                    "z": 20
-                },
-                "F3": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 32.38,
-                    "y": 29.24,
-                    "z": 20
-                },
-                "F4": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 41.38,
-                    "y": 29.24,
-                    "z": 20
-                },
-                "F5": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 50.38,
-                    "y": 29.24,
-                    "z": 20
-                },
-                "F6": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 59.38,
-                    "y": 29.24,
-                    "z": 20
-                },
-                "F7": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 68.38,
-                    "y": 29.24,
-                    "z": 20
-                },
-                "F8": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 77.38,
-                    "y": 29.24,
-                    "z": 20
-                },
-                "F9": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 86.38,
-                    "y": 29.24,
-                    "z": 20
-                },
-                "G1": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 14.38,
-                    "y": 20.24,
-                    "z": 20
-                },
-                "G10": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 95.38,
-                    "y": 20.24,
-                    "z": 20
-                },
-                "G11": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 104.38,
-                    "y": 20.24,
-                    "z": 20
-                },
-                "G12": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 113.38,
-                    "y": 20.24,
-                    "z": 20
-                },
-                "G2": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 23.38,
-                    "y": 20.24,
-                    "z": 20
-                },
-                "G3": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 32.38,
-                    "y": 20.24,
-                    "z": 20
-                },
-                "G4": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 41.38,
-                    "y": 20.24,
-                    "z": 20
-                },
-                "G5": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 50.38,
-                    "y": 20.24,
-                    "z": 20
-                },
-                "G6": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 59.38,
-                    "y": 20.24,
-                    "z": 20
-                },
-                "G7": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 68.38,
-                    "y": 20.24,
-                    "z": 20
-                },
-                "G8": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 77.38,
-                    "y": 20.24,
-                    "z": 20
-                },
-                "G9": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 86.38,
-                    "y": 20.24,
-                    "z": 20
-                },
-                "H1": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 14.38,
-                    "y": 11.24,
-                    "z": 20
-                },
-                "H10": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 95.38,
-                    "y": 11.24,
-                    "z": 20
-                },
-                "H11": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 104.38,
-                    "y": 11.24,
-                    "z": 20
-                },
-                "H12": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 113.38,
-                    "y": 11.24,
-                    "z": 20
-                },
-                "H2": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 23.38,
-                    "y": 11.24,
-                    "z": 20
-                },
-                "H3": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 32.38,
-                    "y": 11.24,
-                    "z": 20
-                },
-                "H4": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 41.38,
-                    "y": 11.24,
-                    "z": 20
-                },
-                "H5": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 50.38,
-                    "y": 11.24,
-                    "z": 20
-                },
-                "H6": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 59.38,
-                    "y": 11.24,
-                    "z": 20
-                },
-                "H7": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 68.38,
-                    "y": 11.24,
-                    "z": 20
-                },
-                "H8": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 77.38,
-                    "y": 11.24,
-                    "z": 20
-                },
-                "H9": {
-                    "depth": 50,
-                    "diameter": 5.2,
-                    "shape": "circular",
-                    "totalLiquidVolume": 200,
-                    "x": 86.38,
-                    "y": 11.24,
-                    "z": 20
-                }
-            }
-        },
-        {
-            "brand": {
                 "brand": "custom",
                 "brandId": []
             },
@@ -2251,6 +1129,1128 @@
                     "x": 86.38,
                     "y": 11.24,
                     "z": 16
+                }
+            }
+        },
+        {
+            "brand": {
+                "brand": "generic"
+            },
+            "cornerOffsetFromSlot": {
+                "x": 0,
+                "y": 0,
+                "z": 0
+            },
+            "dimensions": {
+                "xDimension": 127.76,
+                "yDimension": 85.48,
+                "zDimension": 70
+            },
+            "groups": [
+                {
+                    "metadata": {},
+                    "wells": [
+                        "A1",
+                        "B1",
+                        "C1",
+                        "D1",
+                        "E1",
+                        "F1",
+                        "G1",
+                        "H1",
+                        "A2",
+                        "B2",
+                        "C2",
+                        "D2",
+                        "E2",
+                        "F2",
+                        "G2",
+                        "H2",
+                        "A3",
+                        "B3",
+                        "C3",
+                        "D3",
+                        "E3",
+                        "F3",
+                        "G3",
+                        "H3",
+                        "A4",
+                        "B4",
+                        "C4",
+                        "D4",
+                        "E4",
+                        "F4",
+                        "G4",
+                        "H4",
+                        "A5",
+                        "B5",
+                        "C5",
+                        "D5",
+                        "E5",
+                        "F5",
+                        "G5",
+                        "H5",
+                        "A6",
+                        "B6",
+                        "C6",
+                        "D6",
+                        "E6",
+                        "F6",
+                        "G6",
+                        "H6",
+                        "A7",
+                        "B7",
+                        "C7",
+                        "D7",
+                        "E7",
+                        "F7",
+                        "G7",
+                        "H7",
+                        "A8",
+                        "B8",
+                        "C8",
+                        "D8",
+                        "E8",
+                        "F8",
+                        "G8",
+                        "H8",
+                        "A9",
+                        "B9",
+                        "C9",
+                        "D9",
+                        "E9",
+                        "F9",
+                        "G9",
+                        "H9",
+                        "A10",
+                        "B10",
+                        "C10",
+                        "D10",
+                        "E10",
+                        "F10",
+                        "G10",
+                        "H10",
+                        "A11",
+                        "B11",
+                        "C11",
+                        "D11",
+                        "E11",
+                        "F11",
+                        "G11",
+                        "H11",
+                        "A12",
+                        "B12",
+                        "C12",
+                        "D12",
+                        "E12",
+                        "F12",
+                        "G12",
+                        "H12"
+                    ]
+                }
+            ],
+            "metadata": {
+                "displayCategory": "tipRack",
+                "displayName": "Custom 200\u00b5L Tiprack",
+                "displayVolumeUnits": "\u00b5L",
+                "tags": []
+            },
+            "namespace": "custom_beta",
+            "ordering": [
+                [
+                    "A1",
+                    "B1",
+                    "C1",
+                    "D1",
+                    "E1",
+                    "F1",
+                    "G1",
+                    "H1"
+                ],
+                [
+                    "A2",
+                    "B2",
+                    "C2",
+                    "D2",
+                    "E2",
+                    "F2",
+                    "G2",
+                    "H2"
+                ],
+                [
+                    "A3",
+                    "B3",
+                    "C3",
+                    "D3",
+                    "E3",
+                    "F3",
+                    "G3",
+                    "H3"
+                ],
+                [
+                    "A4",
+                    "B4",
+                    "C4",
+                    "D4",
+                    "E4",
+                    "F4",
+                    "G4",
+                    "H4"
+                ],
+                [
+                    "A5",
+                    "B5",
+                    "C5",
+                    "D5",
+                    "E5",
+                    "F5",
+                    "G5",
+                    "H5"
+                ],
+                [
+                    "A6",
+                    "B6",
+                    "C6",
+                    "D6",
+                    "E6",
+                    "F6",
+                    "G6",
+                    "H6"
+                ],
+                [
+                    "A7",
+                    "B7",
+                    "C7",
+                    "D7",
+                    "E7",
+                    "F7",
+                    "G7",
+                    "H7"
+                ],
+                [
+                    "A8",
+                    "B8",
+                    "C8",
+                    "D8",
+                    "E8",
+                    "F8",
+                    "G8",
+                    "H8"
+                ],
+                [
+                    "A9",
+                    "B9",
+                    "C9",
+                    "D9",
+                    "E9",
+                    "F9",
+                    "G9",
+                    "H9"
+                ],
+                [
+                    "A10",
+                    "B10",
+                    "C10",
+                    "D10",
+                    "E10",
+                    "F10",
+                    "G10",
+                    "H10"
+                ],
+                [
+                    "A11",
+                    "B11",
+                    "C11",
+                    "D11",
+                    "E11",
+                    "F11",
+                    "G11",
+                    "H11"
+                ],
+                [
+                    "A12",
+                    "B12",
+                    "C12",
+                    "D12",
+                    "E12",
+                    "F12",
+                    "G12",
+                    "H12"
+                ]
+            ],
+            "parameters": {
+                "format": "96Standard",
+                "isMagneticModuleCompatible": false,
+                "isTiprack": true,
+                "loadName": "generic_96_tiprack_200ul",
+                "tipLength": 50
+            },
+            "schemaVersion": 2,
+            "version": 1,
+            "wells": {
+                "A1": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 14.38,
+                    "y": 74.24,
+                    "z": 20
+                },
+                "A10": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 95.38,
+                    "y": 74.24,
+                    "z": 20
+                },
+                "A11": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 104.38,
+                    "y": 74.24,
+                    "z": 20
+                },
+                "A12": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 113.38,
+                    "y": 74.24,
+                    "z": 20
+                },
+                "A2": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 23.38,
+                    "y": 74.24,
+                    "z": 20
+                },
+                "A3": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 32.38,
+                    "y": 74.24,
+                    "z": 20
+                },
+                "A4": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 41.38,
+                    "y": 74.24,
+                    "z": 20
+                },
+                "A5": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 50.38,
+                    "y": 74.24,
+                    "z": 20
+                },
+                "A6": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 59.38,
+                    "y": 74.24,
+                    "z": 20
+                },
+                "A7": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 68.38,
+                    "y": 74.24,
+                    "z": 20
+                },
+                "A8": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 77.38,
+                    "y": 74.24,
+                    "z": 20
+                },
+                "A9": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 86.38,
+                    "y": 74.24,
+                    "z": 20
+                },
+                "B1": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 14.38,
+                    "y": 65.24,
+                    "z": 20
+                },
+                "B10": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 95.38,
+                    "y": 65.24,
+                    "z": 20
+                },
+                "B11": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 104.38,
+                    "y": 65.24,
+                    "z": 20
+                },
+                "B12": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 113.38,
+                    "y": 65.24,
+                    "z": 20
+                },
+                "B2": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 23.38,
+                    "y": 65.24,
+                    "z": 20
+                },
+                "B3": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 32.38,
+                    "y": 65.24,
+                    "z": 20
+                },
+                "B4": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 41.38,
+                    "y": 65.24,
+                    "z": 20
+                },
+                "B5": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 50.38,
+                    "y": 65.24,
+                    "z": 20
+                },
+                "B6": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 59.38,
+                    "y": 65.24,
+                    "z": 20
+                },
+                "B7": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 68.38,
+                    "y": 65.24,
+                    "z": 20
+                },
+                "B8": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 77.38,
+                    "y": 65.24,
+                    "z": 20
+                },
+                "B9": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 86.38,
+                    "y": 65.24,
+                    "z": 20
+                },
+                "C1": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 14.38,
+                    "y": 56.24,
+                    "z": 20
+                },
+                "C10": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 95.38,
+                    "y": 56.24,
+                    "z": 20
+                },
+                "C11": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 104.38,
+                    "y": 56.24,
+                    "z": 20
+                },
+                "C12": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 113.38,
+                    "y": 56.24,
+                    "z": 20
+                },
+                "C2": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 23.38,
+                    "y": 56.24,
+                    "z": 20
+                },
+                "C3": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 32.38,
+                    "y": 56.24,
+                    "z": 20
+                },
+                "C4": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 41.38,
+                    "y": 56.24,
+                    "z": 20
+                },
+                "C5": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 50.38,
+                    "y": 56.24,
+                    "z": 20
+                },
+                "C6": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 59.38,
+                    "y": 56.24,
+                    "z": 20
+                },
+                "C7": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 68.38,
+                    "y": 56.24,
+                    "z": 20
+                },
+                "C8": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 77.38,
+                    "y": 56.24,
+                    "z": 20
+                },
+                "C9": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 86.38,
+                    "y": 56.24,
+                    "z": 20
+                },
+                "D1": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 14.38,
+                    "y": 47.24,
+                    "z": 20
+                },
+                "D10": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 95.38,
+                    "y": 47.24,
+                    "z": 20
+                },
+                "D11": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 104.38,
+                    "y": 47.24,
+                    "z": 20
+                },
+                "D12": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 113.38,
+                    "y": 47.24,
+                    "z": 20
+                },
+                "D2": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 23.38,
+                    "y": 47.24,
+                    "z": 20
+                },
+                "D3": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 32.38,
+                    "y": 47.24,
+                    "z": 20
+                },
+                "D4": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 41.38,
+                    "y": 47.24,
+                    "z": 20
+                },
+                "D5": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 50.38,
+                    "y": 47.24,
+                    "z": 20
+                },
+                "D6": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 59.38,
+                    "y": 47.24,
+                    "z": 20
+                },
+                "D7": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 68.38,
+                    "y": 47.24,
+                    "z": 20
+                },
+                "D8": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 77.38,
+                    "y": 47.24,
+                    "z": 20
+                },
+                "D9": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 86.38,
+                    "y": 47.24,
+                    "z": 20
+                },
+                "E1": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 14.38,
+                    "y": 38.24,
+                    "z": 20
+                },
+                "E10": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 95.38,
+                    "y": 38.24,
+                    "z": 20
+                },
+                "E11": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 104.38,
+                    "y": 38.24,
+                    "z": 20
+                },
+                "E12": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 113.38,
+                    "y": 38.24,
+                    "z": 20
+                },
+                "E2": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 23.38,
+                    "y": 38.24,
+                    "z": 20
+                },
+                "E3": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 32.38,
+                    "y": 38.24,
+                    "z": 20
+                },
+                "E4": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 41.38,
+                    "y": 38.24,
+                    "z": 20
+                },
+                "E5": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 50.38,
+                    "y": 38.24,
+                    "z": 20
+                },
+                "E6": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 59.38,
+                    "y": 38.24,
+                    "z": 20
+                },
+                "E7": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 68.38,
+                    "y": 38.24,
+                    "z": 20
+                },
+                "E8": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 77.38,
+                    "y": 38.24,
+                    "z": 20
+                },
+                "E9": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 86.38,
+                    "y": 38.24,
+                    "z": 20
+                },
+                "F1": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 14.38,
+                    "y": 29.24,
+                    "z": 20
+                },
+                "F10": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 95.38,
+                    "y": 29.24,
+                    "z": 20
+                },
+                "F11": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 104.38,
+                    "y": 29.24,
+                    "z": 20
+                },
+                "F12": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 113.38,
+                    "y": 29.24,
+                    "z": 20
+                },
+                "F2": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 23.38,
+                    "y": 29.24,
+                    "z": 20
+                },
+                "F3": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 32.38,
+                    "y": 29.24,
+                    "z": 20
+                },
+                "F4": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 41.38,
+                    "y": 29.24,
+                    "z": 20
+                },
+                "F5": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 50.38,
+                    "y": 29.24,
+                    "z": 20
+                },
+                "F6": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 59.38,
+                    "y": 29.24,
+                    "z": 20
+                },
+                "F7": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 68.38,
+                    "y": 29.24,
+                    "z": 20
+                },
+                "F8": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 77.38,
+                    "y": 29.24,
+                    "z": 20
+                },
+                "F9": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 86.38,
+                    "y": 29.24,
+                    "z": 20
+                },
+                "G1": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 14.38,
+                    "y": 20.24,
+                    "z": 20
+                },
+                "G10": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 95.38,
+                    "y": 20.24,
+                    "z": 20
+                },
+                "G11": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 104.38,
+                    "y": 20.24,
+                    "z": 20
+                },
+                "G12": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 113.38,
+                    "y": 20.24,
+                    "z": 20
+                },
+                "G2": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 23.38,
+                    "y": 20.24,
+                    "z": 20
+                },
+                "G3": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 32.38,
+                    "y": 20.24,
+                    "z": 20
+                },
+                "G4": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 41.38,
+                    "y": 20.24,
+                    "z": 20
+                },
+                "G5": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 50.38,
+                    "y": 20.24,
+                    "z": 20
+                },
+                "G6": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 59.38,
+                    "y": 20.24,
+                    "z": 20
+                },
+                "G7": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 68.38,
+                    "y": 20.24,
+                    "z": 20
+                },
+                "G8": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 77.38,
+                    "y": 20.24,
+                    "z": 20
+                },
+                "G9": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 86.38,
+                    "y": 20.24,
+                    "z": 20
+                },
+                "H1": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 14.38,
+                    "y": 11.24,
+                    "z": 20
+                },
+                "H10": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 95.38,
+                    "y": 11.24,
+                    "z": 20
+                },
+                "H11": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 104.38,
+                    "y": 11.24,
+                    "z": 20
+                },
+                "H12": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 113.38,
+                    "y": 11.24,
+                    "z": 20
+                },
+                "H2": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 23.38,
+                    "y": 11.24,
+                    "z": 20
+                },
+                "H3": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 32.38,
+                    "y": 11.24,
+                    "z": 20
+                },
+                "H4": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 41.38,
+                    "y": 11.24,
+                    "z": 20
+                },
+                "H5": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 50.38,
+                    "y": 11.24,
+                    "z": 20
+                },
+                "H6": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 59.38,
+                    "y": 11.24,
+                    "z": 20
+                },
+                "H7": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 68.38,
+                    "y": 11.24,
+                    "z": 20
+                },
+                "H8": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 77.38,
+                    "y": 11.24,
+                    "z": 20
+                },
+                "H9": {
+                    "depth": 50,
+                    "diameter": 5.2,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 86.38,
+                    "y": 11.24,
+                    "z": 20
                 }
             }
         }

--- a/protoBuilds/5f37a2/5fe7a2.ot2.apiv2.py.json
+++ b/protoBuilds/5f37a2/5fe7a2.ot2.apiv2.py.json
@@ -14,6 +14,1137 @@
             "dimensions": {
                 "xDimension": 127.8,
                 "yDimension": 85.5,
+                "zDimension": 27.1
+            },
+            "groups": [
+                {
+                    "brand": {
+                        "brand": "eppendorf",
+                        "brandId": []
+                    },
+                    "metadata": {
+                        "displayCategory": "wellPlate",
+                        "displayName": "Eppendorf 96 Well Plate 500 \u00b5L",
+                        "wellBottomShape": "v"
+                    },
+                    "wells": [
+                        "A1",
+                        "B1",
+                        "C1",
+                        "D1",
+                        "E1",
+                        "F1",
+                        "G1",
+                        "H1",
+                        "A2",
+                        "B2",
+                        "C2",
+                        "D2",
+                        "E2",
+                        "F2",
+                        "G2",
+                        "H2",
+                        "A3",
+                        "B3",
+                        "C3",
+                        "D3",
+                        "E3",
+                        "F3",
+                        "G3",
+                        "H3",
+                        "A4",
+                        "B4",
+                        "C4",
+                        "D4",
+                        "E4",
+                        "F4",
+                        "G4",
+                        "H4",
+                        "A5",
+                        "B5",
+                        "C5",
+                        "D5",
+                        "E5",
+                        "F5",
+                        "G5",
+                        "H5",
+                        "A6",
+                        "B6",
+                        "C6",
+                        "D6",
+                        "E6",
+                        "F6",
+                        "G6",
+                        "H6",
+                        "A7",
+                        "B7",
+                        "C7",
+                        "D7",
+                        "E7",
+                        "F7",
+                        "G7",
+                        "H7",
+                        "A8",
+                        "B8",
+                        "C8",
+                        "D8",
+                        "E8",
+                        "F8",
+                        "G8",
+                        "H8",
+                        "A9",
+                        "B9",
+                        "C9",
+                        "D9",
+                        "E9",
+                        "F9",
+                        "G9",
+                        "H9",
+                        "A10",
+                        "B10",
+                        "C10",
+                        "D10",
+                        "E10",
+                        "F10",
+                        "G10",
+                        "H10",
+                        "A11",
+                        "B11",
+                        "C11",
+                        "D11",
+                        "E11",
+                        "F11",
+                        "G11",
+                        "H11",
+                        "A12",
+                        "B12",
+                        "C12",
+                        "D12",
+                        "E12",
+                        "F12",
+                        "G12",
+                        "H12"
+                    ]
+                }
+            ],
+            "metadata": {
+                "displayCategory": "wellPlate",
+                "displayName": "Eppendorf 96 Well Plate 500 \u00b5L",
+                "displayVolumeUnits": "\u00b5L",
+                "tags": []
+            },
+            "namespace": "custom_beta",
+            "ordering": [
+                [
+                    "A1",
+                    "B1",
+                    "C1",
+                    "D1",
+                    "E1",
+                    "F1",
+                    "G1",
+                    "H1"
+                ],
+                [
+                    "A2",
+                    "B2",
+                    "C2",
+                    "D2",
+                    "E2",
+                    "F2",
+                    "G2",
+                    "H2"
+                ],
+                [
+                    "A3",
+                    "B3",
+                    "C3",
+                    "D3",
+                    "E3",
+                    "F3",
+                    "G3",
+                    "H3"
+                ],
+                [
+                    "A4",
+                    "B4",
+                    "C4",
+                    "D4",
+                    "E4",
+                    "F4",
+                    "G4",
+                    "H4"
+                ],
+                [
+                    "A5",
+                    "B5",
+                    "C5",
+                    "D5",
+                    "E5",
+                    "F5",
+                    "G5",
+                    "H5"
+                ],
+                [
+                    "A6",
+                    "B6",
+                    "C6",
+                    "D6",
+                    "E6",
+                    "F6",
+                    "G6",
+                    "H6"
+                ],
+                [
+                    "A7",
+                    "B7",
+                    "C7",
+                    "D7",
+                    "E7",
+                    "F7",
+                    "G7",
+                    "H7"
+                ],
+                [
+                    "A8",
+                    "B8",
+                    "C8",
+                    "D8",
+                    "E8",
+                    "F8",
+                    "G8",
+                    "H8"
+                ],
+                [
+                    "A9",
+                    "B9",
+                    "C9",
+                    "D9",
+                    "E9",
+                    "F9",
+                    "G9",
+                    "H9"
+                ],
+                [
+                    "A10",
+                    "B10",
+                    "C10",
+                    "D10",
+                    "E10",
+                    "F10",
+                    "G10",
+                    "H10"
+                ],
+                [
+                    "A11",
+                    "B11",
+                    "C11",
+                    "D11",
+                    "E11",
+                    "F11",
+                    "G11",
+                    "H11"
+                ],
+                [
+                    "A12",
+                    "B12",
+                    "C12",
+                    "D12",
+                    "E12",
+                    "F12",
+                    "G12",
+                    "H12"
+                ]
+            ],
+            "parameters": {
+                "format": "irregular",
+                "isMagneticModuleCompatible": false,
+                "isTiprack": false,
+                "loadName": "eppendorf_96_deepwellplate_500ul",
+                "quirks": []
+            },
+            "schemaVersion": 2,
+            "version": 1,
+            "wells": {
+                "A1": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 14.4,
+                    "y": 74.3,
+                    "z": 3.1
+                },
+                "A10": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 95.4,
+                    "y": 74.3,
+                    "z": 3.1
+                },
+                "A11": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 104.4,
+                    "y": 74.3,
+                    "z": 3.1
+                },
+                "A12": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 113.4,
+                    "y": 74.3,
+                    "z": 3.1
+                },
+                "A2": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 23.4,
+                    "y": 74.3,
+                    "z": 3.1
+                },
+                "A3": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 32.4,
+                    "y": 74.3,
+                    "z": 3.1
+                },
+                "A4": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 41.4,
+                    "y": 74.3,
+                    "z": 3.1
+                },
+                "A5": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 50.4,
+                    "y": 74.3,
+                    "z": 3.1
+                },
+                "A6": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 59.4,
+                    "y": 74.3,
+                    "z": 3.1
+                },
+                "A7": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 68.4,
+                    "y": 74.3,
+                    "z": 3.1
+                },
+                "A8": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 77.4,
+                    "y": 74.3,
+                    "z": 3.1
+                },
+                "A9": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 86.4,
+                    "y": 74.3,
+                    "z": 3.1
+                },
+                "B1": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 14.4,
+                    "y": 65.3,
+                    "z": 3.1
+                },
+                "B10": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 95.4,
+                    "y": 65.3,
+                    "z": 3.1
+                },
+                "B11": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 104.4,
+                    "y": 65.3,
+                    "z": 3.1
+                },
+                "B12": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 113.4,
+                    "y": 65.3,
+                    "z": 3.1
+                },
+                "B2": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 23.4,
+                    "y": 65.3,
+                    "z": 3.1
+                },
+                "B3": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 32.4,
+                    "y": 65.3,
+                    "z": 3.1
+                },
+                "B4": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 41.4,
+                    "y": 65.3,
+                    "z": 3.1
+                },
+                "B5": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 50.4,
+                    "y": 65.3,
+                    "z": 3.1
+                },
+                "B6": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 59.4,
+                    "y": 65.3,
+                    "z": 3.1
+                },
+                "B7": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 68.4,
+                    "y": 65.3,
+                    "z": 3.1
+                },
+                "B8": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 77.4,
+                    "y": 65.3,
+                    "z": 3.1
+                },
+                "B9": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 86.4,
+                    "y": 65.3,
+                    "z": 3.1
+                },
+                "C1": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 14.4,
+                    "y": 56.3,
+                    "z": 3.1
+                },
+                "C10": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 95.4,
+                    "y": 56.3,
+                    "z": 3.1
+                },
+                "C11": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 104.4,
+                    "y": 56.3,
+                    "z": 3.1
+                },
+                "C12": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 113.4,
+                    "y": 56.3,
+                    "z": 3.1
+                },
+                "C2": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 23.4,
+                    "y": 56.3,
+                    "z": 3.1
+                },
+                "C3": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 32.4,
+                    "y": 56.3,
+                    "z": 3.1
+                },
+                "C4": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 41.4,
+                    "y": 56.3,
+                    "z": 3.1
+                },
+                "C5": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 50.4,
+                    "y": 56.3,
+                    "z": 3.1
+                },
+                "C6": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 59.4,
+                    "y": 56.3,
+                    "z": 3.1
+                },
+                "C7": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 68.4,
+                    "y": 56.3,
+                    "z": 3.1
+                },
+                "C8": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 77.4,
+                    "y": 56.3,
+                    "z": 3.1
+                },
+                "C9": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 86.4,
+                    "y": 56.3,
+                    "z": 3.1
+                },
+                "D1": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 14.4,
+                    "y": 47.3,
+                    "z": 3.1
+                },
+                "D10": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 95.4,
+                    "y": 47.3,
+                    "z": 3.1
+                },
+                "D11": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 104.4,
+                    "y": 47.3,
+                    "z": 3.1
+                },
+                "D12": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 113.4,
+                    "y": 47.3,
+                    "z": 3.1
+                },
+                "D2": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 23.4,
+                    "y": 47.3,
+                    "z": 3.1
+                },
+                "D3": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 32.4,
+                    "y": 47.3,
+                    "z": 3.1
+                },
+                "D4": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 41.4,
+                    "y": 47.3,
+                    "z": 3.1
+                },
+                "D5": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 50.4,
+                    "y": 47.3,
+                    "z": 3.1
+                },
+                "D6": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 59.4,
+                    "y": 47.3,
+                    "z": 3.1
+                },
+                "D7": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 68.4,
+                    "y": 47.3,
+                    "z": 3.1
+                },
+                "D8": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 77.4,
+                    "y": 47.3,
+                    "z": 3.1
+                },
+                "D9": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 86.4,
+                    "y": 47.3,
+                    "z": 3.1
+                },
+                "E1": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 14.4,
+                    "y": 38.3,
+                    "z": 3.1
+                },
+                "E10": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 95.4,
+                    "y": 38.3,
+                    "z": 3.1
+                },
+                "E11": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 104.4,
+                    "y": 38.3,
+                    "z": 3.1
+                },
+                "E12": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 113.4,
+                    "y": 38.3,
+                    "z": 3.1
+                },
+                "E2": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 23.4,
+                    "y": 38.3,
+                    "z": 3.1
+                },
+                "E3": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 32.4,
+                    "y": 38.3,
+                    "z": 3.1
+                },
+                "E4": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 41.4,
+                    "y": 38.3,
+                    "z": 3.1
+                },
+                "E5": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 50.4,
+                    "y": 38.3,
+                    "z": 3.1
+                },
+                "E6": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 59.4,
+                    "y": 38.3,
+                    "z": 3.1
+                },
+                "E7": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 68.4,
+                    "y": 38.3,
+                    "z": 3.1
+                },
+                "E8": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 77.4,
+                    "y": 38.3,
+                    "z": 3.1
+                },
+                "E9": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 86.4,
+                    "y": 38.3,
+                    "z": 3.1
+                },
+                "F1": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 14.4,
+                    "y": 29.3,
+                    "z": 3.1
+                },
+                "F10": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 95.4,
+                    "y": 29.3,
+                    "z": 3.1
+                },
+                "F11": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 104.4,
+                    "y": 29.3,
+                    "z": 3.1
+                },
+                "F12": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 113.4,
+                    "y": 29.3,
+                    "z": 3.1
+                },
+                "F2": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 23.4,
+                    "y": 29.3,
+                    "z": 3.1
+                },
+                "F3": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 32.4,
+                    "y": 29.3,
+                    "z": 3.1
+                },
+                "F4": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 41.4,
+                    "y": 29.3,
+                    "z": 3.1
+                },
+                "F5": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 50.4,
+                    "y": 29.3,
+                    "z": 3.1
+                },
+                "F6": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 59.4,
+                    "y": 29.3,
+                    "z": 3.1
+                },
+                "F7": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 68.4,
+                    "y": 29.3,
+                    "z": 3.1
+                },
+                "F8": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 77.4,
+                    "y": 29.3,
+                    "z": 3.1
+                },
+                "F9": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 86.4,
+                    "y": 29.3,
+                    "z": 3.1
+                },
+                "G1": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 14.4,
+                    "y": 20.3,
+                    "z": 3.1
+                },
+                "G10": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 95.4,
+                    "y": 20.3,
+                    "z": 3.1
+                },
+                "G11": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 104.4,
+                    "y": 20.3,
+                    "z": 3.1
+                },
+                "G12": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 113.4,
+                    "y": 20.3,
+                    "z": 3.1
+                },
+                "G2": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 23.4,
+                    "y": 20.3,
+                    "z": 3.1
+                },
+                "G3": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 32.4,
+                    "y": 20.3,
+                    "z": 3.1
+                },
+                "G4": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 41.4,
+                    "y": 20.3,
+                    "z": 3.1
+                },
+                "G5": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 50.4,
+                    "y": 20.3,
+                    "z": 3.1
+                },
+                "G6": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 59.4,
+                    "y": 20.3,
+                    "z": 3.1
+                },
+                "G7": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 68.4,
+                    "y": 20.3,
+                    "z": 3.1
+                },
+                "G8": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 77.4,
+                    "y": 20.3,
+                    "z": 3.1
+                },
+                "G9": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 86.4,
+                    "y": 20.3,
+                    "z": 3.1
+                },
+                "H1": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 14.4,
+                    "y": 11.3,
+                    "z": 3.1
+                },
+                "H10": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 95.4,
+                    "y": 11.3,
+                    "z": 3.1
+                },
+                "H11": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 104.4,
+                    "y": 11.3,
+                    "z": 3.1
+                },
+                "H12": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 113.4,
+                    "y": 11.3,
+                    "z": 3.1
+                },
+                "H2": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 23.4,
+                    "y": 11.3,
+                    "z": 3.1
+                },
+                "H3": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 32.4,
+                    "y": 11.3,
+                    "z": 3.1
+                },
+                "H4": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 41.4,
+                    "y": 11.3,
+                    "z": 3.1
+                },
+                "H5": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 50.4,
+                    "y": 11.3,
+                    "z": 3.1
+                },
+                "H6": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 59.4,
+                    "y": 11.3,
+                    "z": 3.1
+                },
+                "H7": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 68.4,
+                    "y": 11.3,
+                    "z": 3.1
+                },
+                "H8": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 77.4,
+                    "y": 11.3,
+                    "z": 3.1
+                },
+                "H9": {
+                    "depth": 24,
+                    "diameter": 7,
+                    "shape": "circular",
+                    "totalLiquidVolume": 500,
+                    "x": 86.4,
+                    "y": 11.3,
+                    "z": 3.1
+                }
+            }
+        },
+        {
+            "brand": {
+                "brand": "eppendorf",
+                "brandId": []
+            },
+            "cornerOffsetFromSlot": {
+                "x": 0,
+                "y": 0,
+                "z": 0
+            },
+            "dimensions": {
+                "xDimension": 127.8,
+                "yDimension": 85.5,
                 "zDimension": 44.1
             },
             "groups": [
@@ -1227,1137 +2358,6 @@
                     "z": 6
                 }
             }
-        },
-        {
-            "brand": {
-                "brand": "eppendorf",
-                "brandId": []
-            },
-            "cornerOffsetFromSlot": {
-                "x": 0,
-                "y": 0,
-                "z": 0
-            },
-            "dimensions": {
-                "xDimension": 127.8,
-                "yDimension": 85.5,
-                "zDimension": 27.1
-            },
-            "groups": [
-                {
-                    "brand": {
-                        "brand": "eppendorf",
-                        "brandId": []
-                    },
-                    "metadata": {
-                        "displayCategory": "wellPlate",
-                        "displayName": "Eppendorf 96 Well Plate 500 \u00b5L",
-                        "wellBottomShape": "v"
-                    },
-                    "wells": [
-                        "A1",
-                        "B1",
-                        "C1",
-                        "D1",
-                        "E1",
-                        "F1",
-                        "G1",
-                        "H1",
-                        "A2",
-                        "B2",
-                        "C2",
-                        "D2",
-                        "E2",
-                        "F2",
-                        "G2",
-                        "H2",
-                        "A3",
-                        "B3",
-                        "C3",
-                        "D3",
-                        "E3",
-                        "F3",
-                        "G3",
-                        "H3",
-                        "A4",
-                        "B4",
-                        "C4",
-                        "D4",
-                        "E4",
-                        "F4",
-                        "G4",
-                        "H4",
-                        "A5",
-                        "B5",
-                        "C5",
-                        "D5",
-                        "E5",
-                        "F5",
-                        "G5",
-                        "H5",
-                        "A6",
-                        "B6",
-                        "C6",
-                        "D6",
-                        "E6",
-                        "F6",
-                        "G6",
-                        "H6",
-                        "A7",
-                        "B7",
-                        "C7",
-                        "D7",
-                        "E7",
-                        "F7",
-                        "G7",
-                        "H7",
-                        "A8",
-                        "B8",
-                        "C8",
-                        "D8",
-                        "E8",
-                        "F8",
-                        "G8",
-                        "H8",
-                        "A9",
-                        "B9",
-                        "C9",
-                        "D9",
-                        "E9",
-                        "F9",
-                        "G9",
-                        "H9",
-                        "A10",
-                        "B10",
-                        "C10",
-                        "D10",
-                        "E10",
-                        "F10",
-                        "G10",
-                        "H10",
-                        "A11",
-                        "B11",
-                        "C11",
-                        "D11",
-                        "E11",
-                        "F11",
-                        "G11",
-                        "H11",
-                        "A12",
-                        "B12",
-                        "C12",
-                        "D12",
-                        "E12",
-                        "F12",
-                        "G12",
-                        "H12"
-                    ]
-                }
-            ],
-            "metadata": {
-                "displayCategory": "wellPlate",
-                "displayName": "Eppendorf 96 Well Plate 500 \u00b5L",
-                "displayVolumeUnits": "\u00b5L",
-                "tags": []
-            },
-            "namespace": "custom_beta",
-            "ordering": [
-                [
-                    "A1",
-                    "B1",
-                    "C1",
-                    "D1",
-                    "E1",
-                    "F1",
-                    "G1",
-                    "H1"
-                ],
-                [
-                    "A2",
-                    "B2",
-                    "C2",
-                    "D2",
-                    "E2",
-                    "F2",
-                    "G2",
-                    "H2"
-                ],
-                [
-                    "A3",
-                    "B3",
-                    "C3",
-                    "D3",
-                    "E3",
-                    "F3",
-                    "G3",
-                    "H3"
-                ],
-                [
-                    "A4",
-                    "B4",
-                    "C4",
-                    "D4",
-                    "E4",
-                    "F4",
-                    "G4",
-                    "H4"
-                ],
-                [
-                    "A5",
-                    "B5",
-                    "C5",
-                    "D5",
-                    "E5",
-                    "F5",
-                    "G5",
-                    "H5"
-                ],
-                [
-                    "A6",
-                    "B6",
-                    "C6",
-                    "D6",
-                    "E6",
-                    "F6",
-                    "G6",
-                    "H6"
-                ],
-                [
-                    "A7",
-                    "B7",
-                    "C7",
-                    "D7",
-                    "E7",
-                    "F7",
-                    "G7",
-                    "H7"
-                ],
-                [
-                    "A8",
-                    "B8",
-                    "C8",
-                    "D8",
-                    "E8",
-                    "F8",
-                    "G8",
-                    "H8"
-                ],
-                [
-                    "A9",
-                    "B9",
-                    "C9",
-                    "D9",
-                    "E9",
-                    "F9",
-                    "G9",
-                    "H9"
-                ],
-                [
-                    "A10",
-                    "B10",
-                    "C10",
-                    "D10",
-                    "E10",
-                    "F10",
-                    "G10",
-                    "H10"
-                ],
-                [
-                    "A11",
-                    "B11",
-                    "C11",
-                    "D11",
-                    "E11",
-                    "F11",
-                    "G11",
-                    "H11"
-                ],
-                [
-                    "A12",
-                    "B12",
-                    "C12",
-                    "D12",
-                    "E12",
-                    "F12",
-                    "G12",
-                    "H12"
-                ]
-            ],
-            "parameters": {
-                "format": "irregular",
-                "isMagneticModuleCompatible": false,
-                "isTiprack": false,
-                "loadName": "eppendorf_96_deepwellplate_500ul",
-                "quirks": []
-            },
-            "schemaVersion": 2,
-            "version": 1,
-            "wells": {
-                "A1": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 14.4,
-                    "y": 74.3,
-                    "z": 3.1
-                },
-                "A10": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 95.4,
-                    "y": 74.3,
-                    "z": 3.1
-                },
-                "A11": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 104.4,
-                    "y": 74.3,
-                    "z": 3.1
-                },
-                "A12": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 113.4,
-                    "y": 74.3,
-                    "z": 3.1
-                },
-                "A2": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 23.4,
-                    "y": 74.3,
-                    "z": 3.1
-                },
-                "A3": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 32.4,
-                    "y": 74.3,
-                    "z": 3.1
-                },
-                "A4": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 41.4,
-                    "y": 74.3,
-                    "z": 3.1
-                },
-                "A5": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 50.4,
-                    "y": 74.3,
-                    "z": 3.1
-                },
-                "A6": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 59.4,
-                    "y": 74.3,
-                    "z": 3.1
-                },
-                "A7": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 68.4,
-                    "y": 74.3,
-                    "z": 3.1
-                },
-                "A8": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 77.4,
-                    "y": 74.3,
-                    "z": 3.1
-                },
-                "A9": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 86.4,
-                    "y": 74.3,
-                    "z": 3.1
-                },
-                "B1": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 14.4,
-                    "y": 65.3,
-                    "z": 3.1
-                },
-                "B10": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 95.4,
-                    "y": 65.3,
-                    "z": 3.1
-                },
-                "B11": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 104.4,
-                    "y": 65.3,
-                    "z": 3.1
-                },
-                "B12": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 113.4,
-                    "y": 65.3,
-                    "z": 3.1
-                },
-                "B2": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 23.4,
-                    "y": 65.3,
-                    "z": 3.1
-                },
-                "B3": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 32.4,
-                    "y": 65.3,
-                    "z": 3.1
-                },
-                "B4": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 41.4,
-                    "y": 65.3,
-                    "z": 3.1
-                },
-                "B5": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 50.4,
-                    "y": 65.3,
-                    "z": 3.1
-                },
-                "B6": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 59.4,
-                    "y": 65.3,
-                    "z": 3.1
-                },
-                "B7": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 68.4,
-                    "y": 65.3,
-                    "z": 3.1
-                },
-                "B8": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 77.4,
-                    "y": 65.3,
-                    "z": 3.1
-                },
-                "B9": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 86.4,
-                    "y": 65.3,
-                    "z": 3.1
-                },
-                "C1": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 14.4,
-                    "y": 56.3,
-                    "z": 3.1
-                },
-                "C10": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 95.4,
-                    "y": 56.3,
-                    "z": 3.1
-                },
-                "C11": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 104.4,
-                    "y": 56.3,
-                    "z": 3.1
-                },
-                "C12": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 113.4,
-                    "y": 56.3,
-                    "z": 3.1
-                },
-                "C2": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 23.4,
-                    "y": 56.3,
-                    "z": 3.1
-                },
-                "C3": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 32.4,
-                    "y": 56.3,
-                    "z": 3.1
-                },
-                "C4": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 41.4,
-                    "y": 56.3,
-                    "z": 3.1
-                },
-                "C5": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 50.4,
-                    "y": 56.3,
-                    "z": 3.1
-                },
-                "C6": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 59.4,
-                    "y": 56.3,
-                    "z": 3.1
-                },
-                "C7": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 68.4,
-                    "y": 56.3,
-                    "z": 3.1
-                },
-                "C8": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 77.4,
-                    "y": 56.3,
-                    "z": 3.1
-                },
-                "C9": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 86.4,
-                    "y": 56.3,
-                    "z": 3.1
-                },
-                "D1": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 14.4,
-                    "y": 47.3,
-                    "z": 3.1
-                },
-                "D10": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 95.4,
-                    "y": 47.3,
-                    "z": 3.1
-                },
-                "D11": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 104.4,
-                    "y": 47.3,
-                    "z": 3.1
-                },
-                "D12": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 113.4,
-                    "y": 47.3,
-                    "z": 3.1
-                },
-                "D2": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 23.4,
-                    "y": 47.3,
-                    "z": 3.1
-                },
-                "D3": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 32.4,
-                    "y": 47.3,
-                    "z": 3.1
-                },
-                "D4": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 41.4,
-                    "y": 47.3,
-                    "z": 3.1
-                },
-                "D5": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 50.4,
-                    "y": 47.3,
-                    "z": 3.1
-                },
-                "D6": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 59.4,
-                    "y": 47.3,
-                    "z": 3.1
-                },
-                "D7": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 68.4,
-                    "y": 47.3,
-                    "z": 3.1
-                },
-                "D8": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 77.4,
-                    "y": 47.3,
-                    "z": 3.1
-                },
-                "D9": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 86.4,
-                    "y": 47.3,
-                    "z": 3.1
-                },
-                "E1": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 14.4,
-                    "y": 38.3,
-                    "z": 3.1
-                },
-                "E10": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 95.4,
-                    "y": 38.3,
-                    "z": 3.1
-                },
-                "E11": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 104.4,
-                    "y": 38.3,
-                    "z": 3.1
-                },
-                "E12": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 113.4,
-                    "y": 38.3,
-                    "z": 3.1
-                },
-                "E2": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 23.4,
-                    "y": 38.3,
-                    "z": 3.1
-                },
-                "E3": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 32.4,
-                    "y": 38.3,
-                    "z": 3.1
-                },
-                "E4": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 41.4,
-                    "y": 38.3,
-                    "z": 3.1
-                },
-                "E5": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 50.4,
-                    "y": 38.3,
-                    "z": 3.1
-                },
-                "E6": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 59.4,
-                    "y": 38.3,
-                    "z": 3.1
-                },
-                "E7": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 68.4,
-                    "y": 38.3,
-                    "z": 3.1
-                },
-                "E8": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 77.4,
-                    "y": 38.3,
-                    "z": 3.1
-                },
-                "E9": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 86.4,
-                    "y": 38.3,
-                    "z": 3.1
-                },
-                "F1": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 14.4,
-                    "y": 29.3,
-                    "z": 3.1
-                },
-                "F10": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 95.4,
-                    "y": 29.3,
-                    "z": 3.1
-                },
-                "F11": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 104.4,
-                    "y": 29.3,
-                    "z": 3.1
-                },
-                "F12": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 113.4,
-                    "y": 29.3,
-                    "z": 3.1
-                },
-                "F2": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 23.4,
-                    "y": 29.3,
-                    "z": 3.1
-                },
-                "F3": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 32.4,
-                    "y": 29.3,
-                    "z": 3.1
-                },
-                "F4": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 41.4,
-                    "y": 29.3,
-                    "z": 3.1
-                },
-                "F5": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 50.4,
-                    "y": 29.3,
-                    "z": 3.1
-                },
-                "F6": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 59.4,
-                    "y": 29.3,
-                    "z": 3.1
-                },
-                "F7": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 68.4,
-                    "y": 29.3,
-                    "z": 3.1
-                },
-                "F8": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 77.4,
-                    "y": 29.3,
-                    "z": 3.1
-                },
-                "F9": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 86.4,
-                    "y": 29.3,
-                    "z": 3.1
-                },
-                "G1": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 14.4,
-                    "y": 20.3,
-                    "z": 3.1
-                },
-                "G10": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 95.4,
-                    "y": 20.3,
-                    "z": 3.1
-                },
-                "G11": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 104.4,
-                    "y": 20.3,
-                    "z": 3.1
-                },
-                "G12": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 113.4,
-                    "y": 20.3,
-                    "z": 3.1
-                },
-                "G2": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 23.4,
-                    "y": 20.3,
-                    "z": 3.1
-                },
-                "G3": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 32.4,
-                    "y": 20.3,
-                    "z": 3.1
-                },
-                "G4": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 41.4,
-                    "y": 20.3,
-                    "z": 3.1
-                },
-                "G5": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 50.4,
-                    "y": 20.3,
-                    "z": 3.1
-                },
-                "G6": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 59.4,
-                    "y": 20.3,
-                    "z": 3.1
-                },
-                "G7": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 68.4,
-                    "y": 20.3,
-                    "z": 3.1
-                },
-                "G8": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 77.4,
-                    "y": 20.3,
-                    "z": 3.1
-                },
-                "G9": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 86.4,
-                    "y": 20.3,
-                    "z": 3.1
-                },
-                "H1": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 14.4,
-                    "y": 11.3,
-                    "z": 3.1
-                },
-                "H10": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 95.4,
-                    "y": 11.3,
-                    "z": 3.1
-                },
-                "H11": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 104.4,
-                    "y": 11.3,
-                    "z": 3.1
-                },
-                "H12": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 113.4,
-                    "y": 11.3,
-                    "z": 3.1
-                },
-                "H2": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 23.4,
-                    "y": 11.3,
-                    "z": 3.1
-                },
-                "H3": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 32.4,
-                    "y": 11.3,
-                    "z": 3.1
-                },
-                "H4": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 41.4,
-                    "y": 11.3,
-                    "z": 3.1
-                },
-                "H5": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 50.4,
-                    "y": 11.3,
-                    "z": 3.1
-                },
-                "H6": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 59.4,
-                    "y": 11.3,
-                    "z": 3.1
-                },
-                "H7": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 68.4,
-                    "y": 11.3,
-                    "z": 3.1
-                },
-                "H8": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 77.4,
-                    "y": 11.3,
-                    "z": 3.1
-                },
-                "H9": {
-                    "depth": 24,
-                    "diameter": 7,
-                    "shape": "circular",
-                    "totalLiquidVolume": 500,
-                    "x": 86.4,
-                    "y": 11.3,
-                    "z": 3.1
-                }
-            }
         }
     ],
     "fields": [],
@@ -2423,7 +2423,7 @@
             "type": "eppendorf_96_deepwellplate_500ul"
         },
         {
-            "name": "Eppendorf DWP 2000ul on Magnetic Module on 10",
+            "name": "Eppendorf DWP 2000ul on Magnetic Module GEN1 on 10",
             "share": false,
             "slot": "10",
             "type": "eppendorf_96_deepwellplate_2000ul"

--- a/protoBuilds/6030b7/ngs_library_prep.ot2.apiv2.py.json
+++ b/protoBuilds/6030b7/ngs_library_prep.ot2.apiv2.py.json
@@ -1205,7 +1205,7 @@
             "type": "nest_12_reservoir_15ml"
         },
         {
-            "name": "NEST 96 Well Plate 100 \u00b5L PCR Full Skirt on Magnetic Module on 4",
+            "name": "NEST 96 Well Plate 100 \u00b5L PCR Full Skirt on Magnetic Module GEN1 on 4",
             "share": false,
             "slot": "4",
             "type": "nest_96_wellplate_100ul_pcr_full_skirt"
@@ -1223,7 +1223,7 @@
             "type": "opentrons_96_tiprack_20ul"
         },
         {
-            "name": "Opentrons 24 Well Aluminum Block with NEST 1.5 mL Snapcap on Temperature Module on 7",
+            "name": "Opentrons 24 Well Aluminum Block with NEST 1.5 mL Snapcap on Temperature Module GEN1 on 7",
             "share": false,
             "slot": "7",
             "type": "opentrons_24_aluminumblock_nest_1.5ml_snapcap"

--- a/protoBuilds/6f4e2c/6f4e2c.ot2.apiv2.py.json
+++ b/protoBuilds/6f4e2c/6f4e2c.ot2.apiv2.py.json
@@ -1203,7 +1203,7 @@
     ],
     "labware": [
         {
-            "name": "Eppendorf 96 Deep Well Plate 1000\u00b5L on Magnetic Module on 1",
+            "name": "Eppendorf 96 Deep Well Plate 1000\u00b5L on Magnetic Module GEN1 on 1",
             "share": false,
             "slot": "1",
             "type": "eppendorf_96_wellplate_1000ul"
@@ -1221,7 +1221,7 @@
             "type": "opentrons_96_tiprack_300ul"
         },
         {
-            "name": "Eppendorf 96 Deep Well Plate 1000\u00b5L on Temperature Module on 4",
+            "name": "Eppendorf 96 Deep Well Plate 1000\u00b5L on Temperature Module GEN1 on 4",
             "share": false,
             "slot": "4",
             "type": "eppendorf_96_wellplate_1000ul"

--- a/protoBuilds/7aa3fd-library-pooling/lib_pooling.ot2.apiv2.py.json
+++ b/protoBuilds/7aa3fd-library-pooling/lib_pooling.ot2.apiv2.py.json
@@ -1201,7 +1201,7 @@
             "type": "opentrons_96_filtertiprack_10ul"
         },
         {
-            "name": "Opentrons 24 Well Aluminum Block with NEST 2 mL Snapcap on Temperature Module on 4",
+            "name": "Opentrons 24 Well Aluminum Block with NEST 2 mL Snapcap on Temperature Module GEN1 on 4",
             "share": false,
             "slot": "4",
             "type": "opentrons_24_aluminumblock_nest_2ml_snapcap"

--- a/protoBuilds/7aa3fd-library-quantification/lib_quant.ot2.apiv2.py.json
+++ b/protoBuilds/7aa3fd-library-quantification/lib_quant.ot2.apiv2.py.json
@@ -1189,7 +1189,7 @@
             "type": "opentrons_96_filtertiprack_10ul"
         },
         {
-            "name": "Eppendorf Twin.tec 96 Well Plate 150 \u00b5L on Temperature Module on 4",
+            "name": "Eppendorf Twin.tec 96 Well Plate 150 \u00b5L on Temperature Module GEN1 on 4",
             "share": false,
             "slot": "4",
             "type": "eppendorftwin.tec_96_wellplate_150ul"

--- a/protoBuilds/7aa3fd-size-selection/size_selection.ot2.apiv2.py.json
+++ b/protoBuilds/7aa3fd-size-selection/size_selection.ot2.apiv2.py.json
@@ -1210,7 +1210,7 @@
     ],
     "labware": [
         {
-            "name": "Eppendorf Twin.tec 96 Well Plate 150 \u00b5L on Magnetic Module on 1",
+            "name": "Eppendorf Twin.tec 96 Well Plate 150 \u00b5L on Magnetic Module GEN1 on 1",
             "share": false,
             "slot": "1",
             "type": "eppendorftwin.tec_96_wellplate_150ul"

--- a/protoBuilds/bpg-rna-extraction/bpg-rna-extraction.ot2.apiv2.py.json
+++ b/protoBuilds/bpg-rna-extraction/bpg-rna-extraction.ot2.apiv2.py.json
@@ -1216,7 +1216,7 @@
             "type": "opentrons_96_tiprack_20ul"
         },
         {
-            "name": "NEST 1mL Deep Well Plate on Magnetic Module on 4",
+            "name": "NEST 1mL Deep Well Plate on Magnetic Module GEN1 on 4",
             "share": false,
             "slot": "4",
             "type": "nest_96_wellplate_1000ul"

--- a/protoBuilds/illumina-nextera-XT-library-prep-part2/nexteraXT_dna_library_prep_part2.ot2.apiv2.py.json
+++ b/protoBuilds/illumina-nextera-XT-library-prep-part2/nexteraXT_dna_library_prep_part2.ot2.apiv2.py.json
@@ -81,7 +81,7 @@
             "type": "usascientific_12_reservoir_22ml"
         },
         {
-            "name": "Bio-Rad 96 Well Plate 200 \u00b5L PCR on Magnetic Module on 4",
+            "name": "Bio-Rad 96 Well Plate 200 \u00b5L PCR on Magnetic Module GEN1 on 4",
             "share": false,
             "slot": "4",
             "type": "biorad_96_wellplate_200ul_pcr"

--- a/protoBuilds/illumina-nextera-XT-library-prep-part3/nexteraXT_dna_library_prep_part3.ot2.apiv2.py.json
+++ b/protoBuilds/illumina-nextera-XT-library-prep-part3/nexteraXT_dna_library_prep_part3.ot2.apiv2.py.json
@@ -63,7 +63,7 @@
             "type": "usascientific_12_reservoir_22ml"
         },
         {
-            "name": "Bio-Rad 96 Well Plate 200 \u00b5L PCR on Magnetic Module on 4",
+            "name": "Bio-Rad 96 Well Plate 200 \u00b5L PCR on Magnetic Module GEN1 on 4",
             "share": false,
             "slot": "4",
             "type": "biorad_96_wellplate_200ul_pcr"

--- a/protoBuilds/nextera-flex-library-prep-amplify-tagmented-dna/nextera_flex_amplify_tagmented_dna.ot2.apiv2.py.json
+++ b/protoBuilds/nextera-flex-library-prep-amplify-tagmented-dna/nextera_flex_amplify_tagmented_dna.ot2.apiv2.py.json
@@ -66,13 +66,13 @@
     ],
     "labware": [
         {
-            "name": "1 on Magnetic Module on 1",
+            "name": "1 on Magnetic Module GEN1 on 1",
             "share": false,
             "slot": "1",
             "type": "biorad_96_wellplate_200ul_pcr"
         },
         {
-            "name": "4 on Temperature Module on 4",
+            "name": "4 on Temperature Module GEN1 on 4",
             "share": false,
             "slot": "4",
             "type": "opentrons_24_aluminumblock_nest_1.5ml_snapcap"

--- a/protoBuilds/nextera-flex-library-prep-cleanup-libraries/nextera_flex_cleanup_libraries.ot2.apiv2.py.json
+++ b/protoBuilds/nextera-flex-library-prep-cleanup-libraries/nextera_flex_cleanup_libraries.ot2.apiv2.py.json
@@ -81,7 +81,7 @@
     ],
     "labware": [
         {
-            "name": "Bio-Rad 96 Well Plate 200 \u00b5L PCR on Magnetic Module on 1",
+            "name": "Bio-Rad 96 Well Plate 200 \u00b5L PCR on Magnetic Module GEN1 on 1",
             "share": false,
             "slot": "1",
             "type": "biorad_96_wellplate_200ul_pcr"

--- a/protoBuilds/nextera-flex-library-prep-post-tag-cleanup/nextera_flex_post_tag_cleanup.ot2.apiv2.py.json
+++ b/protoBuilds/nextera-flex-library-prep-post-tag-cleanup/nextera_flex_post_tag_cleanup.ot2.apiv2.py.json
@@ -47,7 +47,7 @@
     ],
     "labware": [
         {
-            "name": "1 on Magnetic Module on 1",
+            "name": "1 on Magnetic Module GEN1 on 1",
             "share": false,
             "slot": "1",
             "type": "biorad_96_wellplate_200ul_pcr"

--- a/protoBuilds/nucleic_acid_purification_with_magnetic_beads/dna_purification.ot2.apiv2.py.json
+++ b/protoBuilds/nucleic_acid_purification_with_magnetic_beads/dna_purification.ot2.apiv2.py.json
@@ -123,7 +123,7 @@
     ],
     "labware": [
         {
-            "name": "Bio-Rad 96 Well Plate 200 \u00b5L PCR on Magnetic Module on 1",
+            "name": "Bio-Rad 96 Well Plate 200 \u00b5L PCR on Magnetic Module GEN1 on 1",
             "share": false,
             "slot": "1",
             "type": "biorad_96_wellplate_200ul_pcr"

--- a/protoBuilds/omega_biotek_magbind_totalpure_NGS/omegaMagBind.ot2.apiv2.py.json
+++ b/protoBuilds/omega_biotek_magbind_totalpure_NGS/omegaMagBind.ot2.apiv2.py.json
@@ -123,7 +123,7 @@
     ],
     "labware": [
         {
-            "name": "Bio-Rad 96 Well Plate 200 \u00b5L PCR on Magnetic Module on 1",
+            "name": "Bio-Rad 96 Well Plate 200 \u00b5L PCR on Magnetic Module GEN1 on 1",
             "share": false,
             "slot": "1",
             "type": "biorad_96_wellplate_200ul_pcr"

--- a/protoBuilds/swift-2s-turbo-pt1/swift-2s-turbo-pt1.ot2.apiv2.py.json
+++ b/protoBuilds/swift-2s-turbo-pt1/swift-2s-turbo-pt1.ot2.apiv2.py.json
@@ -63,7 +63,7 @@
             "type": "opentrons_96_aluminumblock_nest_wellplate_100ul"
         },
         {
-            "name": "Opentrons 24-Well Aluminum Block on Temperature Module on 3",
+            "name": "Opentrons 24-Well Aluminum Block on Temperature Module GEN1 on 3",
             "share": false,
             "slot": "3",
             "type": "opentrons_24_aluminumblock_generic_2ml_screwcap"

--- a/protoBuilds/swift-2s-turbo-pt2/swift-2s-turbo-pt2.ot2.apiv2.py.json
+++ b/protoBuilds/swift-2s-turbo-pt2/swift-2s-turbo-pt2.ot2.apiv2.py.json
@@ -103,13 +103,13 @@
             "type": "nest_12_reservoir_15ml"
         },
         {
-            "name": "Opentrons 24-Well Aluminum Block on Temperature Module on 3",
+            "name": "Opentrons 24-Well Aluminum Block on Temperature Module GEN1 on 3",
             "share": false,
             "slot": "3",
             "type": "opentrons_24_aluminumblock_generic_2ml_screwcap"
         },
         {
-            "name": "NEST 96-Well Plate on Magnetic Module on 4",
+            "name": "NEST 96-Well Plate on Magnetic Module GEN1 on 4",
             "share": false,
             "slot": "4",
             "type": "nest_96_wellplate_100ul_pcr_full_skirt"

--- a/protoBuilds/swift-2s-turbo-pt3/swift-2s-turbo-pt3.ot2.apiv2.py.json
+++ b/protoBuilds/swift-2s-turbo-pt3/swift-2s-turbo-pt3.ot2.apiv2.py.json
@@ -57,7 +57,7 @@
             "type": "nest_12_reservoir_15ml"
         },
         {
-            "name": "NEST 96-Well Plate on Magnetic Module on 4",
+            "name": "NEST 96-Well Plate on Magnetic Module GEN1 on 4",
             "share": false,
             "slot": "4",
             "type": "nest_96_wellplate_100ul_pcr_full_skirt"

--- a/protoBuilds/swift-fully-automated/swift-2s-turbo-fully-automated.ot2.apiv2.py.json
+++ b/protoBuilds/swift-fully-automated/swift-2s-turbo-fully-automated.ot2.apiv2.py.json
@@ -99,7 +99,7 @@
     ],
     "labware": [
         {
-            "name": "NEST 96 Well Plate 100 \u00b5L PCR Full Skirt on Magnetic Module on 1",
+            "name": "NEST 96 Well Plate 100 \u00b5L PCR Full Skirt on Magnetic Module GEN1 on 1",
             "share": false,
             "slot": "1",
             "type": "nest_96_wellplate_100ul_pcr_full_skirt"
@@ -111,7 +111,7 @@
             "type": "nest_12_reservoir_15ml"
         },
         {
-            "name": "Opentrons 24 Well Aluminum Block with Generic 2 mL Screwcap on Temperature Module on 3",
+            "name": "Opentrons 24 Well Aluminum Block with Generic 2 mL Screwcap on Temperature Module GEN1 on 3",
             "share": false,
             "slot": "3",
             "type": "opentrons_24_aluminumblock_generic_2ml_screwcap"

--- a/protoBuilds/swift_2s_turbo/swift_2s_turbo.ot2.apiv2.py.json
+++ b/protoBuilds/swift_2s_turbo/swift_2s_turbo.ot2.apiv2.py.json
@@ -245,13 +245,13 @@
             "type": "opentrons_96_tiprack_300ul"
         },
         {
-            "name": "Opentrons 24 Well Aluminum Block with Generic 2 mL Screwcap on Temperature Module on 3",
+            "name": "Opentrons 24 Well Aluminum Block with Generic 2 mL Screwcap on Temperature Module GEN1 on 3",
             "share": false,
             "slot": "3",
             "type": "opentrons_24_aluminumblock_generic_2ml_screwcap"
         },
         {
-            "name": "NEST 96 Well Plate 100 \u00b5L PCR Full Skirt on Magnetic Module on 4",
+            "name": "NEST 96 Well Plate 100 \u00b5L PCR Full Skirt on Magnetic Module GEN1 on 4",
             "share": false,
             "slot": "4",
             "type": "nest_96_wellplate_100ul_pcr_full_skirt"

--- a/protoBuilds/zymo-ribofree-cleanup/cleanup.ot2.apiv2.py.json
+++ b/protoBuilds/zymo-ribofree-cleanup/cleanup.ot2.apiv2.py.json
@@ -104,7 +104,7 @@
             "type": "opentrons_96_tiprack_300ul"
         },
         {
-            "name": "NEST 96 Well Plate 100 \u00b5L PCR Full Skirt on Magnetic Module on 6",
+            "name": "NEST 96 Well Plate 100 \u00b5L PCR Full Skirt on Magnetic Module GEN1 on 6",
             "share": false,
             "slot": "6",
             "type": "nest_96_wellplate_100ul_pcr_full_skirt"

--- a/protoBuilds/zymo-ribofree-first-strand-cdna-synth-universal-depletion/1_first_strand_synth_uni_depletion.ot2.apiv2.py.json
+++ b/protoBuilds/zymo-ribofree-first-strand-cdna-synth-universal-depletion/1_first_strand_synth_uni_depletion.ot2.apiv2.py.json
@@ -98,7 +98,7 @@
             "type": "opentrons_96_tiprack_20ul"
         },
         {
-            "name": "Opentrons 24 Well Aluminum Block with NEST 1.5 mL Screwcap on Temperature Module on 4",
+            "name": "Opentrons 24 Well Aluminum Block with NEST 1.5 mL Screwcap on Temperature Module GEN1 on 4",
             "share": false,
             "slot": "4",
             "type": "opentrons_24_aluminumblock_nest_1.5ml_screwcap"

--- a/protoBuilds/zymo-ribofree-library-index-pcr/4_library_index_pcr.ot2.apiv2.py.json
+++ b/protoBuilds/zymo-ribofree-library-index-pcr/4_library_index_pcr.ot2.apiv2.py.json
@@ -92,7 +92,7 @@
             "type": "opentrons_96_tiprack_300ul"
         },
         {
-            "name": "Opentrons 24 Well Aluminum Block with NEST 1.5 mL Screwcap on Temperature Module on 4",
+            "name": "Opentrons 24 Well Aluminum Block with NEST 1.5 mL Screwcap on Temperature Module GEN1 on 4",
             "share": false,
             "slot": "4",
             "type": "opentrons_24_aluminumblock_nest_1.5ml_screwcap"

--- a/protoBuilds/zymo-ribofree-p5-adapter-ligation/3_p5_adapter_ligation.ot2.apiv2.py.json
+++ b/protoBuilds/zymo-ribofree-p5-adapter-ligation/3_p5_adapter_ligation.ot2.apiv2.py.json
@@ -69,7 +69,7 @@
             "type": "opentrons_96_tiprack_20ul"
         },
         {
-            "name": "Opentrons 24 Well Aluminum Block with NEST 1.5 mL Screwcap on Temperature Module on 4",
+            "name": "Opentrons 24 Well Aluminum Block with NEST 1.5 mL Screwcap on Temperature Module GEN1 on 4",
             "share": false,
             "slot": "4",
             "type": "opentrons_24_aluminumblock_nest_1.5ml_screwcap"

--- a/protoBuilds/zymo-ribofree-p7-adapter-ligation/2_p7_adapter_ligation.ot2.apiv2.py.json
+++ b/protoBuilds/zymo-ribofree-p7-adapter-ligation/2_p7_adapter_ligation.ot2.apiv2.py.json
@@ -50,7 +50,7 @@
             "type": "opentrons_96_tiprack_20ul"
         },
         {
-            "name": "Opentrons 24 Well Aluminum Block with NEST 1.5 mL Screwcap on Temperature Module on 4",
+            "name": "Opentrons 24 Well Aluminum Block with NEST 1.5 mL Screwcap on Temperature Module GEN1 on 4",
             "share": false,
             "slot": "4",
             "type": "opentrons_24_aluminumblock_nest_1.5ml_screwcap"

--- a/protolib/parse/parseOT2v2.py
+++ b/protolib/parse/parseOT2v2.py
@@ -106,6 +106,12 @@ def parse(protocol_path):
     assert protocol.api_level >= (2, 0)
 
     context = opentrons.protocol_api.contexts.ProtocolContext()
+    # NOTE:(IL, 2020-05-13)L there’s no deck calibration, and the
+    # identity deck calibration is about 25 mm too high (as of v1.17.1).
+    # Because of this, tall labware can cross the threshold and cause a
+    # LabwareHeightError even though they're safe to use.
+    # So we'll apply a HACK-y -25 offset of the deck.
+    context._hw_manager.hardware._config.gantry_calibration[2][3] = -25
     context.home()
     run_protocol(protocol, context=context)
 


### PR DESCRIPTION
* Includes a hacky fix to correct the initial deck calibration offset

# Review request

There is a lot of diff noise in protoBuilds after this. I skimmed it and it looks like
1. Labware is reordered (making a really ugly diff that doesn't really change anything)
2. Some display names are slightly different eg `"name": "magnetic plate on Magnetic Module on 1"` becomes `"name": "magnetic plate on Magnetic Module GEN1 on 1"`

Please sanity-check the diff and after this is merged we should double-check the develop subdomain of the site