### PR TITLE
fix-7fc7b1-2

### DIFF
--- a/protocols/7fc7b1/labware/sarstedt_384_wellplate_40ul.json
+++ b/protocols/7fc7b1/labware/sarstedt_384_wellplate_40ul.json
@@ -4302,7 +4302,7 @@
         }
     ],
     "parameters": {
-        "format": "irregular",
+        "format": "384Standard",
         "quirks": [],
         "isTiprack": false,
         "isMagneticModuleCompatible": false,


### PR DESCRIPTION
## overview

fixes cherrypicking PCR prep protocol for 7fc7b1

## changelog

#### 10/16/2020
- update labware definition for 384-plate to `384Standard` from `irregular`