### PR TITLE
chore: update Makefile for 3.21.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SHELL := /bin/bash
 
 MONOREPO_URI := https://github.com/Opentrons/opentrons.git
-OT2_VERSION_TAG := v3.19.0
+OT2_VERSION_TAG := v3.21.2
 OT2_MONOREPO_DIR := ot2monorepoClone
 
 # Parsers output to here


### PR DESCRIPTION
## overview

updates Makefile to build protocols reflecting API changes up to version 3.21.2

## changelog

#### 10/19/2020
- updates `OT2_VERSION_TAG` to v3.21.2