### PR TITLE
fix(protolib): update import for protolib/parseot2v2.py 

### DIFF
--- a/protolib/parse/parseOT2v2.py
+++ b/protolib/parse/parseOT2v2.py
@@ -2,7 +2,7 @@ import json
 import sys
 from pathlib import Path
 import opentrons
-from opentrons.protocol_api.execute import run_protocol
+from opentrons.protocols.execution.execute import run_protocol
 from opentrons.protocols.parse import parse as parse_protocol
 
 


### PR DESCRIPTION
## overview

updates import statement on `protolib.parseot2v2.py` per [this change](https://github.com/Opentrons/opentrons/commit/e5e1b8c1ddc4b82c9fc27ac83d4703dfc94cdbfd#diff-3b8bba58de258c4b0dc3a50b0628f258fddef2716644e6f6c8f35aa49de4e325) in API 

resolves the following error:
`ModuleNotFoundError: No module named 'opentrons.protocol_api.execute'`

to update:
* run `make teardown setup` from top level `protocols` directory
* run `make all`

## changelog

#### 10/22/2020
- changes import statement for protocol 
