### PR TITLE
chore(Makefile): update OT2_VERSION_TAG

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SHELL := /bin/bash
 
 MONOREPO_URI := https://github.com/Opentrons/opentrons.git
-OT2_VERSION_TAG := v3.21.2
+OT2_VERSION_TAG := v4.0.0
 OT2_MONOREPO_DIR := ot2monorepoClone
 
 # Parsers output to here


### PR DESCRIPTION
## overview

update Makefile for Nov 2020 software release

## changelog

#### 11/24/2020
- update `OT2_VERSION_TAG` to 4.0.0