### PR TITLE
ci(travis): update python version to 3.7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-  - "3.6.4"
+  - "3.7.4"
 
 install:
   - export OT_UPLOAD_BRANCH=$(python scripts/getBranch.py)


### PR DESCRIPTION
### Overview
New protocol submissions stopped passing the Travis test, due to dependencies requiring python >= 3.7
The travis.yml file previously set python to 3.6.4 and this PR updates that to 3.7.4

