### PR TITLE
refactor(protocols): fix and speed up

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SHELL := /bin/bash
 
 MONOREPO_URI := https://github.com/Opentrons/opentrons.git
-OT2_VERSION_TAG := edge
+OT2_VERSION_TAG := v4.1.0
 OT2_MONOREPO_DIR := ot2monorepoClone
 
 # Parsers output to here

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SHELL := /bin/bash
 
 MONOREPO_URI := https://github.com/Opentrons/opentrons.git
-OT2_VERSION_TAG := v4.0.0
+OT2_VERSION_TAG := edge
 OT2_MONOREPO_DIR := ot2monorepoClone
 
 # Parsers output to here

--- a/protocols/3359a5/fields.json
+++ b/protocols/3359a5/fields.json
@@ -4,7 +4,6 @@
     "label": "pipette type",
     "name": "pipette_type",
     "options": [
-      {"label": "P20 Multi (GEN 2)", "value": "p20_multi_gen2"},
       {"label": "P20 Single (GEN 2)", "value": "p20_single_gen2"},
       {"label": "P10 Single (GEN 1)", "value": "p10_single"},
       {"label": "P50 Single (GEN 1)", "value": "p50_single"},

--- a/protocols/6fe477-workflow-2/labware/caplugs_6_tuberack_30ml.json
+++ b/protocols/6fe477-workflow-2/labware/caplugs_6_tuberack_30ml.json
@@ -1,0 +1,120 @@
+{
+    "ordering": [
+        [
+            "A1",
+            "B1"
+        ],
+        [
+            "A2",
+            "B2"
+        ],
+        [
+            "A3",
+            "B3"
+        ]
+    ],
+    "brand": {
+        "brand": "Caplugs",
+        "brandId": [
+            "2223530G80"
+        ]
+    },
+    "metadata": {
+        "displayName": "Caplugs 6 Tube Rack 30 mL",
+        "displayCategory": "tubeRack",
+        "displayVolumeUnits": "µL",
+        "tags": []
+    },
+    "dimensions": {
+        "xDimension": 127.76,
+        "yDimension": 85.48,
+        "zDimension": 96
+    },
+    "wells": {
+        "A1": {
+            "depth": 93,
+            "totalLiquidVolume": 30000,
+            "shape": "circular",
+            "diameter": 30,
+            "x": 35.5,
+            "y": 60.24,
+            "z": 3
+        },
+        "B1": {
+            "depth": 93,
+            "totalLiquidVolume": 30000,
+            "shape": "circular",
+            "diameter": 30,
+            "x": 35.5,
+            "y": 25.24,
+            "z": 3
+        },
+        "A2": {
+            "depth": 93,
+            "totalLiquidVolume": 30000,
+            "shape": "circular",
+            "diameter": 30,
+            "x": 70.5,
+            "y": 60.24,
+            "z": 3
+        },
+        "B2": {
+            "depth": 93,
+            "totalLiquidVolume": 30000,
+            "shape": "circular",
+            "diameter": 30,
+            "x": 70.5,
+            "y": 25.24,
+            "z": 3
+        },
+        "A3": {
+            "depth": 93,
+            "totalLiquidVolume": 30000,
+            "shape": "circular",
+            "diameter": 30,
+            "x": 105.5,
+            "y": 60.24,
+            "z": 3
+        },
+        "B3": {
+            "depth": 93,
+            "totalLiquidVolume": 30000,
+            "shape": "circular",
+            "diameter": 30,
+            "x": 105.5,
+            "y": 25.24,
+            "z": 3
+        }
+    },
+    "groups": [
+        {
+            "metadata": {
+                "wellBottomShape": "v",
+                "displayCategory": "tubeRack"
+            },
+            "wells": [
+                "A1",
+                "B1",
+                "A2",
+                "B2",
+                "A3",
+                "B3"
+            ]
+        }
+    ],
+    "parameters": {
+        "format": "irregular",
+        "quirks": [],
+        "isTiprack": false,
+        "isMagneticModuleCompatible": false,
+        "loadName": "caplugs_6_tuberack_30ml"
+    },
+    "namespace": "custom_beta",
+    "version": 1,
+    "schemaVersion": 2,
+    "cornerOffsetFromSlot": {
+        "x": 0,
+        "y": 0,
+        "z": 0
+    }
+}

--- a/protolib/parse/parseOT2v2.py
+++ b/protolib/parse/parseOT2v2.py
@@ -4,7 +4,8 @@ from pathlib import Path
 import opentrons
 from opentrons.protocols.execution.execute import run_protocol
 from opentrons.protocols.parse import parse as parse_protocol
-from opentrons.protocols.implementations.simulators.protocol_context import SimProtocolContext
+from opentrons.protocols.implementations.simulators.protocol_context \
+    import SimProtocolContext
 
 
 def filter_none(arr):
@@ -109,7 +110,8 @@ def parse(protocol_path):
     # Use a simulating protocol context
     context_impl = SimProtocolContext()
 
-    context = opentrons.protocol_api.contexts.ProtocolContext(implementation=context_impl)
+    context = opentrons.protocol_api.contexts.ProtocolContext(
+        implementation=context_impl)
     # NOTE:(IL, 2020-05-13)L there’s no deck calibration, and the
     # identity deck calibration is about 25 mm too high (as of v1.17.1).
     # Because of this, tall labware can cross the threshold and cause a

--- a/protolib/parse/parseOT2v2.py
+++ b/protolib/parse/parseOT2v2.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import opentrons
 from opentrons.protocols.execution.execute import run_protocol
 from opentrons.protocols.parse import parse as parse_protocol
+from opentrons.protocols.implementations.simulators.protocol_context import SimProtocolContext
 
 
 def filter_none(arr):
@@ -105,13 +106,15 @@ def parse(protocol_path):
 
     assert protocol.api_level >= (2, 0)
 
-    context = opentrons.protocol_api.contexts.ProtocolContext()
+    # Use a simulating protocol context
+    context_impl = SimProtocolContext()
+
+    context = opentrons.protocol_api.contexts.ProtocolContext(implementation=context_impl)
     # NOTE:(IL, 2020-05-13)L there’s no deck calibration, and the
     # identity deck calibration is about 25 mm too high (as of v1.17.1).
     # Because of this, tall labware can cross the threshold and cause a
     # LabwareHeightError even though they're safe to use.
     # So we'll apply a HACK-y -25 offset of the deck.
-    context._hw_manager.hardware._config.gantry_calibration[2][3] = -25
     context.home()
     run_protocol(protocol, context=context)
 


### PR DESCRIPTION
This PR prepares for changes added since version 4.0. Namely that `ProtocolContext` now requires an `implementation` argument. An implementation called `SimProtocolContext` has been added that greatly reduces simulation time.

I tried a clean build and many protocols fail for reasons that I am pretty sure are not related to my changes.

@IanLondon mentioned that build speed is a concern. Hopefully this PR helps. 

I would also consider using `-j` make flat. It tells make how many concurrent processes to spawn. This seems like a perfect make target to parallelize. (ie `make -j 12 parse-ot2`).