### PR TITLE
fix value for destination plate dropdown field

### DIFF
--- a/protocols/5a5767/fields.json
+++ b/protocols/5a5767/fields.json
@@ -13,7 +13,7 @@
     "label": "destination plate type",
     "name": "dest_plate_type",
     "options": [
-      {"label": "Corning 384 Well Plate 20 µL", "value": "greinerbioone_384_wellplate_100ul"},
+      {"label": "Corning 384 Well Plate 20 µL", "value": "corning_384_wellplate_20ul"},
       {"label": "Bio-Rad 384 Well Plate 50 µL", "value": "biorad_384_wellplate_50ul"}
     ]
   },


### PR DESCRIPTION
## overview

fixes labware field for plate filling protocol for 5a5767

## changelog

#### 12/22/2020
- changes value for `destination plate` field to Corning plate loadname 