### PR TITLE
49de51-readme

### DIFF
--- a/protocols/49de51-pt2/fields.json
+++ b/protocols/49de51-pt2/fields.json
@@ -21,8 +21,8 @@
     "name": "bead_loc",
     "options": [
       {"label": "NEST 12-Well Reservoir; Slot 7; A1", "value": "NEST_reservoir"},
-      {"label": "PCR Strip in Aluminum Block; Slot 4; Column 1", "value": "opentrons_96_aluminumblock_generic_pcr_strip_200ul"},
-      {"label": "NEST 96-Deep Well Plate; Slot 4; Column 1", "value": "nest_96_wellplate_2ml_deep"}
+      {"label": "PCR Strip in Aluminum Block; Slot 10; Column 1", "value": "opentrons_96_aluminumblock_generic_pcr_strip_200ul"},
+      {"label": "NEST 96-Deep Well Plate; Slot 10; Column 1", "value": "nest_96_wellplate_2ml_deep"}
     ]
   }
 ]


### PR DESCRIPTION
### Overview
The text in the drop-down of the `fields.json` did not match the description in the readme or protocol file. This PR updates that.

### Changelog
Updates text in fields.json to match the rest of the protocol package