### PR TITLE
fix(protocols/5a3797-protocol-3): added height parameters for tubes and plates, parameter for tip type

### DIFF
--- a/protoBuilds/5a3797-protocol-3/5a3797-protocol-3.ot2.apiv2.py.json
+++ b/protoBuilds/5a3797-protocol-3/5a3797-protocol-3.ot2.apiv2.py.json
@@ -1,5 +1,5 @@
 {
-    "content": "import math\n\nmetadata = {\n    'protocolName': 'Protocol 3 - Sample Plate setup',\n    'author': 'Sakib <sakib.hossain@opentrons.com>',\n    'description': 'Custom Protocol Request',\n    'apiLevel': '2.8'\n}\n\n\ndef run(ctx):\n\n    [m300_mount, p300_mount, samples, tuberack_1, tuberack_2, tuberack_3,\n        tuberack_4, tuberack_5, tuberack_6, tuberack_7,\n        final_asp_speed, final_air_gap] = get_values(  # noqa: F821\n        \"m300_mount\", \"p300_mount\", \"samples\", \"tuberack_1\",\n        \"tuberack_2\", \"tuberack_3\",\n        \"tuberack_4\", \"tuberack_5\", \"tuberack_6\",\n        \"tuberack_7\", \"final_asp_speed\", \"final_air_gap\")\n\n    final_asp_speed = float(final_asp_speed)\n    final_air_gap = float(final_air_gap)\n\n    # Get sample number\n    samples = int(samples)\n    if samples > 96:\n        raise Exception(\"You cannot have greater than 96 samples\")\n\n    columns = math.ceil(samples/8)\n\n    # Load Labware\n    tipracks = [ctx.load_labware('opentrons_96_filtertiprack_200ul', slot)\n                for slot in range(1, 3)]\n    tuberack_types = [tuberack_1, tuberack_2, tuberack_3, tuberack_4,\n                      tuberack_5, tuberack_6, tuberack_7]\n\n    tuberacks = []\n    for rack, slot in zip(tuberack_types, range(5, 12)):\n        tuberacks.append(ctx.load_labware(rack, slot))\n\n    sample_plate = ctx.load_labware('kingfisher_96_deepwell_plate_2ml', 3)\n    reservoir = ctx.load_labware('nest_12_reservoir_15ml', 4)\n\n    # Load Pipette\n    p300 = ctx.load_instrument('p300_single_gen2', p300_mount,\n                               tip_racks=tipracks)\n    m300 = ctx.load_instrument('p300_multi_gen2', m300_mount,\n                               tip_racks=tipracks)\n\n    # Get list of tubes across 7 racks based on sample number\n    tuberack_wells = [tuberacks[i].wells() for i in range(len(tuberacks))]\n    tuberack_samples = [well for wells in tuberack_wells for well in\n                        wells][:samples]\n\n    sample_plate_wells = sample_plate.rows()[0][:columns]\n    reservoir_columns = reservoir.wells()[:columns]\n\n    # Aliquot 200 uL from ~7 Tube Racks\n    p300.transfer(200, tuberack_samples, sample_plate.wells()[:samples],\n                  new_tip='always')\n\n    # Aliquot 275 uL from Reservoir\n    m300.flow_rate.aspirate = final_asp_speed\n    m300.transfer(275, reservoir_columns, sample_plate_wells,\n                  air_gap=final_air_gap, new_tip='always')\n",
+    "content": "import math\n\nmetadata = {\n    'protocolName': 'Protocol 3 - Sample Plate setup',\n    'author': 'Sakib <sakib.hossain@opentrons.com>',\n    'description': 'Custom Protocol Request',\n    'apiLevel': '2.8'\n}\n\n\ndef run(ctx):\n\n    [m300_mount, p300_mount, samples, tuberack_1, tuberack_2, tuberack_3,\n        tuberack_4, tuberack_5, tuberack_6, tuberack_7,\n        final_asp_speed, final_air_gap, tube_height, sample_plate_height,\n        reservoir_height, tip_type] = get_values(  # noqa: F821\n        \"m300_mount\", \"p300_mount\", \"samples\", \"tuberack_1\",\n        \"tuberack_2\", \"tuberack_3\",\n        \"tuberack_4\", \"tuberack_5\", \"tuberack_6\",\n        \"tuberack_7\", \"final_asp_speed\", \"final_air_gap\",\n        \"tube_height\", \"sample_plate_height\", \"reservoir_height\", \"tip_type\")\n\n    final_asp_speed = float(final_asp_speed)\n    final_air_gap = float(final_air_gap)\n    tube_height = float(tube_height)\n    sample_plate_height = float(sample_plate_height)\n    reservoir_height = float(reservoir_height)\n\n    # Get sample number\n    samples = int(samples)\n    if samples > 96:\n        raise Exception(\"You cannot have greater than 96 samples\")\n\n    columns = math.ceil(samples/8)\n\n    # Load Labware\n    tipracks = [ctx.load_labware(tip_type, slot)\n                for slot in range(1, 3)]\n    tuberack_types = [tuberack_1, tuberack_2, tuberack_3, tuberack_4,\n                      tuberack_5, tuberack_6, tuberack_7]\n\n    tuberacks = []\n    for rack, slot in zip(tuberack_types, range(5, 12)):\n        tuberacks.append(ctx.load_labware(rack, slot))\n\n    sample_plate = ctx.load_labware('kingfisher_96_deepwell_plate_2ml', 3)\n    reservoir = ctx.load_labware('nest_12_reservoir_15ml', 4)\n\n    # Load Pipette\n    p300 = ctx.load_instrument('p300_single_gen2', p300_mount,\n                               tip_racks=tipracks)\n    m300 = ctx.load_instrument('p300_multi_gen2', m300_mount,\n                               tip_racks=tipracks)\n\n    # Get list of tubes across 7 racks based on sample number\n    tuberack_wells = [tuberacks[i].wells() for i in range(len(tuberacks))]\n    tuberack_samples = [well for wells in tuberack_wells for well in\n                        wells][:samples]\n\n    sample_plate_wells = sample_plate.rows()[0][:columns]\n    reservoir_columns = reservoir.wells()[:columns]\n\n    # Aliquot 200 uL from ~7 Tube Racks\n    for tuberack_well, sample_well in zip(tuberack_samples,\n                                          sample_plate.wells()[:samples]):\n        p300.transfer(200, tuberack_well.bottom(tube_height),\n                      sample_well.bottom(sample_plate_height),\n                      new_tip='always')\n\n    # Aliquot 275 uL from Reservoir\n    m300.flow_rate.aspirate = final_asp_speed\n    for res, sample_well in zip(reservoir_columns, sample_plate_wells):\n        m300.transfer(275, res.bottom(reservoir_height), sample_well.center(),\n                      air_gap=final_air_gap, new_tip='always')\n",
     "custom_labware_defs": [
         {
             "brand": {
@@ -1605,6 +1605,21 @@
             "type": "dropDown"
         },
         {
+            "label": "Tip Type",
+            "name": "tip_type",
+            "options": [
+                {
+                    "label": "Opentrons 300 uL Tips",
+                    "value": "opentrons_96_tiprack_300ul"
+                },
+                {
+                    "label": "Opentrons 200 uL Filter Tips",
+                    "value": "opentrons_96_filtertiprack_200ul"
+                }
+            ],
+            "type": "dropDown"
+        },
+        {
             "default": 96,
             "label": "Total Sample Number (# of Tubes)",
             "name": "samples",
@@ -1726,6 +1741,24 @@
             "label": "Final Step Air Gap (uL)",
             "name": "final_air_gap",
             "type": "float"
+        },
+        {
+            "default": 15,
+            "label": "Tube Height from bottom (mm)",
+            "name": "tube_height",
+            "type": "float"
+        },
+        {
+            "default": 5,
+            "label": "Deep Well Plate Height from bottom (mm)",
+            "name": "sample_plate_height",
+            "type": "float"
+        },
+        {
+            "default": 5,
+            "label": "Reservoir Height from bottom (mm)",
+            "name": "reservoir_height",
+            "type": "float"
         }
     ],
     "instruments": [
@@ -1740,16 +1773,16 @@
     ],
     "labware": [
         {
-            "name": "Opentrons 96 Filter Tip Rack 200 \u00b5L on 1",
+            "name": "Opentrons 96 Tip Rack 300 \u00b5L on 1",
             "share": false,
             "slot": "1",
-            "type": "opentrons_96_filtertiprack_200ul"
+            "type": "opentrons_96_tiprack_300ul"
         },
         {
-            "name": "Opentrons 96 Filter Tip Rack 200 \u00b5L on 2",
+            "name": "Opentrons 96 Tip Rack 300 \u00b5L on 2",
             "share": false,
             "slot": "2",
-            "type": "opentrons_96_filtertiprack_200ul"
+            "type": "opentrons_96_tiprack_300ul"
         },
         {
             "name": "KingFisher 96 Deep Well Plate on 3",

--- a/protocols/5a3797-protocol-3/5a3797-protocol-3.ot2.apiv2.py
+++ b/protocols/5a3797-protocol-3/5a3797-protocol-3.ot2.apiv2.py
@@ -12,12 +12,12 @@ def run(ctx):
 
     [m300_mount, p300_mount, samples, tuberack_1, tuberack_2, tuberack_3,
         tuberack_4, tuberack_5, tuberack_6, tuberack_7,
-        final_asp_speed, final_air_gap, tube_height, sample_plate_height, 
+        final_asp_speed, final_air_gap, tube_height, sample_plate_height,
         reservoir_height, tip_type] = get_values(  # noqa: F821
         "m300_mount", "p300_mount", "samples", "tuberack_1",
         "tuberack_2", "tuberack_3",
         "tuberack_4", "tuberack_5", "tuberack_6",
-        "tuberack_7", "final_asp_speed", "final_air_gap", 
+        "tuberack_7", "final_asp_speed", "final_air_gap",
         "tube_height", "sample_plate_height", "reservoir_height", "tip_type")
 
     final_asp_speed = float(final_asp_speed)
@@ -61,12 +61,14 @@ def run(ctx):
     reservoir_columns = reservoir.wells()[:columns]
 
     # Aliquot 200 uL from ~7 Tube Racks
-    for tuberack_well, sample_well in zip(tuberack_samples, sample_plate.wells()[:samples]):
-        p300.transfer(200, tuberack_well.bottom(tube_height), sample_well.bottom(sample_plate_height),
-                    new_tip='always')
+    for tuberack_well, sample_well in zip(tuberack_samples,
+                                          sample_plate.wells()[:samples]):
+        p300.transfer(200, tuberack_well.bottom(tube_height),
+                      sample_well.bottom(sample_plate_height),
+                      new_tip='always')
 
     # Aliquot 275 uL from Reservoir
     m300.flow_rate.aspirate = final_asp_speed
     for res, sample_well in zip(reservoir_columns, sample_plate_wells):
         m300.transfer(275, res.bottom(reservoir_height), sample_well.center(),
-                    air_gap=final_air_gap, new_tip='always')
+                      air_gap=final_air_gap, new_tip='always')

--- a/protocols/5a3797-protocol-3/fields.json
+++ b/protocols/5a3797-protocol-3/fields.json
@@ -18,6 +18,15 @@
         ]
     },
     {
+      "type": "dropDown",
+      "label": "Tip Type",
+      "name": "tip_type",
+      "options": [
+        {"label": "Opentrons 300 uL Tips", "value": "opentrons_96_tiprack_300ul"},
+        {"label": "Opentrons 200 uL Filter Tips", "value": "opentrons_96_filtertiprack_200ul"}
+      ]
+    },
+    {
       "type": "int",
       "label": "Total Sample Number (# of Tubes)",
       "name": "samples",
@@ -97,5 +106,23 @@
       "label": "Final Step Air Gap (uL)",
       "name": "final_air_gap",
       "default": 20
+    },
+    {
+      "type": "float",
+      "label": "Tube Height from bottom (mm)",
+      "name": "tube_height",
+      "default": 15
+    },
+    {
+      "type": "float",
+      "label": "Deep Well Plate Height from bottom (mm)",
+      "name": "sample_plate_height",
+      "default": 5
+    },
+    {
+      "type": "float",
+      "label": "Reservoir Height from bottom (mm)",
+      "name": "reservoir_height",
+      "default": 5
     }
   ]


### PR DESCRIPTION
## changelog
- Added height fields for Sorfa and Copan tubes
- Added height fields for reservoir and deep well plates
- Added tip rack type for 200 uL filter tips and 300 uL tips
- Dispenses viscous liquid at vertical and horizontal center of the wells 