### PR TITLE
fix(protocols/1ccd23-station-B): fields.json typo

### DIFF
--- a/protocols/1ccd23-station-B/fields.json
+++ b/protocols/1ccd23-station-B/fields.json
@@ -13,7 +13,7 @@
   },
   {
     "type": "int",
-    "label": "height offset from bottom of deepwell palte (in mm)",
+    "label": "height offset from bottom of deepwell plate (in mm)",
     "name": "magplate_offset",
     "default": 1.0
   },


### PR DESCRIPTION
## overview

typo fix

## changelog

#### 2/8/2021
- fix typo in `magwell_offset` label (`palte` to `plate`)