### PR TITLE
fix(protocols/1ccd23-station-B): change type of offset parameters

### DIFF
--- a/protocols/1ccd23-station-B/fields.json
+++ b/protocols/1ccd23-station-B/fields.json
@@ -12,13 +12,13 @@
     "default": 13.7
   },
   {
-    "type": "int",
+    "type": "float",
     "label": "height offset from bottom of deepwell plate (in mm)",
     "name": "magplate_offset",
     "default": 1.0
   },
   {
-    "type": "int",
+    "type": "float",
     "label": "lateral offset (as fraction of deepwell radius)",
     "name": "radial_offset",
     "default": 0.8


### PR DESCRIPTION
## overview

fix types of custom fields for 1ccd23-station-B

## changelog

#### 2/23/2021
- update type of offset parameters from `int` to `float`