### PR TITLE
chore(.gitignore): update .gitignore for supplementary protocol files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,6 @@ ENV/
 
 releases
 smoketest/*.py
+
+# supplementary protocol bundle files
+protocols/**/supplements


### PR DESCRIPTION
## overview

Often, custom protocol submissions contain additional information in various supplementary files, with various extensions (.pptx, .csv, .pdf, etc.). The Applications Engineering team find value in including these files within the protocol folder locally, but we need git to ignore these supplementary files. This PR adds adds folders of the type `protocols/**/supplements` to the `.gitignore` file, so that protocol folders can contain the subfolder `supplements` containing these addition info files without git's recognition.

## changelog

#### 3/8/2021
- update `.gitignore` for supplementary protocol files