### PR TITLE
restrict README parsing to headers in allowlist

### DIFF
--- a/protolib/parse/markdown.py
+++ b/protolib/parse/markdown.py
@@ -3,6 +3,27 @@ import re
 from bs4 import BeautifulSoup
 import markdown
 
+# NOTE(IL, 2021-03-16): these were gathered from existing READMEs.
+ALLOWED_HEADERS = [
+    'author',
+    'categories',
+    'deck setup',
+    'description',
+    'internal',
+    'modules',
+    'notes',
+    'partner',
+    'preview',
+    'process',
+    'protocol steps',
+    'reagents',
+    'reagent setup',
+    'robot',
+    'subcategories',
+    'time-estimate',
+    'title'
+]
+
 
 def markdown_to_dom(text):
     """
@@ -171,6 +192,13 @@ def parse(filename):
 
     with open(filename) as md:
         md = parse_headers(split_markdown(list(md)))
+
+        md = {
+            key: value
+            for key, value in md.items()
+            if key in ALLOWED_HEADERS
+        }
+
         return {
             **parse_values(md),
             'markdown': md


### PR DESCRIPTION
# Acceptance Criteria

- [x] Add a bad header to a README and run `make parse-README`. You shouldn't see the bad header added to the `README.json`
- [ ] Test this on `master` -- running `make parse-README` with all the protocols on `master` should not generate any diff when you do `git diff`