### PR TITLE
fix(protocols/bc-rnadvance-viral): hide from search

### DIFF
--- a/protoBuilds/bc-rnadvance-viral/metadata.json
+++ b/protoBuilds/bc-rnadvance-viral/metadata.json
@@ -11,7 +11,7 @@
     "flags": {
         "embedded-app": false,
         "feature": false,
-        "hide-from-search": false,
+        "hide-from-search": true,
         "skip-tests": false
     },
     "path": "protocols/bc-rnadvance-viral",


### PR DESCRIPTION
## overview

hides Beckman Coulter RNadvance from search until final optimizations are made

## changelog

#### 3/18/2021
- adds `.hide-from-search` file