### PR TITLE
Hide test

### DIFF
--- a/protoBuilds/test-readme/metadata.json
+++ b/protoBuilds/test-readme/metadata.json
@@ -11,7 +11,7 @@
     "flags": {
         "embedded-app": false,
         "feature": false,
-        "hide-from-search": false,
+        "hide-from-search": true,
         "skip-tests": false
     },
     "path": "protocols/test-readme",


### PR DESCRIPTION
### Overview
This PR adds a `.hide-from-search` to a test protocol bundle, removing the holder categories from our current protocol library.

### Changelog
Added `.hide-from-search` and updated protoBuilds file