### PR TITLE
chore(Makefile): update Makefile to reflect 4.3.0 (apiLevel 2.10)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SHELL := /bin/bash
 
 MONOREPO_URI := https://github.com/Opentrons/opentrons.git
-OT2_VERSION_TAG := v4.1.0
+OT2_VERSION_TAG := v4.3.0
 OT2_MONOREPO_DIR := ot2monorepoClone
 
 # Parsers output to here


### PR DESCRIPTION
## overview

update `Makefile` `OT2_VERSION_TAG` to reflect latest software version (4.3.0) and API level (2.10)

## changelog

#### 5/26/2021
- update `Makefile`