### PR TITLE
5414fa

### DIFF
--- a/protoBuilds/5414fa/5414fa.ot2.apiv2.py.json
+++ b/protoBuilds/5414fa/5414fa.ot2.apiv2.py.json
@@ -1,0 +1,253 @@
+{
+    "content": "metadata = {\n    'protocolName': 'Vitrolife Plate Prep',\n    'author': 'Sakib <sakib.hossain@opentrons.com>',\n    'description': 'Custom Protocol Request',\n    'apiLevel': '2.10'\n}\n\n\ndef run(ctx):\n\n    # Load Labware\n\n    dish = ctx.load_labware('vitrolife_culture_dish', 1)\n    tipracks_200ul = ctx.load_labware('opentrons_96_filtertiprack_200ul', 2)\n    tipracks_1000ul = ctx.load_labware('opentrons_96_filtertiprack_1000ul', 3)\n    tuberack = ctx.load_labware('opentrons_6_tuberack_falcon_50ml_conical', 4)\n\n    # Load Pipettes\n\n    p300 = ctx.load_instrument('p300_single_gen2', 'left',\n                               tip_racks=[tipracks_200ul])\n    p1000 = ctx.load_instrument('p1000_single_gen2', 'right',\n                                tip_racks=[tipracks_1000ul])\n\n    # Helper Functions\n    def change_flow_rates(pip, asp_speed, disp_speed):\n        pip.flow_rate.aspirate = asp_speed\n        pip.flow_rate.dispense = disp_speed\n\n    def reset_flow_rates(pip):\n        if pip.name == 'p300_single_gen2':\n            pip.flow_rate.aspirate = 92.86\n            pip.flow_rate.dispense = 92.86\n        else:\n            pip.flow_rate.aspirate = 274.7\n            pip.flow_rate.dispense = 274.7\n\n    # Reagents\n\n    media = tuberack['A1']\n    oil_1 = tuberack['B1']\n\n    # Sample Wells\n\n    wells = []\n    for i, row in enumerate(dish.rows()):\n        if i % 2 == 0:\n            for well in row:\n                wells.append(well)\n        else:\n            for well in row[::-1]:\n                wells.append(well)\n\n    oil_loc = dish['D1']\n\n    # Protocol Steps\n\n    # Step 1\n    p300.distribute(20, media, wells, new_tip='once')\n    # Step 2\n    p1000.pick_up_tip()\n    for i in range(5):\n        reset_flow_rates(p1000)\n        if i == 0:\n            change_flow_rates(p1000, 200, 200)\n        p1000.aspirate(1000, oil_1)\n        p1000.dispense(1000, oil_loc)\n        ctx.delay(seconds=2)\n        p1000.blow_out()\n    p1000.drop_tip()\n",
+    "custom_labware_defs": [
+        {
+            "brand": {
+                "brand": "generic"
+            },
+            "cornerOffsetFromSlot": {
+                "x": 0,
+                "y": 0,
+                "z": 0
+            },
+            "dimensions": {
+                "xDimension": 66,
+                "yDimension": 66,
+                "zDimension": 20
+            },
+            "groups": [
+                {
+                    "metadata": {},
+                    "wells": [
+                        "A1",
+                        "B1",
+                        "C1",
+                        "A2",
+                        "B2",
+                        "C2",
+                        "A3",
+                        "B3",
+                        "C3",
+                        "A4",
+                        "B4",
+                        "C4"
+                    ]
+                },
+                {
+                    "metadata": {},
+                    "wells": [
+                        "D1"
+                    ]
+                }
+            ],
+            "metadata": {
+                "displayCategory": "tubeRack",
+                "displayName": "Vitrolife Micro-droplet Culture Dish",
+                "displayVolumeUnits": "mL",
+                "tags": []
+            },
+            "namespace": "custom_beta",
+            "ordering": [
+                [
+                    "A1",
+                    "B1",
+                    "C1",
+                    "D1"
+                ],
+                [
+                    "A2",
+                    "B2",
+                    "C2"
+                ],
+                [
+                    "A3",
+                    "B3",
+                    "C3"
+                ],
+                [
+                    "A4",
+                    "B4",
+                    "C4"
+                ]
+            ],
+            "parameters": {
+                "format": "irregular",
+                "isMagneticModuleCompatible": false,
+                "isTiprack": false,
+                "loadName": "vitrolife_culture_dish"
+            },
+            "schemaVersion": 2,
+            "version": 1,
+            "wells": {
+                "A1": {
+                    "depth": 10,
+                    "diameter": 4,
+                    "shape": "circular",
+                    "totalLiquidVolume": 15000,
+                    "x": 25,
+                    "y": 45,
+                    "z": 10
+                },
+                "A2": {
+                    "depth": 10,
+                    "diameter": 4,
+                    "shape": "circular",
+                    "totalLiquidVolume": 15000,
+                    "x": 30,
+                    "y": 45,
+                    "z": 10
+                },
+                "A3": {
+                    "depth": 10,
+                    "diameter": 4,
+                    "shape": "circular",
+                    "totalLiquidVolume": 15000,
+                    "x": 35,
+                    "y": 45,
+                    "z": 10
+                },
+                "A4": {
+                    "depth": 10,
+                    "diameter": 4,
+                    "shape": "circular",
+                    "totalLiquidVolume": 15000,
+                    "x": 40,
+                    "y": 45,
+                    "z": 10
+                },
+                "B1": {
+                    "depth": 10,
+                    "diameter": 4,
+                    "shape": "circular",
+                    "totalLiquidVolume": 15000,
+                    "x": 25,
+                    "y": 40,
+                    "z": 10
+                },
+                "B2": {
+                    "depth": 10,
+                    "diameter": 4,
+                    "shape": "circular",
+                    "totalLiquidVolume": 15000,
+                    "x": 30,
+                    "y": 40,
+                    "z": 10
+                },
+                "B3": {
+                    "depth": 10,
+                    "diameter": 4,
+                    "shape": "circular",
+                    "totalLiquidVolume": 15000,
+                    "x": 35,
+                    "y": 40,
+                    "z": 10
+                },
+                "B4": {
+                    "depth": 10,
+                    "diameter": 4,
+                    "shape": "circular",
+                    "totalLiquidVolume": 15000,
+                    "x": 40,
+                    "y": 40,
+                    "z": 10
+                },
+                "C1": {
+                    "depth": 10,
+                    "diameter": 4,
+                    "shape": "circular",
+                    "totalLiquidVolume": 15000,
+                    "x": 25,
+                    "y": 35,
+                    "z": 10
+                },
+                "C2": {
+                    "depth": 10,
+                    "diameter": 4,
+                    "shape": "circular",
+                    "totalLiquidVolume": 15000,
+                    "x": 30,
+                    "y": 35,
+                    "z": 10
+                },
+                "C3": {
+                    "depth": 10,
+                    "diameter": 4,
+                    "shape": "circular",
+                    "totalLiquidVolume": 15000,
+                    "x": 35,
+                    "y": 35,
+                    "z": 10
+                },
+                "C4": {
+                    "depth": 10,
+                    "diameter": 4,
+                    "shape": "circular",
+                    "totalLiquidVolume": 15000,
+                    "x": 40,
+                    "y": 35,
+                    "z": 10
+                },
+                "D1": {
+                    "depth": 10,
+                    "shape": "rectangular",
+                    "totalLiquidVolume": 15000,
+                    "x": 32,
+                    "xDimension": 20,
+                    "y": 28,
+                    "yDimension": 5,
+                    "z": 10
+                }
+            }
+        }
+    ],
+    "fields": [],
+    "instruments": [
+        {
+            "mount": "left",
+            "name": "p300_single_gen2"
+        },
+        {
+            "mount": "right",
+            "name": "p1000_single_gen2"
+        }
+    ],
+    "labware": [
+        {
+            "name": "Vitrolife Micro-droplet Culture Dish on 1",
+            "share": false,
+            "slot": "1",
+            "type": "vitrolife_culture_dish"
+        },
+        {
+            "name": "Opentrons 96 Filter Tip Rack 200 \u00b5L on 2",
+            "share": false,
+            "slot": "2",
+            "type": "opentrons_96_filtertiprack_200ul"
+        },
+        {
+            "name": "Opentrons 96 Filter Tip Rack 1000 \u00b5L on 3",
+            "share": false,
+            "slot": "3",
+            "type": "opentrons_96_filtertiprack_1000ul"
+        },
+        {
+            "name": "Opentrons 6 Tube Rack with Falcon 50 mL Conical on 4",
+            "share": false,
+            "slot": "4",
+            "type": "opentrons_6_tuberack_falcon_50ml_conical"
+        },
+        {
+            "name": "Opentrons Fixed Trash on 12",
+            "share": false,
+            "slot": "12",
+            "type": "opentrons_1_trash_1100ml_fixed"
+        }
+    ],
+    "metadata": {
+        "apiLevel": "2.10",
+        "author": "Sakib <sakib.hossain@opentrons.com>",
+        "description": "Custom Protocol Request",
+        "protocolName": "Vitrolife Plate Prep"
+    },
+    "modules": []
+}

--- a/protoBuilds/5414fa/README.json
+++ b/protoBuilds/5414fa/README.json
@@ -1,0 +1,35 @@
+{
+    "author": "Opentrons",
+    "categories": {
+        "Sample Prep": [
+            "Plate Filling"
+        ]
+    },
+    "deck-setup": "Deck Setup is currently unavailable as the custom labware component to house the plates and reagents on the OT-2 deck are actively being developed.\nThe protocol currently uses a dummy labware definition of the Vitrolife dish to display the basic protocol logic using our Python API. \n\n",
+    "description": "This protocol performs the preparation of media and oils onto the Vitrolife Micro-droplet Culture Dish. It adds media to each of the 12 wells in the plate by distributing 20 uL in a single take. It will then transfer a total of 5 mL of oil to the inner perimeter of the plate. This protocol is still a Work In Progress and is subject to refactoring based on a pending custom labware piece.\n",
+    "internal": "5414fa",
+    "labware": "\nOpentrons 200 uL Filter Tips\nOpentrons 1000 uL Filter Tips\nVitrolife Micro-droplet Culture Dish\n",
+    "markdown": {
+        "author": "[Opentrons](https://opentrons.com/)\n\n",
+        "categories": "* Sample Prep\n\t* Plate Filling\n\n",
+        "deck-setup": "**Deck Setup is currently unavailable as the custom labware component to house the plates and reagents on the OT-2 deck are actively being developed.**\n\nThe protocol currently uses a dummy labware definition of the Vitrolife dish to display the basic protocol logic using our Python API. \n![Vitrolife Dish](https://opentrons-protocol-library-website.s3.amazonaws.com/custom-README-images/5414fa/vitrolife_culture_dish.png)\n\n---\n\n",
+        "description": "This protocol performs the preparation of media and oils onto the [Vitrolife Micro-droplet Culture Dish](https://www.vitrolife.com/products/labware/dishes/). It adds media to each of the 12 wells in the plate by distributing 20 uL in a single take. It will then transfer a total of 5 mL of oil to the inner perimeter of the plate. **This protocol is still a Work In Progress and is subject to refactoring based on a pending custom labware piece.**\n\n---\n\n",
+        "internal": "5414fa",
+        "labware": "* [Opentrons 200 uL Filter Tips](https://shop.opentrons.com/collections/opentrons-tips/products/opentrons-200ul-filter-tips)\n* [Opentrons 1000 uL Filter Tips](https://shop.opentrons.com/collections/opentrons-tips/products/opentrons-1000ul-filter-tips)\n* [Vitrolife Micro-droplet Culture Dish](https://www.vitrolife.com/products/labware/dishes/)\n\n",
+        "notes": "If you have any questions about this protocol, please contact the Protocol Development Team by filling out the [Troubleshooting Survey](https://protocol-troubleshooting.paperform.co/).\n\n",
+        "pipettes": "* [P300 Single GEN2 Pipette](https://shop.opentrons.com/collections/ot-2-robot/products/single-channel-electronic-pipette?variant=5984549109789)\n* [P1000 Single GEN2 Pipette](https://shop.opentrons.com/collections/ot-2-robot/products/single-channel-electronic-pipette?variant=5984549142557)\n\n",
+        "process": "1. Input your protocol parameters above.\n2. Download your protocol and unzip if needed.\n3. Upload your custom labware to the [OT App](https://opentrons.com/ot-app) by navigating to `More` > `Custom Labware` > `Add Labware`, and selecting your labware files (.json extensions) if needed.\n4. Upload your protocol file (.py extension) to the [OT App](https://opentrons.com/ot-app) in the `Protocol` tab.\n5. Set up your deck according to the deck map.\n6. Calibrate your labware, tiprack and pipette using the OT App. For calibration tips, check out our [support articles](https://support.opentrons.com/en/collections/1559720-guide-for-getting-started-with-the-ot-2).\n7. Hit 'Run'.\n\n",
+        "protocol-steps": "1. Distribute 20 uL of media on each well of plate 1 in the following order: A1, A2, A3, A4, B4, B3, B2, B1, C1, C2, C3, C4.\n2. Aspirate 1000 uL of oil and dispense it onto plate 1. (Repeat Step 4 more times).\n3. Repeat steps 1 and 2 for all plates on deck.\n\n",
+        "reagents": "* [Global Total Media](https://fertility.coopersurgical.com/art_media/global-total/)\n* [Life Global LifeGuard Oil](https://fertility.coopersurgical.com/art_media/lifeglobal-oils/)\n\n---\n\n",
+        "title": "Vitrolife Plate Prep"
+    },
+    "notes": "If you have any questions about this protocol, please contact the Protocol Development Team by filling out the Troubleshooting Survey.",
+    "pipettes": "\nP300 Single GEN2 Pipette\nP1000 Single GEN2 Pipette\n",
+    "process": "\nInput your protocol parameters above.\nDownload your protocol and unzip if needed.\nUpload your custom labware to the OT App by navigating to More > Custom Labware > Add Labware, and selecting your labware files (.json extensions) if needed.\nUpload your protocol file (.py extension) to the OT App in the Protocol tab.\nSet up your deck according to the deck map.\nCalibrate your labware, tiprack and pipette using the OT App. For calibration tips, check out our support articles.\nHit 'Run'.\n",
+    "protocol-steps": "\nDistribute 20 uL of media on each well of plate 1 in the following order: A1, A2, A3, A4, B4, B3, B2, B1, C1, C2, C3, C4.\nAspirate 1000 uL of oil and dispense it onto plate 1. (Repeat Step 4 more times).\nRepeat steps 1 and 2 for all plates on deck.\n",
+    "reagents": [
+        "Global Total Media",
+        "Life Global LifeGuard Oil"
+    ],
+    "title": "Vitrolife Plate Prep"
+}

--- a/protoBuilds/5414fa/metadata.json
+++ b/protoBuilds/5414fa/metadata.json
@@ -1,0 +1,20 @@
+{
+    "files": {
+        "OT 1 protocol": [],
+        "OT 2 protocol": [
+            "5414fa.ot2.apiv2.py"
+        ],
+        "description": [
+            "README.md"
+        ]
+    },
+    "flags": {
+        "embedded-app": false,
+        "feature": false,
+        "hide-from-search": false,
+        "skip-tests": false
+    },
+    "path": "protocols/5414fa",
+    "slug": "5414fa",
+    "status": "ok"
+}

--- a/protocols/5414fa/5414fa.ot2.apiv2.py
+++ b/protocols/5414fa/5414fa.ot2.apiv2.py
@@ -1,0 +1,70 @@
+metadata = {
+    'protocolName': 'Vitrolife Plate Prep',
+    'author': 'Sakib <sakib.hossain@opentrons.com>',
+    'description': 'Custom Protocol Request',
+    'apiLevel': '2.10'
+}
+
+
+def run(ctx):
+
+    # Load Labware
+
+    dish = ctx.load_labware('vitrolife_culture_dish', 1)
+    tipracks_200ul = ctx.load_labware('opentrons_96_filtertiprack_200ul', 2)
+    tipracks_1000ul = ctx.load_labware('opentrons_96_filtertiprack_1000ul', 3)
+    tuberack = ctx.load_labware('opentrons_6_tuberack_falcon_50ml_conical', 4)
+
+    # Load Pipettes
+
+    p300 = ctx.load_instrument('p300_single_gen2', 'left',
+                               tip_racks=[tipracks_200ul])
+    p1000 = ctx.load_instrument('p1000_single_gen2', 'right',
+                                tip_racks=[tipracks_1000ul])
+
+    # Helper Functions
+    def change_flow_rates(pip, asp_speed, disp_speed):
+        pip.flow_rate.aspirate = asp_speed
+        pip.flow_rate.dispense = disp_speed
+
+    def reset_flow_rates(pip):
+        if pip.name == 'p300_single_gen2':
+            pip.flow_rate.aspirate = 92.86
+            pip.flow_rate.dispense = 92.86
+        else:
+            pip.flow_rate.aspirate = 274.7
+            pip.flow_rate.dispense = 274.7
+
+    # Reagents
+
+    media = tuberack['A1']
+    oil_1 = tuberack['B1']
+
+    # Sample Wells
+
+    wells = []
+    for i, row in enumerate(dish.rows()):
+        if i % 2 == 0:
+            for well in row:
+                wells.append(well)
+        else:
+            for well in row[::-1]:
+                wells.append(well)
+
+    oil_loc = dish['D1']
+
+    # Protocol Steps
+
+    # Step 1
+    p300.distribute(20, media, wells, new_tip='once')
+    # Step 2
+    p1000.pick_up_tip()
+    for i in range(5):
+        reset_flow_rates(p1000)
+        if i == 0:
+            change_flow_rates(p1000, 200, 200)
+        p1000.aspirate(1000, oil_1)
+        p1000.dispense(1000, oil_loc)
+        ctx.delay(seconds=2)
+        p1000.blow_out()
+    p1000.drop_tip()

--- a/protocols/5414fa/README.md
+++ b/protocols/5414fa/README.md
@@ -1,0 +1,56 @@
+# Vitrolife Plate Prep
+
+### Author
+[Opentrons](https://opentrons.com/)
+
+## Categories
+* Sample Prep
+	* Plate Filling
+
+## Description
+This protocol performs the preparation of media and oils onto the [Vitrolife Micro-droplet Culture Dish](https://www.vitrolife.com/products/labware/dishes/). It adds media to each of the 12 wells in the plate by distributing 20 uL in a single take. It will then transfer a total of 5 mL of oil to the inner perimeter of the plate. **This protocol is still a Work In Progress and is subject to refactoring based on a pending custom labware piece.**
+
+---
+
+### Labware
+* [Opentrons 200 uL Filter Tips](https://shop.opentrons.com/collections/opentrons-tips/products/opentrons-200ul-filter-tips)
+* [Opentrons 1000 uL Filter Tips](https://shop.opentrons.com/collections/opentrons-tips/products/opentrons-1000ul-filter-tips)
+* [Vitrolife Micro-droplet Culture Dish](https://www.vitrolife.com/products/labware/dishes/)
+
+### Pipettes
+* [P300 Single GEN2 Pipette](https://shop.opentrons.com/collections/ot-2-robot/products/single-channel-electronic-pipette?variant=5984549109789)
+* [P1000 Single GEN2 Pipette](https://shop.opentrons.com/collections/ot-2-robot/products/single-channel-electronic-pipette?variant=5984549142557)
+
+### Reagents
+* [Global Total Media](https://fertility.coopersurgical.com/art_media/global-total/)
+* [Life Global LifeGuard Oil](https://fertility.coopersurgical.com/art_media/lifeglobal-oils/)
+
+---
+
+### Deck Setup
+**Deck Setup is currently unavailable as the custom labware component to house the plates and reagents on the OT-2 deck are actively being developed.**
+
+The protocol currently uses a dummy labware definition of the Vitrolife dish to display the basic protocol logic using our Python API. 
+![Vitrolife Dish](https://opentrons-protocol-library-website.s3.amazonaws.com/custom-README-images/5414fa/vitrolife_culture_dish.png)
+
+---
+
+### Protocol Steps
+1. Distribute 20 uL of media on each well of plate 1 in the following order: A1, A2, A3, A4, B4, B3, B2, B1, C1, C2, C3, C4.
+2. Aspirate 1000 uL of oil and dispense it onto plate 1. (Repeat Step 4 more times).
+3. Repeat steps 1 and 2 for all plates on deck.
+
+### Process
+1. Input your protocol parameters above.
+2. Download your protocol and unzip if needed.
+3. Upload your custom labware to the [OT App](https://opentrons.com/ot-app) by navigating to `More` > `Custom Labware` > `Add Labware`, and selecting your labware files (.json extensions) if needed.
+4. Upload your protocol file (.py extension) to the [OT App](https://opentrons.com/ot-app) in the `Protocol` tab.
+5. Set up your deck according to the deck map.
+6. Calibrate your labware, tiprack and pipette using the OT App. For calibration tips, check out our [support articles](https://support.opentrons.com/en/collections/1559720-guide-for-getting-started-with-the-ot-2).
+7. Hit 'Run'.
+
+### Additional Notes
+If you have any questions about this protocol, please contact the Protocol Development Team by filling out the [Troubleshooting Survey](https://protocol-troubleshooting.paperform.co/).
+
+###### Internal
+5414fa

--- a/protocols/5414fa/labware/vitrolife_dish.json
+++ b/protocols/5414fa/labware/vitrolife_dish.json
@@ -1,0 +1,198 @@
+{
+    "wells": {
+      "A1": {
+        "totalLiquidVolume": 15000,
+        "diameter": 4,
+        "shape": "circular",
+        "depth": 10,
+        "x": 25,
+        "y": 45,
+        "z": 10
+      },
+      "B1": {
+        "totalLiquidVolume": 15000,
+        "diameter": 4,
+        "shape": "circular",
+        "depth": 10,
+        "x": 25,
+        "y": 40,
+        "z": 10
+      },
+      "C1": {
+        "totalLiquidVolume": 15000,
+        "diameter": 4,
+        "shape": "circular",
+        "depth": 10,
+        "x": 25,
+        "y": 35,
+        "z": 10
+      },
+      "A2": {
+        "totalLiquidVolume": 15000,
+        "diameter": 4,
+        "shape": "circular",
+        "depth": 10,
+        "x": 30,
+        "y": 45,
+        "z": 10
+      },
+      "B2": {
+        "totalLiquidVolume": 15000,
+        "diameter": 4,
+        "shape": "circular",
+        "depth": 10,
+        "x": 30,
+        "y": 40,
+        "z": 10
+      },
+      "C2": {
+        "totalLiquidVolume": 15000,
+        "diameter": 4,
+        "shape": "circular",
+        "depth": 10,
+        "x": 30,
+        "y": 35,
+        "z": 10
+      },
+      "A3": {
+        "totalLiquidVolume": 15000,
+        "diameter": 4,
+        "shape": "circular",
+        "depth": 10,
+        "x": 35,
+        "y": 45,
+        "z": 10
+      },
+      "B3": {
+        "totalLiquidVolume": 15000,
+        "diameter": 4,
+        "shape": "circular",
+        "depth": 10,
+        "x": 35,
+        "y": 40,
+        "z": 10
+      },
+      "C3": {
+        "totalLiquidVolume": 15000,
+        "diameter": 4,
+        "shape": "circular",
+        "depth": 10,
+        "x": 35,
+        "y": 35,
+        "z": 10
+      },
+      "A4": {
+        "totalLiquidVolume": 15000,
+        "diameter": 4,
+        "shape": "circular",
+        "depth": 10,
+        "x": 40,
+        "y": 45,
+        "z": 10
+      },
+      "B4": {
+        "totalLiquidVolume": 15000,
+        "diameter": 4,
+        "shape": "circular",
+        "depth": 10,
+        "x": 40,
+        "y": 40,
+        "z": 10
+      },
+      "C4": {
+        "totalLiquidVolume": 15000,
+        "diameter": 4,
+        "shape": "circular",
+        "depth": 10,
+        "x": 40,
+        "y": 35,
+        "z": 10
+      },
+      "D1": {
+        "totalLiquidVolume": 15000,
+        "xDimension": 20,
+        "yDimension": 5,
+        "shape": "rectangular",
+        "depth": 10,
+        "x": 32,
+        "y": 28,
+        "z": 10
+      }
+    },
+    "groups": [
+      {
+        "metadata": {},
+        "wells": [
+          "A1",
+          "B1",
+          "C1",
+          "A2",
+          "B2",
+          "C2",
+          "A3",
+          "B3",
+          "C3",
+          "A4",
+          "B4",
+          "C4"
+        ]
+      },
+      {
+        "metadata": {},
+        "wells": [
+          "D1"
+        ]
+      }
+    ],
+    "brand": {
+      "brand": "generic"
+    },
+    "metadata": {
+      "displayName": "Vitrolife Micro-droplet Culture Dish",
+      "displayCategory": "tubeRack",
+      "displayVolumeUnits": "mL",
+      "tags": []
+    },
+    "dimensions": {
+      "xDimension": 66,
+      "yDimension": 66,
+      "zDimension": 20
+    },
+    "parameters": {
+      "format": "irregular",
+      "isTiprack": false,
+      "isMagneticModuleCompatible": false,
+      "loadName": "vitrolife_culture_dish"
+    },
+    "ordering": [
+      [
+        "A1",
+        "B1",
+        "C1",
+        "D1"
+      ],
+      [
+        "A2",
+        "B2",
+        "C2"
+      ],
+      [
+        "A3",
+        "B3",
+        "C3"
+      ],
+      [
+        "A4",
+        "B4",
+        "C4"
+      ]
+    ],
+    "namespace": "custom_beta",
+    "version": 1,
+    "schemaVersion": 2,
+    "cornerOffsetFromSlot": {
+      "x": 0,
+      "y": 0,
+      "z": 0
+    }
+  }


### PR DESCRIPTION
## overview
This protocol performs the preparation of media and oils onto the [Vitrolife Micro-droplet Culture Dish](https://www.vitrolife.com/products/labware/dishes/). It adds media to each of the 12 wells in the plate by distributing 20 uL in a single take. It will then transfer a total of 5 mL of oil to the inner perimeter of the plate. **This protocol is still a Work In Progress and is subject to refactoring based on a pending custom labware piece.** closes #2596 closes #2593 