### PR TITLE
feat(scripts): create scripts for Protocol Designer supplement file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,7 @@ $(BUILD_DIR)/%.ot2.apiv2.py.json: protocols/%.ot2.apiv2.py
 	source venvs/ot2/bin/activate && \
 	export OVERRIDE_SETTINGS_DIR=$(OT2_MONOREPO_DIR)/api/tests/opentrons/data && \
 	python protolib/parse/parseOT2v2.py $< $@ && \
+	python scripts/pd-generate.py $< && \
 	deactivate
 
 .PHONY: parse-README

--- a/scripts/generator-test.json
+++ b/scripts/generator-test.json
@@ -1,0 +1,6222 @@
+{
+  "metadata": {
+    "protocolName": "test_generator",
+    "author": "",
+    "description": "this is a test description of the protocol test",
+    "created": 1630960035646,
+    "lastModified": 1630960814888,
+    "category": null,
+    "subcategory": null,
+    "tags": []
+  },
+  "designerApplication": {
+    "name": "opentrons/protocol-designer",
+    "version": "5.2.6",
+    "data": {
+      "_internalAppBuildDate": "Mon, 26 Apr 2021 18:42:28 GMT",
+      "defaultValues": {
+        "aspirate_mmFromBottom": 1,
+        "dispense_mmFromBottom": 0.5,
+        "touchTip_mmFromTop": -1,
+        "blowout_mmFromTop": 0
+      },
+      "pipetteTiprackAssignments": {
+        "d330bdf0-0f50-11ec-8a82-4f331e0525fd": "opentrons/opentrons_96_tiprack_20ul/1",
+        "d330bdf1-0f50-11ec-8a82-4f331e0525fd": "opentrons/opentrons_96_filtertiprack_200ul/1"
+      },
+      "dismissedWarnings": {
+        "form": {},
+        "timeline": {}
+      },
+      "ingredients": {
+        "0": {
+          "name": "binding buffer",
+          "description": "test description of binding buffer",
+          "serialize": false,
+          "liquidGroupId": "0"
+        }
+      },
+      "ingredLocations": {
+        "0f7b9e10-0f51-11ec-8a82-4f331e0525fd:opentrons/opentrons_15_tuberack_falcon_15ml_conical/1": {
+          "A1": {
+            "0": {
+              "volume": 10000
+            }
+          }
+        },
+        "21b0e9e0-0f52-11ec-8a82-4f331e0525fd:opentrons/biorad_96_wellplate_200ul_pcr/1": {
+          "A4": {
+            "0": {
+              "volume": 200
+            }
+          },
+          "B4": {
+            "0": {
+              "volume": 200
+            }
+          },
+          "C4": {
+            "0": {
+              "volume": 200
+            }
+          },
+          "D4": {
+            "0": {
+              "volume": 200
+            }
+          },
+          "E4": {
+            "0": {
+              "volume": 200
+            }
+          },
+          "F4": {
+            "0": {
+              "volume": 200
+            }
+          },
+          "G4": {
+            "0": {
+              "volume": 200
+            }
+          },
+          "H4": {
+            "0": {
+              "volume": 200
+            }
+          }
+        }
+      },
+      "savedStepForms": {
+        "__INITIAL_DECK_SETUP_STEP__": {
+          "stepType": "manualIntervention",
+          "id": "__INITIAL_DECK_SETUP_STEP__",
+          "labwareLocationUpdate": {
+            "trashId": "12",
+            "d33307e0-0f50-11ec-8a82-4f331e0525fd:opentrons/opentrons_96_tiprack_20ul/1": "5",
+            "d333f240-0f50-11ec-8a82-4f331e0525fd:opentrons/opentrons_96_filtertiprack_200ul/1": "2",
+            "0f7b9e10-0f51-11ec-8a82-4f331e0525fd:opentrons/opentrons_15_tuberack_falcon_15ml_conical/1": "3",
+            "1efa98f0-0f51-11ec-8a82-4f331e0525fd:custom_beta/tpp_96well_plate_340ul/1": "6",
+            "1db21df0-0f52-11ec-8a82-4f331e0525fd:opentrons/nest_96_wellplate_2ml_deep/1": "e7c4d6c0-0f50-11ec-8a82-4f331e0525fd:magneticModuleType",
+            "21b0e9e0-0f52-11ec-8a82-4f331e0525fd:opentrons/biorad_96_wellplate_200ul_pcr/1": "d3321d80-0f50-11ec-8a82-4f331e0525fd:temperatureModuleType"
+          },
+          "pipetteLocationUpdate": {
+            "d330bdf0-0f50-11ec-8a82-4f331e0525fd": "left",
+            "d330bdf1-0f50-11ec-8a82-4f331e0525fd": "right"
+          },
+          "moduleLocationUpdate": {
+            "d3321d80-0f50-11ec-8a82-4f331e0525fd:temperatureModuleType": "1",
+            "e7c4d6c0-0f50-11ec-8a82-4f331e0525fd:magneticModuleType": "4"
+          }
+        }
+      },
+      "orderedStepIds": [
+      ]
+    }
+  },
+  "robot": {
+    "model": "OT-2 Standard"
+  },
+  "pipettes": {
+    "d330bdf0-0f50-11ec-8a82-4f331e0525fd": {
+      "mount": "left",
+      "name": "p20_single_gen2"
+    },
+    "d330bdf1-0f50-11ec-8a82-4f331e0525fd": {
+      "mount": "right",
+      "name": "p300_multi_gen2"
+    }
+  },
+  "labware": {
+    "trashId": {
+      "slot": "12",
+      "displayName": "Trash",
+      "definitionId": "opentrons/opentrons_1_trash_1100ml_fixed/1"
+    },
+    "d33307e0-0f50-11ec-8a82-4f331e0525fd:opentrons/opentrons_96_tiprack_20ul/1": {
+      "slot": "5",
+      "displayName": "Opentrons 96 Tip Rack 20 µL",
+      "definitionId": "opentrons/opentrons_96_tiprack_20ul/1"
+    },
+    "d333f240-0f50-11ec-8a82-4f331e0525fd:opentrons/opentrons_96_filtertiprack_200ul/1": {
+      "slot": "2",
+      "displayName": "Opentrons 96 Filter Tip Rack 200 µL",
+      "definitionId": "opentrons/opentrons_96_filtertiprack_200ul/1"
+    },
+    "0f7b9e10-0f51-11ec-8a82-4f331e0525fd:opentrons/opentrons_15_tuberack_falcon_15ml_conical/1": {
+      "slot": "3",
+      "displayName": "Opentrons 15 Tube Rack with Falcon 15 mL Conical",
+      "definitionId": "opentrons/opentrons_15_tuberack_falcon_15ml_conical/1"
+    },
+    "1efa98f0-0f51-11ec-8a82-4f331e0525fd:custom_beta/tpp_96well_plate_340ul/1": {
+      "slot": "6",
+      "displayName": "TPP Tissue culture testplate 96F 92096",
+      "definitionId": "custom_beta/tpp_96well_plate_340ul/1"
+    },
+    "1db21df0-0f52-11ec-8a82-4f331e0525fd:opentrons/nest_96_wellplate_2ml_deep/1": {
+      "slot": "e7c4d6c0-0f50-11ec-8a82-4f331e0525fd:magneticModuleType",
+      "displayName": "NEST 96 Deepwell Plate 2mL",
+      "definitionId": "opentrons/nest_96_wellplate_2ml_deep/1"
+    },
+    "21b0e9e0-0f52-11ec-8a82-4f331e0525fd:opentrons/biorad_96_wellplate_200ul_pcr/1": {
+      "slot": "d3321d80-0f50-11ec-8a82-4f331e0525fd:temperatureModuleType",
+      "displayName": "Bio-Rad 96 Well Plate 200 µL PCR",
+      "definitionId": "opentrons/biorad_96_wellplate_200ul_pcr/1"
+    }
+  },
+  "labwareDefinitions": {
+    "opentrons/opentrons_96_tiprack_20ul/1": {
+      "ordering": [
+        [
+          "A1",
+          "B1",
+          "C1",
+          "D1",
+          "E1",
+          "F1",
+          "G1",
+          "H1"
+        ],
+        [
+          "A2",
+          "B2",
+          "C2",
+          "D2",
+          "E2",
+          "F2",
+          "G2",
+          "H2"
+        ],
+        [
+          "A3",
+          "B3",
+          "C3",
+          "D3",
+          "E3",
+          "F3",
+          "G3",
+          "H3"
+        ],
+        [
+          "A4",
+          "B4",
+          "C4",
+          "D4",
+          "E4",
+          "F4",
+          "G4",
+          "H4"
+        ],
+        [
+          "A5",
+          "B5",
+          "C5",
+          "D5",
+          "E5",
+          "F5",
+          "G5",
+          "H5"
+        ],
+        [
+          "A6",
+          "B6",
+          "C6",
+          "D6",
+          "E6",
+          "F6",
+          "G6",
+          "H6"
+        ],
+        [
+          "A7",
+          "B7",
+          "C7",
+          "D7",
+          "E7",
+          "F7",
+          "G7",
+          "H7"
+        ],
+        [
+          "A8",
+          "B8",
+          "C8",
+          "D8",
+          "E8",
+          "F8",
+          "G8",
+          "H8"
+        ],
+        [
+          "A9",
+          "B9",
+          "C9",
+          "D9",
+          "E9",
+          "F9",
+          "G9",
+          "H9"
+        ],
+        [
+          "A10",
+          "B10",
+          "C10",
+          "D10",
+          "E10",
+          "F10",
+          "G10",
+          "H10"
+        ],
+        [
+          "A11",
+          "B11",
+          "C11",
+          "D11",
+          "E11",
+          "F11",
+          "G11",
+          "H11"
+        ],
+        [
+          "A12",
+          "B12",
+          "C12",
+          "D12",
+          "E12",
+          "F12",
+          "G12",
+          "H12"
+        ]
+      ],
+      "brand": {
+        "brand": "Opentrons",
+        "brandId": [],
+        "links": [
+          "https://shop.opentrons.com/collections/opentrons-tips/products/opentrons-10ul-tips"
+        ]
+      },
+      "metadata": {
+        "displayName": "Opentrons 96 Tip Rack 20 µL",
+        "displayCategory": "tipRack",
+        "displayVolumeUnits": "µL",
+        "tags": []
+      },
+      "dimensions": {
+        "xDimension": 127.76,
+        "yDimension": 85.48,
+        "zDimension": 64.69
+      },
+      "wells": {
+        "A1": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 14.38,
+          "y": 74.24,
+          "z": 25.49
+        },
+        "B1": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 14.38,
+          "y": 65.24,
+          "z": 25.49
+        },
+        "C1": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 14.38,
+          "y": 56.24,
+          "z": 25.49
+        },
+        "D1": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 14.38,
+          "y": 47.24,
+          "z": 25.49
+        },
+        "E1": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 14.38,
+          "y": 38.24,
+          "z": 25.49
+        },
+        "F1": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 14.38,
+          "y": 29.24,
+          "z": 25.49
+        },
+        "G1": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 14.38,
+          "y": 20.24,
+          "z": 25.49
+        },
+        "H1": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 14.38,
+          "y": 11.24,
+          "z": 25.49
+        },
+        "A2": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 23.38,
+          "y": 74.24,
+          "z": 25.49
+        },
+        "B2": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 23.38,
+          "y": 65.24,
+          "z": 25.49
+        },
+        "C2": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 23.38,
+          "y": 56.24,
+          "z": 25.49
+        },
+        "D2": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 23.38,
+          "y": 47.24,
+          "z": 25.49
+        },
+        "E2": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 23.38,
+          "y": 38.24,
+          "z": 25.49
+        },
+        "F2": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 23.38,
+          "y": 29.24,
+          "z": 25.49
+        },
+        "G2": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 23.38,
+          "y": 20.24,
+          "z": 25.49
+        },
+        "H2": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 23.38,
+          "y": 11.24,
+          "z": 25.49
+        },
+        "A3": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 32.38,
+          "y": 74.24,
+          "z": 25.49
+        },
+        "B3": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 32.38,
+          "y": 65.24,
+          "z": 25.49
+        },
+        "C3": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 32.38,
+          "y": 56.24,
+          "z": 25.49
+        },
+        "D3": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 32.38,
+          "y": 47.24,
+          "z": 25.49
+        },
+        "E3": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 32.38,
+          "y": 38.24,
+          "z": 25.49
+        },
+        "F3": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 32.38,
+          "y": 29.24,
+          "z": 25.49
+        },
+        "G3": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 32.38,
+          "y": 20.24,
+          "z": 25.49
+        },
+        "H3": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 32.38,
+          "y": 11.24,
+          "z": 25.49
+        },
+        "A4": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 41.38,
+          "y": 74.24,
+          "z": 25.49
+        },
+        "B4": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 41.38,
+          "y": 65.24,
+          "z": 25.49
+        },
+        "C4": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 41.38,
+          "y": 56.24,
+          "z": 25.49
+        },
+        "D4": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 41.38,
+          "y": 47.24,
+          "z": 25.49
+        },
+        "E4": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 41.38,
+          "y": 38.24,
+          "z": 25.49
+        },
+        "F4": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 41.38,
+          "y": 29.24,
+          "z": 25.49
+        },
+        "G4": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 41.38,
+          "y": 20.24,
+          "z": 25.49
+        },
+        "H4": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 41.38,
+          "y": 11.24,
+          "z": 25.49
+        },
+        "A5": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 50.38,
+          "y": 74.24,
+          "z": 25.49
+        },
+        "B5": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 50.38,
+          "y": 65.24,
+          "z": 25.49
+        },
+        "C5": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 50.38,
+          "y": 56.24,
+          "z": 25.49
+        },
+        "D5": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 50.38,
+          "y": 47.24,
+          "z": 25.49
+        },
+        "E5": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 50.38,
+          "y": 38.24,
+          "z": 25.49
+        },
+        "F5": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 50.38,
+          "y": 29.24,
+          "z": 25.49
+        },
+        "G5": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 50.38,
+          "y": 20.24,
+          "z": 25.49
+        },
+        "H5": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 50.38,
+          "y": 11.24,
+          "z": 25.49
+        },
+        "A6": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 59.38,
+          "y": 74.24,
+          "z": 25.49
+        },
+        "B6": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 59.38,
+          "y": 65.24,
+          "z": 25.49
+        },
+        "C6": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 59.38,
+          "y": 56.24,
+          "z": 25.49
+        },
+        "D6": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 59.38,
+          "y": 47.24,
+          "z": 25.49
+        },
+        "E6": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 59.38,
+          "y": 38.24,
+          "z": 25.49
+        },
+        "F6": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 59.38,
+          "y": 29.24,
+          "z": 25.49
+        },
+        "G6": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 59.38,
+          "y": 20.24,
+          "z": 25.49
+        },
+        "H6": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 59.38,
+          "y": 11.24,
+          "z": 25.49
+        },
+        "A7": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 68.38,
+          "y": 74.24,
+          "z": 25.49
+        },
+        "B7": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 68.38,
+          "y": 65.24,
+          "z": 25.49
+        },
+        "C7": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 68.38,
+          "y": 56.24,
+          "z": 25.49
+        },
+        "D7": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 68.38,
+          "y": 47.24,
+          "z": 25.49
+        },
+        "E7": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 68.38,
+          "y": 38.24,
+          "z": 25.49
+        },
+        "F7": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 68.38,
+          "y": 29.24,
+          "z": 25.49
+        },
+        "G7": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 68.38,
+          "y": 20.24,
+          "z": 25.49
+        },
+        "H7": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 68.38,
+          "y": 11.24,
+          "z": 25.49
+        },
+        "A8": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 77.38,
+          "y": 74.24,
+          "z": 25.49
+        },
+        "B8": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 77.38,
+          "y": 65.24,
+          "z": 25.49
+        },
+        "C8": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 77.38,
+          "y": 56.24,
+          "z": 25.49
+        },
+        "D8": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 77.38,
+          "y": 47.24,
+          "z": 25.49
+        },
+        "E8": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 77.38,
+          "y": 38.24,
+          "z": 25.49
+        },
+        "F8": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 77.38,
+          "y": 29.24,
+          "z": 25.49
+        },
+        "G8": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 77.38,
+          "y": 20.24,
+          "z": 25.49
+        },
+        "H8": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 77.38,
+          "y": 11.24,
+          "z": 25.49
+        },
+        "A9": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 86.38,
+          "y": 74.24,
+          "z": 25.49
+        },
+        "B9": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 86.38,
+          "y": 65.24,
+          "z": 25.49
+        },
+        "C9": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 86.38,
+          "y": 56.24,
+          "z": 25.49
+        },
+        "D9": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 86.38,
+          "y": 47.24,
+          "z": 25.49
+        },
+        "E9": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 86.38,
+          "y": 38.24,
+          "z": 25.49
+        },
+        "F9": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 86.38,
+          "y": 29.24,
+          "z": 25.49
+        },
+        "G9": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 86.38,
+          "y": 20.24,
+          "z": 25.49
+        },
+        "H9": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 86.38,
+          "y": 11.24,
+          "z": 25.49
+        },
+        "A10": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 95.38,
+          "y": 74.24,
+          "z": 25.49
+        },
+        "B10": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 95.38,
+          "y": 65.24,
+          "z": 25.49
+        },
+        "C10": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 95.38,
+          "y": 56.24,
+          "z": 25.49
+        },
+        "D10": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 95.38,
+          "y": 47.24,
+          "z": 25.49
+        },
+        "E10": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 95.38,
+          "y": 38.24,
+          "z": 25.49
+        },
+        "F10": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 95.38,
+          "y": 29.24,
+          "z": 25.49
+        },
+        "G10": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 95.38,
+          "y": 20.24,
+          "z": 25.49
+        },
+        "H10": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 95.38,
+          "y": 11.24,
+          "z": 25.49
+        },
+        "A11": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 104.38,
+          "y": 74.24,
+          "z": 25.49
+        },
+        "B11": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 104.38,
+          "y": 65.24,
+          "z": 25.49
+        },
+        "C11": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 104.38,
+          "y": 56.24,
+          "z": 25.49
+        },
+        "D11": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 104.38,
+          "y": 47.24,
+          "z": 25.49
+        },
+        "E11": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 104.38,
+          "y": 38.24,
+          "z": 25.49
+        },
+        "F11": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 104.38,
+          "y": 29.24,
+          "z": 25.49
+        },
+        "G11": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 104.38,
+          "y": 20.24,
+          "z": 25.49
+        },
+        "H11": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 104.38,
+          "y": 11.24,
+          "z": 25.49
+        },
+        "A12": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 113.38,
+          "y": 74.24,
+          "z": 25.49
+        },
+        "B12": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 113.38,
+          "y": 65.24,
+          "z": 25.49
+        },
+        "C12": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 113.38,
+          "y": 56.24,
+          "z": 25.49
+        },
+        "D12": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 113.38,
+          "y": 47.24,
+          "z": 25.49
+        },
+        "E12": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 113.38,
+          "y": 38.24,
+          "z": 25.49
+        },
+        "F12": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 113.38,
+          "y": 29.24,
+          "z": 25.49
+        },
+        "G12": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 113.38,
+          "y": 20.24,
+          "z": 25.49
+        },
+        "H12": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 20,
+          "x": 113.38,
+          "y": 11.24,
+          "z": 25.49
+        }
+      },
+      "groups": [
+        {
+          "metadata": {},
+          "wells": [
+            "A1",
+            "B1",
+            "C1",
+            "D1",
+            "E1",
+            "F1",
+            "G1",
+            "H1",
+            "A2",
+            "B2",
+            "C2",
+            "D2",
+            "E2",
+            "F2",
+            "G2",
+            "H2",
+            "A3",
+            "B3",
+            "C3",
+            "D3",
+            "E3",
+            "F3",
+            "G3",
+            "H3",
+            "A4",
+            "B4",
+            "C4",
+            "D4",
+            "E4",
+            "F4",
+            "G4",
+            "H4",
+            "A5",
+            "B5",
+            "C5",
+            "D5",
+            "E5",
+            "F5",
+            "G5",
+            "H5",
+            "A6",
+            "B6",
+            "C6",
+            "D6",
+            "E6",
+            "F6",
+            "G6",
+            "H6",
+            "A7",
+            "B7",
+            "C7",
+            "D7",
+            "E7",
+            "F7",
+            "G7",
+            "H7",
+            "A8",
+            "B8",
+            "C8",
+            "D8",
+            "E8",
+            "F8",
+            "G8",
+            "H8",
+            "A9",
+            "B9",
+            "C9",
+            "D9",
+            "E9",
+            "F9",
+            "G9",
+            "H9",
+            "A10",
+            "B10",
+            "C10",
+            "D10",
+            "E10",
+            "F10",
+            "G10",
+            "H10",
+            "A11",
+            "B11",
+            "C11",
+            "D11",
+            "E11",
+            "F11",
+            "G11",
+            "H11",
+            "A12",
+            "B12",
+            "C12",
+            "D12",
+            "E12",
+            "F12",
+            "G12",
+            "H12"
+          ]
+        }
+      ],
+      "parameters": {
+        "format": "96Standard",
+        "isTiprack": true,
+        "tipLength": 39.2,
+        "tipOverlap": 8.25,
+        "isMagneticModuleCompatible": false,
+        "loadName": "opentrons_96_tiprack_20ul"
+      },
+      "namespace": "opentrons",
+      "version": 1,
+      "schemaVersion": 2,
+      "cornerOffsetFromSlot": {
+        "x": 0,
+        "y": 0,
+        "z": 0
+      }
+    },
+    "opentrons/opentrons_96_filtertiprack_200ul/1": {
+      "ordering": [
+        [
+          "A1",
+          "B1",
+          "C1",
+          "D1",
+          "E1",
+          "F1",
+          "G1",
+          "H1"
+        ],
+        [
+          "A2",
+          "B2",
+          "C2",
+          "D2",
+          "E2",
+          "F2",
+          "G2",
+          "H2"
+        ],
+        [
+          "A3",
+          "B3",
+          "C3",
+          "D3",
+          "E3",
+          "F3",
+          "G3",
+          "H3"
+        ],
+        [
+          "A4",
+          "B4",
+          "C4",
+          "D4",
+          "E4",
+          "F4",
+          "G4",
+          "H4"
+        ],
+        [
+          "A5",
+          "B5",
+          "C5",
+          "D5",
+          "E5",
+          "F5",
+          "G5",
+          "H5"
+        ],
+        [
+          "A6",
+          "B6",
+          "C6",
+          "D6",
+          "E6",
+          "F6",
+          "G6",
+          "H6"
+        ],
+        [
+          "A7",
+          "B7",
+          "C7",
+          "D7",
+          "E7",
+          "F7",
+          "G7",
+          "H7"
+        ],
+        [
+          "A8",
+          "B8",
+          "C8",
+          "D8",
+          "E8",
+          "F8",
+          "G8",
+          "H8"
+        ],
+        [
+          "A9",
+          "B9",
+          "C9",
+          "D9",
+          "E9",
+          "F9",
+          "G9",
+          "H9"
+        ],
+        [
+          "A10",
+          "B10",
+          "C10",
+          "D10",
+          "E10",
+          "F10",
+          "G10",
+          "H10"
+        ],
+        [
+          "A11",
+          "B11",
+          "C11",
+          "D11",
+          "E11",
+          "F11",
+          "G11",
+          "H11"
+        ],
+        [
+          "A12",
+          "B12",
+          "C12",
+          "D12",
+          "E12",
+          "F12",
+          "G12",
+          "H12"
+        ]
+      ],
+      "brand": {
+        "brand": "Opentrons",
+        "brandId": [],
+        "links": []
+      },
+      "metadata": {
+        "displayName": "Opentrons 96 Filter Tip Rack 200 µL",
+        "displayCategory": "tipRack",
+        "displayVolumeUnits": "µL",
+        "tags": []
+      },
+      "dimensions": {
+        "xDimension": 127.76,
+        "yDimension": 85.48,
+        "zDimension": 64.49
+      },
+      "wells": {
+        "A1": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 14.38,
+          "y": 74.24,
+          "z": 5.39
+        },
+        "B1": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 14.38,
+          "y": 65.24,
+          "z": 5.39
+        },
+        "C1": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 14.38,
+          "y": 56.24,
+          "z": 5.39
+        },
+        "D1": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 14.38,
+          "y": 47.24,
+          "z": 5.39
+        },
+        "E1": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 14.38,
+          "y": 38.24,
+          "z": 5.39
+        },
+        "F1": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 14.38,
+          "y": 29.24,
+          "z": 5.39
+        },
+        "G1": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 14.38,
+          "y": 20.24,
+          "z": 5.39
+        },
+        "H1": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 14.38,
+          "y": 11.24,
+          "z": 5.39
+        },
+        "A2": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 23.38,
+          "y": 74.24,
+          "z": 5.39
+        },
+        "B2": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 23.38,
+          "y": 65.24,
+          "z": 5.39
+        },
+        "C2": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 23.38,
+          "y": 56.24,
+          "z": 5.39
+        },
+        "D2": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 23.38,
+          "y": 47.24,
+          "z": 5.39
+        },
+        "E2": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 23.38,
+          "y": 38.24,
+          "z": 5.39
+        },
+        "F2": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 23.38,
+          "y": 29.24,
+          "z": 5.39
+        },
+        "G2": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 23.38,
+          "y": 20.24,
+          "z": 5.39
+        },
+        "H2": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 23.38,
+          "y": 11.24,
+          "z": 5.39
+        },
+        "A3": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 32.38,
+          "y": 74.24,
+          "z": 5.39
+        },
+        "B3": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 32.38,
+          "y": 65.24,
+          "z": 5.39
+        },
+        "C3": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 32.38,
+          "y": 56.24,
+          "z": 5.39
+        },
+        "D3": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 32.38,
+          "y": 47.24,
+          "z": 5.39
+        },
+        "E3": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 32.38,
+          "y": 38.24,
+          "z": 5.39
+        },
+        "F3": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 32.38,
+          "y": 29.24,
+          "z": 5.39
+        },
+        "G3": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 32.38,
+          "y": 20.24,
+          "z": 5.39
+        },
+        "H3": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 32.38,
+          "y": 11.24,
+          "z": 5.39
+        },
+        "A4": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 41.38,
+          "y": 74.24,
+          "z": 5.39
+        },
+        "B4": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 41.38,
+          "y": 65.24,
+          "z": 5.39
+        },
+        "C4": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 41.38,
+          "y": 56.24,
+          "z": 5.39
+        },
+        "D4": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 41.38,
+          "y": 47.24,
+          "z": 5.39
+        },
+        "E4": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 41.38,
+          "y": 38.24,
+          "z": 5.39
+        },
+        "F4": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 41.38,
+          "y": 29.24,
+          "z": 5.39
+        },
+        "G4": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 41.38,
+          "y": 20.24,
+          "z": 5.39
+        },
+        "H4": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 41.38,
+          "y": 11.24,
+          "z": 5.39
+        },
+        "A5": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 50.38,
+          "y": 74.24,
+          "z": 5.39
+        },
+        "B5": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 50.38,
+          "y": 65.24,
+          "z": 5.39
+        },
+        "C5": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 50.38,
+          "y": 56.24,
+          "z": 5.39
+        },
+        "D5": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 50.38,
+          "y": 47.24,
+          "z": 5.39
+        },
+        "E5": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 50.38,
+          "y": 38.24,
+          "z": 5.39
+        },
+        "F5": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 50.38,
+          "y": 29.24,
+          "z": 5.39
+        },
+        "G5": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 50.38,
+          "y": 20.24,
+          "z": 5.39
+        },
+        "H5": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 50.38,
+          "y": 11.24,
+          "z": 5.39
+        },
+        "A6": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 59.38,
+          "y": 74.24,
+          "z": 5.39
+        },
+        "B6": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 59.38,
+          "y": 65.24,
+          "z": 5.39
+        },
+        "C6": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 59.38,
+          "y": 56.24,
+          "z": 5.39
+        },
+        "D6": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 59.38,
+          "y": 47.24,
+          "z": 5.39
+        },
+        "E6": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 59.38,
+          "y": 38.24,
+          "z": 5.39
+        },
+        "F6": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 59.38,
+          "y": 29.24,
+          "z": 5.39
+        },
+        "G6": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 59.38,
+          "y": 20.24,
+          "z": 5.39
+        },
+        "H6": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 59.38,
+          "y": 11.24,
+          "z": 5.39
+        },
+        "A7": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 68.38,
+          "y": 74.24,
+          "z": 5.39
+        },
+        "B7": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 68.38,
+          "y": 65.24,
+          "z": 5.39
+        },
+        "C7": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 68.38,
+          "y": 56.24,
+          "z": 5.39
+        },
+        "D7": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 68.38,
+          "y": 47.24,
+          "z": 5.39
+        },
+        "E7": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 68.38,
+          "y": 38.24,
+          "z": 5.39
+        },
+        "F7": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 68.38,
+          "y": 29.24,
+          "z": 5.39
+        },
+        "G7": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 68.38,
+          "y": 20.24,
+          "z": 5.39
+        },
+        "H7": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 68.38,
+          "y": 11.24,
+          "z": 5.39
+        },
+        "A8": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 77.38,
+          "y": 74.24,
+          "z": 5.39
+        },
+        "B8": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 77.38,
+          "y": 65.24,
+          "z": 5.39
+        },
+        "C8": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 77.38,
+          "y": 56.24,
+          "z": 5.39
+        },
+        "D8": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 77.38,
+          "y": 47.24,
+          "z": 5.39
+        },
+        "E8": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 77.38,
+          "y": 38.24,
+          "z": 5.39
+        },
+        "F8": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 77.38,
+          "y": 29.24,
+          "z": 5.39
+        },
+        "G8": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 77.38,
+          "y": 20.24,
+          "z": 5.39
+        },
+        "H8": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 77.38,
+          "y": 11.24,
+          "z": 5.39
+        },
+        "A9": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 86.38,
+          "y": 74.24,
+          "z": 5.39
+        },
+        "B9": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 86.38,
+          "y": 65.24,
+          "z": 5.39
+        },
+        "C9": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 86.38,
+          "y": 56.24,
+          "z": 5.39
+        },
+        "D9": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 86.38,
+          "y": 47.24,
+          "z": 5.39
+        },
+        "E9": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 86.38,
+          "y": 38.24,
+          "z": 5.39
+        },
+        "F9": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 86.38,
+          "y": 29.24,
+          "z": 5.39
+        },
+        "G9": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 86.38,
+          "y": 20.24,
+          "z": 5.39
+        },
+        "H9": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 86.38,
+          "y": 11.24,
+          "z": 5.39
+        },
+        "A10": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 95.38,
+          "y": 74.24,
+          "z": 5.39
+        },
+        "B10": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 95.38,
+          "y": 65.24,
+          "z": 5.39
+        },
+        "C10": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 95.38,
+          "y": 56.24,
+          "z": 5.39
+        },
+        "D10": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 95.38,
+          "y": 47.24,
+          "z": 5.39
+        },
+        "E10": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 95.38,
+          "y": 38.24,
+          "z": 5.39
+        },
+        "F10": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 95.38,
+          "y": 29.24,
+          "z": 5.39
+        },
+        "G10": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 95.38,
+          "y": 20.24,
+          "z": 5.39
+        },
+        "H10": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 95.38,
+          "y": 11.24,
+          "z": 5.39
+        },
+        "A11": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 104.38,
+          "y": 74.24,
+          "z": 5.39
+        },
+        "B11": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 104.38,
+          "y": 65.24,
+          "z": 5.39
+        },
+        "C11": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 104.38,
+          "y": 56.24,
+          "z": 5.39
+        },
+        "D11": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 104.38,
+          "y": 47.24,
+          "z": 5.39
+        },
+        "E11": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 104.38,
+          "y": 38.24,
+          "z": 5.39
+        },
+        "F11": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 104.38,
+          "y": 29.24,
+          "z": 5.39
+        },
+        "G11": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 104.38,
+          "y": 20.24,
+          "z": 5.39
+        },
+        "H11": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 104.38,
+          "y": 11.24,
+          "z": 5.39
+        },
+        "A12": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 113.38,
+          "y": 74.24,
+          "z": 5.39
+        },
+        "B12": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 113.38,
+          "y": 65.24,
+          "z": 5.39
+        },
+        "C12": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 113.38,
+          "y": 56.24,
+          "z": 5.39
+        },
+        "D12": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 113.38,
+          "y": 47.24,
+          "z": 5.39
+        },
+        "E12": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 113.38,
+          "y": 38.24,
+          "z": 5.39
+        },
+        "F12": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 113.38,
+          "y": 29.24,
+          "z": 5.39
+        },
+        "G12": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 113.38,
+          "y": 20.24,
+          "z": 5.39
+        },
+        "H12": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 200,
+          "x": 113.38,
+          "y": 11.24,
+          "z": 5.39
+        }
+      },
+      "groups": [
+        {
+          "metadata": {},
+          "wells": [
+            "A1",
+            "B1",
+            "C1",
+            "D1",
+            "E1",
+            "F1",
+            "G1",
+            "H1",
+            "A2",
+            "B2",
+            "C2",
+            "D2",
+            "E2",
+            "F2",
+            "G2",
+            "H2",
+            "A3",
+            "B3",
+            "C3",
+            "D3",
+            "E3",
+            "F3",
+            "G3",
+            "H3",
+            "A4",
+            "B4",
+            "C4",
+            "D4",
+            "E4",
+            "F4",
+            "G4",
+            "H4",
+            "A5",
+            "B5",
+            "C5",
+            "D5",
+            "E5",
+            "F5",
+            "G5",
+            "H5",
+            "A6",
+            "B6",
+            "C6",
+            "D6",
+            "E6",
+            "F6",
+            "G6",
+            "H6",
+            "A7",
+            "B7",
+            "C7",
+            "D7",
+            "E7",
+            "F7",
+            "G7",
+            "H7",
+            "A8",
+            "B8",
+            "C8",
+            "D8",
+            "E8",
+            "F8",
+            "G8",
+            "H8",
+            "A9",
+            "B9",
+            "C9",
+            "D9",
+            "E9",
+            "F9",
+            "G9",
+            "H9",
+            "A10",
+            "B10",
+            "C10",
+            "D10",
+            "E10",
+            "F10",
+            "G10",
+            "H10",
+            "A11",
+            "B11",
+            "C11",
+            "D11",
+            "E11",
+            "F11",
+            "G11",
+            "H11",
+            "A12",
+            "B12",
+            "C12",
+            "D12",
+            "E12",
+            "F12",
+            "G12",
+            "H12"
+          ]
+        }
+      ],
+      "parameters": {
+        "format": "96Standard",
+        "isTiprack": true,
+        "tipLength": 59.3,
+        "tipOverlap": 7.47,
+        "isMagneticModuleCompatible": false,
+        "loadName": "opentrons_96_filtertiprack_200ul"
+      },
+      "namespace": "opentrons",
+      "version": 1,
+      "schemaVersion": 2,
+      "cornerOffsetFromSlot": {
+        "x": 0,
+        "y": 0,
+        "z": 0
+      }
+    },
+    "opentrons/opentrons_1_trash_1100ml_fixed/1": {
+      "ordering": [
+        [
+          "A1"
+        ]
+      ],
+      "metadata": {
+        "displayCategory": "trash",
+        "displayVolumeUnits": "mL",
+        "displayName": "Opentrons Fixed Trash",
+        "tags": []
+      },
+      "schemaVersion": 2,
+      "version": 1,
+      "namespace": "opentrons",
+      "dimensions": {
+        "xDimension": 172.86,
+        "yDimension": 165.86,
+        "zDimension": 82
+      },
+      "parameters": {
+        "format": "trash",
+        "isTiprack": false,
+        "loadName": "opentrons_1_trash_1100ml_fixed",
+        "isMagneticModuleCompatible": false,
+        "quirks": [
+          "fixedTrash",
+          "centerMultichannelOnWells",
+          "touchTipDisabled"
+        ]
+      },
+      "wells": {
+        "A1": {
+          "shape": "rectangular",
+          "yDimension": 165.67,
+          "xDimension": 107.11,
+          "totalLiquidVolume": 1100000,
+          "depth": 0,
+          "x": 82.84,
+          "y": 80,
+          "z": 82
+        }
+      },
+      "brand": {
+        "brand": "Opentrons"
+      },
+      "groups": [
+        {
+          "wells": [
+            "A1"
+          ],
+          "metadata": {}
+        }
+      ],
+      "cornerOffsetFromSlot": {
+        "x": 0,
+        "y": 0,
+        "z": 0
+      }
+    },
+    "opentrons/opentrons_15_tuberack_falcon_15ml_conical/1": {
+      "ordering": [
+        [
+          "A1",
+          "B1",
+          "C1"
+        ],
+        [
+          "A2",
+          "B2",
+          "C2"
+        ],
+        [
+          "A3",
+          "B3",
+          "C3"
+        ],
+        [
+          "A4",
+          "B4",
+          "C4"
+        ],
+        [
+          "A5",
+          "B5",
+          "C5"
+        ]
+      ],
+      "brand": {
+        "brand": "Opentrons",
+        "brandId": [],
+        "links": [
+          "https://shop.opentrons.com/collections/opentrons-tips/products/tube-rack-set-1"
+        ]
+      },
+      "metadata": {
+        "tags": [],
+        "displayName": "Opentrons 15 Tube Rack with Falcon 15 mL Conical",
+        "displayCategory": "tubeRack",
+        "displayVolumeUnits": "mL"
+      },
+      "dimensions": {
+        "xDimension": 127.76,
+        "yDimension": 85.48,
+        "zDimension": 124.35
+      },
+      "schemaVersion": 2,
+      "version": 1,
+      "namespace": "opentrons",
+      "wells": {
+        "C1": {
+          "depth": 117.5,
+          "diameter": 14.9,
+          "shape": "circular",
+          "totalLiquidVolume": 15000,
+          "x": 13.88,
+          "y": 17.74,
+          "z": 6.85
+        },
+        "B1": {
+          "depth": 117.5,
+          "diameter": 14.9,
+          "shape": "circular",
+          "totalLiquidVolume": 15000,
+          "x": 13.88,
+          "y": 42.74,
+          "z": 6.85
+        },
+        "A1": {
+          "depth": 117.5,
+          "diameter": 14.9,
+          "shape": "circular",
+          "totalLiquidVolume": 15000,
+          "x": 13.88,
+          "y": 67.74,
+          "z": 6.85
+        },
+        "C2": {
+          "depth": 117.5,
+          "diameter": 14.9,
+          "shape": "circular",
+          "totalLiquidVolume": 15000,
+          "x": 38.88,
+          "y": 17.74,
+          "z": 6.85
+        },
+        "B2": {
+          "depth": 117.5,
+          "diameter": 14.9,
+          "shape": "circular",
+          "totalLiquidVolume": 15000,
+          "x": 38.88,
+          "y": 42.74,
+          "z": 6.85
+        },
+        "A2": {
+          "depth": 117.5,
+          "diameter": 14.9,
+          "shape": "circular",
+          "totalLiquidVolume": 15000,
+          "x": 38.88,
+          "y": 67.74,
+          "z": 6.85
+        },
+        "C3": {
+          "depth": 117.5,
+          "diameter": 14.9,
+          "shape": "circular",
+          "totalLiquidVolume": 15000,
+          "x": 63.88,
+          "y": 17.74,
+          "z": 6.85
+        },
+        "B3": {
+          "depth": 117.5,
+          "diameter": 14.9,
+          "shape": "circular",
+          "totalLiquidVolume": 15000,
+          "x": 63.88,
+          "y": 42.74,
+          "z": 6.85
+        },
+        "A3": {
+          "depth": 117.5,
+          "diameter": 14.9,
+          "shape": "circular",
+          "totalLiquidVolume": 15000,
+          "x": 63.88,
+          "y": 67.74,
+          "z": 6.85
+        },
+        "C4": {
+          "depth": 117.5,
+          "diameter": 14.9,
+          "shape": "circular",
+          "totalLiquidVolume": 15000,
+          "x": 88.88,
+          "y": 17.74,
+          "z": 6.85
+        },
+        "B4": {
+          "depth": 117.5,
+          "diameter": 14.9,
+          "shape": "circular",
+          "totalLiquidVolume": 15000,
+          "x": 88.88,
+          "y": 42.74,
+          "z": 6.85
+        },
+        "A4": {
+          "depth": 117.5,
+          "diameter": 14.9,
+          "shape": "circular",
+          "totalLiquidVolume": 15000,
+          "x": 88.88,
+          "y": 67.74,
+          "z": 6.85
+        },
+        "C5": {
+          "depth": 117.5,
+          "diameter": 14.9,
+          "shape": "circular",
+          "totalLiquidVolume": 15000,
+          "x": 113.88,
+          "y": 17.74,
+          "z": 6.85
+        },
+        "B5": {
+          "depth": 117.5,
+          "diameter": 14.9,
+          "shape": "circular",
+          "totalLiquidVolume": 15000,
+          "x": 113.88,
+          "y": 42.74,
+          "z": 6.85
+        },
+        "A5": {
+          "depth": 117.5,
+          "diameter": 14.9,
+          "shape": "circular",
+          "totalLiquidVolume": 15000,
+          "x": 113.88,
+          "y": 67.74,
+          "z": 6.85
+        }
+      },
+      "parameters": {
+        "format": "irregular",
+        "isTiprack": false,
+        "isMagneticModuleCompatible": false,
+        "loadName": "opentrons_15_tuberack_falcon_15ml_conical"
+      },
+      "groups": [
+        {
+          "wells": [
+            "A1",
+            "B1",
+            "C1",
+            "A2",
+            "B2",
+            "C2",
+            "A3",
+            "B3",
+            "C3",
+            "A4",
+            "B4",
+            "C4",
+            "A5",
+            "B5",
+            "C5"
+          ],
+          "metadata": {
+            "displayName": "Falcon 6x15 mL Conical",
+            "displayCategory": "tubeRack",
+            "wellBottomShape": "v"
+          },
+          "brand": {
+            "brand": "Falcon",
+            "brandId": [
+              "352095",
+              "352096",
+              "352097",
+              "352099",
+              "352196"
+            ],
+            "links": [
+              "https://ecatalog.corning.com/life-sciences/b2c/US/en/Liquid-Handling/Tubes,-Liquid-Handling/Centrifuge-Tubes/Falcon%C2%AE-Conical-Centrifuge-Tubes/p/falconConicalTubes"
+            ]
+          }
+        }
+      ],
+      "cornerOffsetFromSlot": {
+        "x": 0,
+        "y": 0,
+        "z": 0
+      }
+    },
+    "custom_beta/tpp_96well_plate_340ul/1": {
+      "ordering": [
+        [
+          "A1",
+          "B1",
+          "C1",
+          "D1",
+          "E1",
+          "F1",
+          "G1",
+          "H1"
+        ],
+        [
+          "A2",
+          "B2",
+          "C2",
+          "D2",
+          "E2",
+          "F2",
+          "G2",
+          "H2"
+        ],
+        [
+          "A3",
+          "B3",
+          "C3",
+          "D3",
+          "E3",
+          "F3",
+          "G3",
+          "H3"
+        ],
+        [
+          "A4",
+          "B4",
+          "C4",
+          "D4",
+          "E4",
+          "F4",
+          "G4",
+          "H4"
+        ],
+        [
+          "A5",
+          "B5",
+          "C5",
+          "D5",
+          "E5",
+          "F5",
+          "G5",
+          "H5"
+        ],
+        [
+          "A6",
+          "B6",
+          "C6",
+          "D6",
+          "E6",
+          "F6",
+          "G6",
+          "H6"
+        ],
+        [
+          "A7",
+          "B7",
+          "C7",
+          "D7",
+          "E7",
+          "F7",
+          "G7",
+          "H7"
+        ],
+        [
+          "A8",
+          "B8",
+          "C8",
+          "D8",
+          "E8",
+          "F8",
+          "G8",
+          "H8"
+        ],
+        [
+          "A9",
+          "B9",
+          "C9",
+          "D9",
+          "E9",
+          "F9",
+          "G9",
+          "H9"
+        ],
+        [
+          "A10",
+          "B10",
+          "C10",
+          "D10",
+          "E10",
+          "F10",
+          "G10",
+          "H10"
+        ],
+        [
+          "A11",
+          "B11",
+          "C11",
+          "D11",
+          "E11",
+          "F11",
+          "G11",
+          "H11"
+        ],
+        [
+          "A12",
+          "B12",
+          "C12",
+          "D12",
+          "E12",
+          "F12",
+          "G12",
+          "H12"
+        ]
+      ],
+      "brand": {
+        "brand": "TPP",
+        "brandId": [
+          "92096"
+        ]
+      },
+      "metadata": {
+        "displayName": "TPP Tissue culture testplate 96F 92096",
+        "displayCategory": "wellPlate",
+        "displayVolumeUnits": "µL",
+        "tags": []
+      },
+      "dimensions": {
+        "xDimension": 127.8,
+        "yDimension": 85.5,
+        "zDimension": 14.4
+      },
+      "wells": {
+        "A1": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 14.4,
+          "y": 74.26,
+          "z": 3.3
+        },
+        "B1": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 14.4,
+          "y": 65.26,
+          "z": 3.3
+        },
+        "C1": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 14.4,
+          "y": 56.26,
+          "z": 3.3
+        },
+        "D1": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 14.4,
+          "y": 47.26,
+          "z": 3.3
+        },
+        "E1": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 14.4,
+          "y": 38.26,
+          "z": 3.3
+        },
+        "F1": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 14.4,
+          "y": 29.26,
+          "z": 3.3
+        },
+        "G1": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 14.4,
+          "y": 20.26,
+          "z": 3.3
+        },
+        "H1": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 14.4,
+          "y": 11.26,
+          "z": 3.3
+        },
+        "A2": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 23.4,
+          "y": 74.26,
+          "z": 3.3
+        },
+        "B2": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 23.4,
+          "y": 65.26,
+          "z": 3.3
+        },
+        "C2": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 23.4,
+          "y": 56.26,
+          "z": 3.3
+        },
+        "D2": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 23.4,
+          "y": 47.26,
+          "z": 3.3
+        },
+        "E2": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 23.4,
+          "y": 38.26,
+          "z": 3.3
+        },
+        "F2": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 23.4,
+          "y": 29.26,
+          "z": 3.3
+        },
+        "G2": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 23.4,
+          "y": 20.26,
+          "z": 3.3
+        },
+        "H2": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 23.4,
+          "y": 11.26,
+          "z": 3.3
+        },
+        "A3": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 32.4,
+          "y": 74.26,
+          "z": 3.3
+        },
+        "B3": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 32.4,
+          "y": 65.26,
+          "z": 3.3
+        },
+        "C3": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 32.4,
+          "y": 56.26,
+          "z": 3.3
+        },
+        "D3": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 32.4,
+          "y": 47.26,
+          "z": 3.3
+        },
+        "E3": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 32.4,
+          "y": 38.26,
+          "z": 3.3
+        },
+        "F3": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 32.4,
+          "y": 29.26,
+          "z": 3.3
+        },
+        "G3": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 32.4,
+          "y": 20.26,
+          "z": 3.3
+        },
+        "H3": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 32.4,
+          "y": 11.26,
+          "z": 3.3
+        },
+        "A4": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 41.4,
+          "y": 74.26,
+          "z": 3.3
+        },
+        "B4": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 41.4,
+          "y": 65.26,
+          "z": 3.3
+        },
+        "C4": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 41.4,
+          "y": 56.26,
+          "z": 3.3
+        },
+        "D4": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 41.4,
+          "y": 47.26,
+          "z": 3.3
+        },
+        "E4": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 41.4,
+          "y": 38.26,
+          "z": 3.3
+        },
+        "F4": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 41.4,
+          "y": 29.26,
+          "z": 3.3
+        },
+        "G4": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 41.4,
+          "y": 20.26,
+          "z": 3.3
+        },
+        "H4": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 41.4,
+          "y": 11.26,
+          "z": 3.3
+        },
+        "A5": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 50.4,
+          "y": 74.26,
+          "z": 3.3
+        },
+        "B5": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 50.4,
+          "y": 65.26,
+          "z": 3.3
+        },
+        "C5": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 50.4,
+          "y": 56.26,
+          "z": 3.3
+        },
+        "D5": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 50.4,
+          "y": 47.26,
+          "z": 3.3
+        },
+        "E5": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 50.4,
+          "y": 38.26,
+          "z": 3.3
+        },
+        "F5": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 50.4,
+          "y": 29.26,
+          "z": 3.3
+        },
+        "G5": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 50.4,
+          "y": 20.26,
+          "z": 3.3
+        },
+        "H5": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 50.4,
+          "y": 11.26,
+          "z": 3.3
+        },
+        "A6": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 59.4,
+          "y": 74.26,
+          "z": 3.3
+        },
+        "B6": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 59.4,
+          "y": 65.26,
+          "z": 3.3
+        },
+        "C6": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 59.4,
+          "y": 56.26,
+          "z": 3.3
+        },
+        "D6": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 59.4,
+          "y": 47.26,
+          "z": 3.3
+        },
+        "E6": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 59.4,
+          "y": 38.26,
+          "z": 3.3
+        },
+        "F6": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 59.4,
+          "y": 29.26,
+          "z": 3.3
+        },
+        "G6": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 59.4,
+          "y": 20.26,
+          "z": 3.3
+        },
+        "H6": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 59.4,
+          "y": 11.26,
+          "z": 3.3
+        },
+        "A7": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 68.4,
+          "y": 74.26,
+          "z": 3.3
+        },
+        "B7": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 68.4,
+          "y": 65.26,
+          "z": 3.3
+        },
+        "C7": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 68.4,
+          "y": 56.26,
+          "z": 3.3
+        },
+        "D7": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 68.4,
+          "y": 47.26,
+          "z": 3.3
+        },
+        "E7": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 68.4,
+          "y": 38.26,
+          "z": 3.3
+        },
+        "F7": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 68.4,
+          "y": 29.26,
+          "z": 3.3
+        },
+        "G7": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 68.4,
+          "y": 20.26,
+          "z": 3.3
+        },
+        "H7": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 68.4,
+          "y": 11.26,
+          "z": 3.3
+        },
+        "A8": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 77.4,
+          "y": 74.26,
+          "z": 3.3
+        },
+        "B8": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 77.4,
+          "y": 65.26,
+          "z": 3.3
+        },
+        "C8": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 77.4,
+          "y": 56.26,
+          "z": 3.3
+        },
+        "D8": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 77.4,
+          "y": 47.26,
+          "z": 3.3
+        },
+        "E8": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 77.4,
+          "y": 38.26,
+          "z": 3.3
+        },
+        "F8": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 77.4,
+          "y": 29.26,
+          "z": 3.3
+        },
+        "G8": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 77.4,
+          "y": 20.26,
+          "z": 3.3
+        },
+        "H8": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 77.4,
+          "y": 11.26,
+          "z": 3.3
+        },
+        "A9": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 86.4,
+          "y": 74.26,
+          "z": 3.3
+        },
+        "B9": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 86.4,
+          "y": 65.26,
+          "z": 3.3
+        },
+        "C9": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 86.4,
+          "y": 56.26,
+          "z": 3.3
+        },
+        "D9": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 86.4,
+          "y": 47.26,
+          "z": 3.3
+        },
+        "E9": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 86.4,
+          "y": 38.26,
+          "z": 3.3
+        },
+        "F9": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 86.4,
+          "y": 29.26,
+          "z": 3.3
+        },
+        "G9": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 86.4,
+          "y": 20.26,
+          "z": 3.3
+        },
+        "H9": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 86.4,
+          "y": 11.26,
+          "z": 3.3
+        },
+        "A10": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 95.4,
+          "y": 74.26,
+          "z": 3.3
+        },
+        "B10": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 95.4,
+          "y": 65.26,
+          "z": 3.3
+        },
+        "C10": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 95.4,
+          "y": 56.26,
+          "z": 3.3
+        },
+        "D10": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 95.4,
+          "y": 47.26,
+          "z": 3.3
+        },
+        "E10": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 95.4,
+          "y": 38.26,
+          "z": 3.3
+        },
+        "F10": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 95.4,
+          "y": 29.26,
+          "z": 3.3
+        },
+        "G10": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 95.4,
+          "y": 20.26,
+          "z": 3.3
+        },
+        "H10": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 95.4,
+          "y": 11.26,
+          "z": 3.3
+        },
+        "A11": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 104.4,
+          "y": 74.26,
+          "z": 3.3
+        },
+        "B11": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 104.4,
+          "y": 65.26,
+          "z": 3.3
+        },
+        "C11": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 104.4,
+          "y": 56.26,
+          "z": 3.3
+        },
+        "D11": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 104.4,
+          "y": 47.26,
+          "z": 3.3
+        },
+        "E11": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 104.4,
+          "y": 38.26,
+          "z": 3.3
+        },
+        "F11": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 104.4,
+          "y": 29.26,
+          "z": 3.3
+        },
+        "G11": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 104.4,
+          "y": 20.26,
+          "z": 3.3
+        },
+        "H11": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 104.4,
+          "y": 11.26,
+          "z": 3.3
+        },
+        "A12": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 113.4,
+          "y": 74.26,
+          "z": 3.3
+        },
+        "B12": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 113.4,
+          "y": 65.26,
+          "z": 3.3
+        },
+        "C12": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 113.4,
+          "y": 56.26,
+          "z": 3.3
+        },
+        "D12": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 113.4,
+          "y": 47.26,
+          "z": 3.3
+        },
+        "E12": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 113.4,
+          "y": 38.26,
+          "z": 3.3
+        },
+        "F12": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 113.4,
+          "y": 29.26,
+          "z": 3.3
+        },
+        "G12": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 113.4,
+          "y": 20.26,
+          "z": 3.3
+        },
+        "H12": {
+          "depth": 11.1,
+          "totalLiquidVolume": 340,
+          "shape": "circular",
+          "diameter": 6.9,
+          "x": 113.4,
+          "y": 11.26,
+          "z": 3.3
+        }
+      },
+      "groups": [
+        {
+          "metadata": {
+            "wellBottomShape": "flat"
+          },
+          "wells": [
+            "A1",
+            "B1",
+            "C1",
+            "D1",
+            "E1",
+            "F1",
+            "G1",
+            "H1",
+            "A2",
+            "B2",
+            "C2",
+            "D2",
+            "E2",
+            "F2",
+            "G2",
+            "H2",
+            "A3",
+            "B3",
+            "C3",
+            "D3",
+            "E3",
+            "F3",
+            "G3",
+            "H3",
+            "A4",
+            "B4",
+            "C4",
+            "D4",
+            "E4",
+            "F4",
+            "G4",
+            "H4",
+            "A5",
+            "B5",
+            "C5",
+            "D5",
+            "E5",
+            "F5",
+            "G5",
+            "H5",
+            "A6",
+            "B6",
+            "C6",
+            "D6",
+            "E6",
+            "F6",
+            "G6",
+            "H6",
+            "A7",
+            "B7",
+            "C7",
+            "D7",
+            "E7",
+            "F7",
+            "G7",
+            "H7",
+            "A8",
+            "B8",
+            "C8",
+            "D8",
+            "E8",
+            "F8",
+            "G8",
+            "H8",
+            "A9",
+            "B9",
+            "C9",
+            "D9",
+            "E9",
+            "F9",
+            "G9",
+            "H9",
+            "A10",
+            "B10",
+            "C10",
+            "D10",
+            "E10",
+            "F10",
+            "G10",
+            "H10",
+            "A11",
+            "B11",
+            "C11",
+            "D11",
+            "E11",
+            "F11",
+            "G11",
+            "H11",
+            "A12",
+            "B12",
+            "C12",
+            "D12",
+            "E12",
+            "F12",
+            "G12",
+            "H12"
+          ]
+        }
+      ],
+      "parameters": {
+        "format": "irregular",
+        "quirks": [],
+        "isTiprack": false,
+        "isMagneticModuleCompatible": false,
+        "loadName": "tpp_96well_plate_340ul"
+      },
+      "namespace": "custom_beta",
+      "version": 1,
+      "schemaVersion": 2,
+      "cornerOffsetFromSlot": {
+        "x": 0,
+        "y": 0,
+        "z": 0
+      }
+    },
+    "opentrons/nest_96_wellplate_2ml_deep/1": {
+      "ordering": [
+        [
+          "A1",
+          "B1",
+          "C1",
+          "D1",
+          "E1",
+          "F1",
+          "G1",
+          "H1"
+        ],
+        [
+          "A2",
+          "B2",
+          "C2",
+          "D2",
+          "E2",
+          "F2",
+          "G2",
+          "H2"
+        ],
+        [
+          "A3",
+          "B3",
+          "C3",
+          "D3",
+          "E3",
+          "F3",
+          "G3",
+          "H3"
+        ],
+        [
+          "A4",
+          "B4",
+          "C4",
+          "D4",
+          "E4",
+          "F4",
+          "G4",
+          "H4"
+        ],
+        [
+          "A5",
+          "B5",
+          "C5",
+          "D5",
+          "E5",
+          "F5",
+          "G5",
+          "H5"
+        ],
+        [
+          "A6",
+          "B6",
+          "C6",
+          "D6",
+          "E6",
+          "F6",
+          "G6",
+          "H6"
+        ],
+        [
+          "A7",
+          "B7",
+          "C7",
+          "D7",
+          "E7",
+          "F7",
+          "G7",
+          "H7"
+        ],
+        [
+          "A8",
+          "B8",
+          "C8",
+          "D8",
+          "E8",
+          "F8",
+          "G8",
+          "H8"
+        ],
+        [
+          "A9",
+          "B9",
+          "C9",
+          "D9",
+          "E9",
+          "F9",
+          "G9",
+          "H9"
+        ],
+        [
+          "A10",
+          "B10",
+          "C10",
+          "D10",
+          "E10",
+          "F10",
+          "G10",
+          "H10"
+        ],
+        [
+          "A11",
+          "B11",
+          "C11",
+          "D11",
+          "E11",
+          "F11",
+          "G11",
+          "H11"
+        ],
+        [
+          "A12",
+          "B12",
+          "C12",
+          "D12",
+          "E12",
+          "F12",
+          "G12",
+          "H12"
+        ]
+      ],
+      "brand": {
+        "brand": "NEST",
+        "brandId": [
+          "503001",
+          "503501"
+        ],
+        "links": [
+          "http://www.cell-nest.com/page94?product_id=101&_l=en"
+        ]
+      },
+      "metadata": {
+        "displayName": "NEST 96 Deepwell Plate 2mL",
+        "displayCategory": "wellPlate",
+        "displayVolumeUnits": "µL",
+        "tags": []
+      },
+      "dimensions": {
+        "xDimension": 127.6,
+        "yDimension": 85.3,
+        "zDimension": 41
+      },
+      "wells": {
+        "A1": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 14.3,
+          "y": 74.15,
+          "z": 3
+        },
+        "B1": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 14.3,
+          "y": 65.15,
+          "z": 3
+        },
+        "C1": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 14.3,
+          "y": 56.15,
+          "z": 3
+        },
+        "D1": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 14.3,
+          "y": 47.15,
+          "z": 3
+        },
+        "E1": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 14.3,
+          "y": 38.15,
+          "z": 3
+        },
+        "F1": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 14.3,
+          "y": 29.15,
+          "z": 3
+        },
+        "G1": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 14.3,
+          "y": 20.15,
+          "z": 3
+        },
+        "H1": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 14.3,
+          "y": 11.15,
+          "z": 3
+        },
+        "A2": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 23.3,
+          "y": 74.15,
+          "z": 3
+        },
+        "B2": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 23.3,
+          "y": 65.15,
+          "z": 3
+        },
+        "C2": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 23.3,
+          "y": 56.15,
+          "z": 3
+        },
+        "D2": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 23.3,
+          "y": 47.15,
+          "z": 3
+        },
+        "E2": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 23.3,
+          "y": 38.15,
+          "z": 3
+        },
+        "F2": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 23.3,
+          "y": 29.15,
+          "z": 3
+        },
+        "G2": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 23.3,
+          "y": 20.15,
+          "z": 3
+        },
+        "H2": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 23.3,
+          "y": 11.15,
+          "z": 3
+        },
+        "A3": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 32.3,
+          "y": 74.15,
+          "z": 3
+        },
+        "B3": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 32.3,
+          "y": 65.15,
+          "z": 3
+        },
+        "C3": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 32.3,
+          "y": 56.15,
+          "z": 3
+        },
+        "D3": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 32.3,
+          "y": 47.15,
+          "z": 3
+        },
+        "E3": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 32.3,
+          "y": 38.15,
+          "z": 3
+        },
+        "F3": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 32.3,
+          "y": 29.15,
+          "z": 3
+        },
+        "G3": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 32.3,
+          "y": 20.15,
+          "z": 3
+        },
+        "H3": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 32.3,
+          "y": 11.15,
+          "z": 3
+        },
+        "A4": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 41.3,
+          "y": 74.15,
+          "z": 3
+        },
+        "B4": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 41.3,
+          "y": 65.15,
+          "z": 3
+        },
+        "C4": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 41.3,
+          "y": 56.15,
+          "z": 3
+        },
+        "D4": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 41.3,
+          "y": 47.15,
+          "z": 3
+        },
+        "E4": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 41.3,
+          "y": 38.15,
+          "z": 3
+        },
+        "F4": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 41.3,
+          "y": 29.15,
+          "z": 3
+        },
+        "G4": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 41.3,
+          "y": 20.15,
+          "z": 3
+        },
+        "H4": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 41.3,
+          "y": 11.15,
+          "z": 3
+        },
+        "A5": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 50.3,
+          "y": 74.15,
+          "z": 3
+        },
+        "B5": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 50.3,
+          "y": 65.15,
+          "z": 3
+        },
+        "C5": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 50.3,
+          "y": 56.15,
+          "z": 3
+        },
+        "D5": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 50.3,
+          "y": 47.15,
+          "z": 3
+        },
+        "E5": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 50.3,
+          "y": 38.15,
+          "z": 3
+        },
+        "F5": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 50.3,
+          "y": 29.15,
+          "z": 3
+        },
+        "G5": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 50.3,
+          "y": 20.15,
+          "z": 3
+        },
+        "H5": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 50.3,
+          "y": 11.15,
+          "z": 3
+        },
+        "A6": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 59.3,
+          "y": 74.15,
+          "z": 3
+        },
+        "B6": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 59.3,
+          "y": 65.15,
+          "z": 3
+        },
+        "C6": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 59.3,
+          "y": 56.15,
+          "z": 3
+        },
+        "D6": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 59.3,
+          "y": 47.15,
+          "z": 3
+        },
+        "E6": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 59.3,
+          "y": 38.15,
+          "z": 3
+        },
+        "F6": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 59.3,
+          "y": 29.15,
+          "z": 3
+        },
+        "G6": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 59.3,
+          "y": 20.15,
+          "z": 3
+        },
+        "H6": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 59.3,
+          "y": 11.15,
+          "z": 3
+        },
+        "A7": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 68.3,
+          "y": 74.15,
+          "z": 3
+        },
+        "B7": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 68.3,
+          "y": 65.15,
+          "z": 3
+        },
+        "C7": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 68.3,
+          "y": 56.15,
+          "z": 3
+        },
+        "D7": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 68.3,
+          "y": 47.15,
+          "z": 3
+        },
+        "E7": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 68.3,
+          "y": 38.15,
+          "z": 3
+        },
+        "F7": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 68.3,
+          "y": 29.15,
+          "z": 3
+        },
+        "G7": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 68.3,
+          "y": 20.15,
+          "z": 3
+        },
+        "H7": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 68.3,
+          "y": 11.15,
+          "z": 3
+        },
+        "A8": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 77.3,
+          "y": 74.15,
+          "z": 3
+        },
+        "B8": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 77.3,
+          "y": 65.15,
+          "z": 3
+        },
+        "C8": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 77.3,
+          "y": 56.15,
+          "z": 3
+        },
+        "D8": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 77.3,
+          "y": 47.15,
+          "z": 3
+        },
+        "E8": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 77.3,
+          "y": 38.15,
+          "z": 3
+        },
+        "F8": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 77.3,
+          "y": 29.15,
+          "z": 3
+        },
+        "G8": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 77.3,
+          "y": 20.15,
+          "z": 3
+        },
+        "H8": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 77.3,
+          "y": 11.15,
+          "z": 3
+        },
+        "A9": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 86.3,
+          "y": 74.15,
+          "z": 3
+        },
+        "B9": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 86.3,
+          "y": 65.15,
+          "z": 3
+        },
+        "C9": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 86.3,
+          "y": 56.15,
+          "z": 3
+        },
+        "D9": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 86.3,
+          "y": 47.15,
+          "z": 3
+        },
+        "E9": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 86.3,
+          "y": 38.15,
+          "z": 3
+        },
+        "F9": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 86.3,
+          "y": 29.15,
+          "z": 3
+        },
+        "G9": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 86.3,
+          "y": 20.15,
+          "z": 3
+        },
+        "H9": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 86.3,
+          "y": 11.15,
+          "z": 3
+        },
+        "A10": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 95.3,
+          "y": 74.15,
+          "z": 3
+        },
+        "B10": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 95.3,
+          "y": 65.15,
+          "z": 3
+        },
+        "C10": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 95.3,
+          "y": 56.15,
+          "z": 3
+        },
+        "D10": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 95.3,
+          "y": 47.15,
+          "z": 3
+        },
+        "E10": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 95.3,
+          "y": 38.15,
+          "z": 3
+        },
+        "F10": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 95.3,
+          "y": 29.15,
+          "z": 3
+        },
+        "G10": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 95.3,
+          "y": 20.15,
+          "z": 3
+        },
+        "H10": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 95.3,
+          "y": 11.15,
+          "z": 3
+        },
+        "A11": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 104.3,
+          "y": 74.15,
+          "z": 3
+        },
+        "B11": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 104.3,
+          "y": 65.15,
+          "z": 3
+        },
+        "C11": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 104.3,
+          "y": 56.15,
+          "z": 3
+        },
+        "D11": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 104.3,
+          "y": 47.15,
+          "z": 3
+        },
+        "E11": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 104.3,
+          "y": 38.15,
+          "z": 3
+        },
+        "F11": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 104.3,
+          "y": 29.15,
+          "z": 3
+        },
+        "G11": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 104.3,
+          "y": 20.15,
+          "z": 3
+        },
+        "H11": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 104.3,
+          "y": 11.15,
+          "z": 3
+        },
+        "A12": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 113.3,
+          "y": 74.15,
+          "z": 3
+        },
+        "B12": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 113.3,
+          "y": 65.15,
+          "z": 3
+        },
+        "C12": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 113.3,
+          "y": 56.15,
+          "z": 3
+        },
+        "D12": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 113.3,
+          "y": 47.15,
+          "z": 3
+        },
+        "E12": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 113.3,
+          "y": 38.15,
+          "z": 3
+        },
+        "F12": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 113.3,
+          "y": 29.15,
+          "z": 3
+        },
+        "G12": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 113.3,
+          "y": 20.15,
+          "z": 3
+        },
+        "H12": {
+          "depth": 38,
+          "totalLiquidVolume": 2000,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "x": 113.3,
+          "y": 11.15,
+          "z": 3
+        }
+      },
+      "groups": [
+        {
+          "metadata": {
+            "displayName": "NEST 96 Deepwell Plate 2mL",
+            "displayCategory": "wellPlate",
+            "wellBottomShape": "v"
+          },
+          "brand": {
+            "brand": "NEST",
+            "brandId": []
+          },
+          "wells": [
+            "A1",
+            "B1",
+            "C1",
+            "D1",
+            "E1",
+            "F1",
+            "G1",
+            "H1",
+            "A2",
+            "B2",
+            "C2",
+            "D2",
+            "E2",
+            "F2",
+            "G2",
+            "H2",
+            "A3",
+            "B3",
+            "C3",
+            "D3",
+            "E3",
+            "F3",
+            "G3",
+            "H3",
+            "A4",
+            "B4",
+            "C4",
+            "D4",
+            "E4",
+            "F4",
+            "G4",
+            "H4",
+            "A5",
+            "B5",
+            "C5",
+            "D5",
+            "E5",
+            "F5",
+            "G5",
+            "H5",
+            "A6",
+            "B6",
+            "C6",
+            "D6",
+            "E6",
+            "F6",
+            "G6",
+            "H6",
+            "A7",
+            "B7",
+            "C7",
+            "D7",
+            "E7",
+            "F7",
+            "G7",
+            "H7",
+            "A8",
+            "B8",
+            "C8",
+            "D8",
+            "E8",
+            "F8",
+            "G8",
+            "H8",
+            "A9",
+            "B9",
+            "C9",
+            "D9",
+            "E9",
+            "F9",
+            "G9",
+            "H9",
+            "A10",
+            "B10",
+            "C10",
+            "D10",
+            "E10",
+            "F10",
+            "G10",
+            "H10",
+            "A11",
+            "B11",
+            "C11",
+            "D11",
+            "E11",
+            "F11",
+            "G11",
+            "H11",
+            "A12",
+            "B12",
+            "C12",
+            "D12",
+            "E12",
+            "F12",
+            "G12",
+            "H12"
+          ]
+        }
+      ],
+      "parameters": {
+        "format": "96Standard",
+        "quirks": [],
+        "isTiprack": false,
+        "isMagneticModuleCompatible": true,
+        "loadName": "nest_96_wellplate_2ml_deep",
+        "magneticModuleEngageHeight": 6.8
+      },
+      "namespace": "opentrons",
+      "version": 1,
+      "schemaVersion": 2,
+      "cornerOffsetFromSlot": {
+        "x": 0,
+        "y": 0,
+        "z": 0
+      }
+    },
+    "opentrons/biorad_96_wellplate_200ul_pcr/1": {
+      "ordering": [
+        [
+          "A1",
+          "B1",
+          "C1",
+          "D1",
+          "E1",
+          "F1",
+          "G1",
+          "H1"
+        ],
+        [
+          "A2",
+          "B2",
+          "C2",
+          "D2",
+          "E2",
+          "F2",
+          "G2",
+          "H2"
+        ],
+        [
+          "A3",
+          "B3",
+          "C3",
+          "D3",
+          "E3",
+          "F3",
+          "G3",
+          "H3"
+        ],
+        [
+          "A4",
+          "B4",
+          "C4",
+          "D4",
+          "E4",
+          "F4",
+          "G4",
+          "H4"
+        ],
+        [
+          "A5",
+          "B5",
+          "C5",
+          "D5",
+          "E5",
+          "F5",
+          "G5",
+          "H5"
+        ],
+        [
+          "A6",
+          "B6",
+          "C6",
+          "D6",
+          "E6",
+          "F6",
+          "G6",
+          "H6"
+        ],
+        [
+          "A7",
+          "B7",
+          "C7",
+          "D7",
+          "E7",
+          "F7",
+          "G7",
+          "H7"
+        ],
+        [
+          "A8",
+          "B8",
+          "C8",
+          "D8",
+          "E8",
+          "F8",
+          "G8",
+          "H8"
+        ],
+        [
+          "A9",
+          "B9",
+          "C9",
+          "D9",
+          "E9",
+          "F9",
+          "G9",
+          "H9"
+        ],
+        [
+          "A10",
+          "B10",
+          "C10",
+          "D10",
+          "E10",
+          "F10",
+          "G10",
+          "H10"
+        ],
+        [
+          "A11",
+          "B11",
+          "C11",
+          "D11",
+          "E11",
+          "F11",
+          "G11",
+          "H11"
+        ],
+        [
+          "A12",
+          "B12",
+          "C12",
+          "D12",
+          "E12",
+          "F12",
+          "G12",
+          "H12"
+        ]
+      ],
+      "schemaVersion": 2,
+      "version": 1,
+      "namespace": "opentrons",
+      "metadata": {
+        "displayName": "Bio-Rad 96 Well Plate 200 µL PCR",
+        "displayCategory": "wellPlate",
+        "displayVolumeUnits": "µL",
+        "tags": []
+      },
+      "dimensions": {
+        "yDimension": 85.48,
+        "xDimension": 127.76,
+        "zDimension": 16.06
+      },
+      "parameters": {
+        "format": "96Standard",
+        "isTiprack": false,
+        "loadName": "biorad_96_wellplate_200ul_pcr",
+        "isMagneticModuleCompatible": true,
+        "magneticModuleEngageHeight": 18
+      },
+      "wells": {
+        "H1": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 14.38,
+          "y": 11.24,
+          "z": 1.25
+        },
+        "G1": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 14.38,
+          "y": 20.24,
+          "z": 1.25
+        },
+        "F1": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 14.38,
+          "y": 29.24,
+          "z": 1.25
+        },
+        "E1": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 14.38,
+          "y": 38.24,
+          "z": 1.25
+        },
+        "D1": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 14.38,
+          "y": 47.24,
+          "z": 1.25
+        },
+        "C1": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 14.38,
+          "y": 56.24,
+          "z": 1.25
+        },
+        "B1": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 14.38,
+          "y": 65.24,
+          "z": 1.25
+        },
+        "A1": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 14.38,
+          "y": 74.24,
+          "z": 1.25
+        },
+        "H2": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 23.38,
+          "y": 11.24,
+          "z": 1.25
+        },
+        "G2": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 23.38,
+          "y": 20.24,
+          "z": 1.25
+        },
+        "F2": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 23.38,
+          "y": 29.24,
+          "z": 1.25
+        },
+        "E2": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 23.38,
+          "y": 38.24,
+          "z": 1.25
+        },
+        "D2": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 23.38,
+          "y": 47.24,
+          "z": 1.25
+        },
+        "C2": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 23.38,
+          "y": 56.24,
+          "z": 1.25
+        },
+        "B2": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 23.38,
+          "y": 65.24,
+          "z": 1.25
+        },
+        "A2": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 23.38,
+          "y": 74.24,
+          "z": 1.25
+        },
+        "H3": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 32.38,
+          "y": 11.24,
+          "z": 1.25
+        },
+        "G3": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 32.38,
+          "y": 20.24,
+          "z": 1.25
+        },
+        "F3": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 32.38,
+          "y": 29.24,
+          "z": 1.25
+        },
+        "E3": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 32.38,
+          "y": 38.24,
+          "z": 1.25
+        },
+        "D3": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 32.38,
+          "y": 47.24,
+          "z": 1.25
+        },
+        "C3": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 32.38,
+          "y": 56.24,
+          "z": 1.25
+        },
+        "B3": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 32.38,
+          "y": 65.24,
+          "z": 1.25
+        },
+        "A3": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 32.38,
+          "y": 74.24,
+          "z": 1.25
+        },
+        "H4": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 41.38,
+          "y": 11.24,
+          "z": 1.25
+        },
+        "G4": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 41.38,
+          "y": 20.24,
+          "z": 1.25
+        },
+        "F4": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 41.38,
+          "y": 29.24,
+          "z": 1.25
+        },
+        "E4": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 41.38,
+          "y": 38.24,
+          "z": 1.25
+        },
+        "D4": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 41.38,
+          "y": 47.24,
+          "z": 1.25
+        },
+        "C4": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 41.38,
+          "y": 56.24,
+          "z": 1.25
+        },
+        "B4": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 41.38,
+          "y": 65.24,
+          "z": 1.25
+        },
+        "A4": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 41.38,
+          "y": 74.24,
+          "z": 1.25
+        },
+        "H5": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 50.38,
+          "y": 11.24,
+          "z": 1.25
+        },
+        "G5": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 50.38,
+          "y": 20.24,
+          "z": 1.25
+        },
+        "F5": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 50.38,
+          "y": 29.24,
+          "z": 1.25
+        },
+        "E5": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 50.38,
+          "y": 38.24,
+          "z": 1.25
+        },
+        "D5": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 50.38,
+          "y": 47.24,
+          "z": 1.25
+        },
+        "C5": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 50.38,
+          "y": 56.24,
+          "z": 1.25
+        },
+        "B5": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 50.38,
+          "y": 65.24,
+          "z": 1.25
+        },
+        "A5": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 50.38,
+          "y": 74.24,
+          "z": 1.25
+        },
+        "H6": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 59.38,
+          "y": 11.24,
+          "z": 1.25
+        },
+        "G6": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 59.38,
+          "y": 20.24,
+          "z": 1.25
+        },
+        "F6": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 59.38,
+          "y": 29.24,
+          "z": 1.25
+        },
+        "E6": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 59.38,
+          "y": 38.24,
+          "z": 1.25
+        },
+        "D6": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 59.38,
+          "y": 47.24,
+          "z": 1.25
+        },
+        "C6": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 59.38,
+          "y": 56.24,
+          "z": 1.25
+        },
+        "B6": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 59.38,
+          "y": 65.24,
+          "z": 1.25
+        },
+        "A6": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 59.38,
+          "y": 74.24,
+          "z": 1.25
+        },
+        "H7": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 68.38,
+          "y": 11.24,
+          "z": 1.25
+        },
+        "G7": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 68.38,
+          "y": 20.24,
+          "z": 1.25
+        },
+        "F7": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 68.38,
+          "y": 29.24,
+          "z": 1.25
+        },
+        "E7": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 68.38,
+          "y": 38.24,
+          "z": 1.25
+        },
+        "D7": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 68.38,
+          "y": 47.24,
+          "z": 1.25
+        },
+        "C7": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 68.38,
+          "y": 56.24,
+          "z": 1.25
+        },
+        "B7": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 68.38,
+          "y": 65.24,
+          "z": 1.25
+        },
+        "A7": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 68.38,
+          "y": 74.24,
+          "z": 1.25
+        },
+        "H8": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 77.38,
+          "y": 11.24,
+          "z": 1.25
+        },
+        "G8": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 77.38,
+          "y": 20.24,
+          "z": 1.25
+        },
+        "F8": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 77.38,
+          "y": 29.24,
+          "z": 1.25
+        },
+        "E8": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 77.38,
+          "y": 38.24,
+          "z": 1.25
+        },
+        "D8": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 77.38,
+          "y": 47.24,
+          "z": 1.25
+        },
+        "C8": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 77.38,
+          "y": 56.24,
+          "z": 1.25
+        },
+        "B8": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 77.38,
+          "y": 65.24,
+          "z": 1.25
+        },
+        "A8": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 77.38,
+          "y": 74.24,
+          "z": 1.25
+        },
+        "H9": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 86.38,
+          "y": 11.24,
+          "z": 1.25
+        },
+        "G9": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 86.38,
+          "y": 20.24,
+          "z": 1.25
+        },
+        "F9": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 86.38,
+          "y": 29.24,
+          "z": 1.25
+        },
+        "E9": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 86.38,
+          "y": 38.24,
+          "z": 1.25
+        },
+        "D9": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 86.38,
+          "y": 47.24,
+          "z": 1.25
+        },
+        "C9": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 86.38,
+          "y": 56.24,
+          "z": 1.25
+        },
+        "B9": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 86.38,
+          "y": 65.24,
+          "z": 1.25
+        },
+        "A9": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 86.38,
+          "y": 74.24,
+          "z": 1.25
+        },
+        "H10": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 95.38,
+          "y": 11.24,
+          "z": 1.25
+        },
+        "G10": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 95.38,
+          "y": 20.24,
+          "z": 1.25
+        },
+        "F10": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 95.38,
+          "y": 29.24,
+          "z": 1.25
+        },
+        "E10": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 95.38,
+          "y": 38.24,
+          "z": 1.25
+        },
+        "D10": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 95.38,
+          "y": 47.24,
+          "z": 1.25
+        },
+        "C10": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 95.38,
+          "y": 56.24,
+          "z": 1.25
+        },
+        "B10": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 95.38,
+          "y": 65.24,
+          "z": 1.25
+        },
+        "A10": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 95.38,
+          "y": 74.24,
+          "z": 1.25
+        },
+        "H11": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 104.38,
+          "y": 11.24,
+          "z": 1.25
+        },
+        "G11": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 104.38,
+          "y": 20.24,
+          "z": 1.25
+        },
+        "F11": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 104.38,
+          "y": 29.24,
+          "z": 1.25
+        },
+        "E11": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 104.38,
+          "y": 38.24,
+          "z": 1.25
+        },
+        "D11": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 104.38,
+          "y": 47.24,
+          "z": 1.25
+        },
+        "C11": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 104.38,
+          "y": 56.24,
+          "z": 1.25
+        },
+        "B11": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 104.38,
+          "y": 65.24,
+          "z": 1.25
+        },
+        "A11": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 104.38,
+          "y": 74.24,
+          "z": 1.25
+        },
+        "H12": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 113.38,
+          "y": 11.24,
+          "z": 1.25
+        },
+        "G12": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 113.38,
+          "y": 20.24,
+          "z": 1.25
+        },
+        "F12": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 113.38,
+          "y": 29.24,
+          "z": 1.25
+        },
+        "E12": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 113.38,
+          "y": 38.24,
+          "z": 1.25
+        },
+        "D12": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 113.38,
+          "y": 47.24,
+          "z": 1.25
+        },
+        "C12": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 113.38,
+          "y": 56.24,
+          "z": 1.25
+        },
+        "B12": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 113.38,
+          "y": 65.24,
+          "z": 1.25
+        },
+        "A12": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 113.38,
+          "y": 74.24,
+          "z": 1.25
+        }
+      },
+      "brand": {
+        "brand": "Bio-Rad",
+        "brandId": [
+          "hsp9601"
+        ],
+        "links": [
+          "http://www.bio-rad.com/en-us/sku/hsp9601-hard-shell-96-well-pcr-plates-low-profile-thin-wall-skirted-white-clear?ID=hsp9601"
+        ]
+      },
+      "groups": [
+        {
+          "wells": [
+            "A1",
+            "B1",
+            "C1",
+            "D1",
+            "E1",
+            "F1",
+            "G1",
+            "H1",
+            "A2",
+            "B2",
+            "C2",
+            "D2",
+            "E2",
+            "F2",
+            "G2",
+            "H2",
+            "A3",
+            "B3",
+            "C3",
+            "D3",
+            "E3",
+            "F3",
+            "G3",
+            "H3",
+            "A4",
+            "B4",
+            "C4",
+            "D4",
+            "E4",
+            "F4",
+            "G4",
+            "H4",
+            "A5",
+            "B5",
+            "C5",
+            "D5",
+            "E5",
+            "F5",
+            "G5",
+            "H5",
+            "A6",
+            "B6",
+            "C6",
+            "D6",
+            "E6",
+            "F6",
+            "G6",
+            "H6",
+            "A7",
+            "B7",
+            "C7",
+            "D7",
+            "E7",
+            "F7",
+            "G7",
+            "H7",
+            "A8",
+            "B8",
+            "C8",
+            "D8",
+            "E8",
+            "F8",
+            "G8",
+            "H8",
+            "A9",
+            "B9",
+            "C9",
+            "D9",
+            "E9",
+            "F9",
+            "G9",
+            "H9",
+            "A10",
+            "B10",
+            "C10",
+            "D10",
+            "E10",
+            "F10",
+            "G10",
+            "H10",
+            "A11",
+            "B11",
+            "C11",
+            "D11",
+            "E11",
+            "F11",
+            "G11",
+            "H11",
+            "A12",
+            "B12",
+            "C12",
+            "D12",
+            "E12",
+            "F12",
+            "G12",
+            "H12"
+          ],
+          "metadata": {
+            "wellBottomShape": "v"
+          }
+        }
+      ],
+      "cornerOffsetFromSlot": {
+        "x": 0,
+        "y": 0,
+        "z": 0
+      }
+    }
+  },
+  "$otSharedSchema": "#/protocol/schemas/4",
+  "schemaVersion": 4,
+  "modules": {
+    "d3321d80-0f50-11ec-8a82-4f331e0525fd:temperatureModuleType": {
+      "slot": "1",
+      "model": "temperatureModuleV2"
+    },
+    "e7c4d6c0-0f50-11ec-8a82-4f331e0525fd:magneticModuleType": {
+      "slot": "4",
+      "model": "magneticModuleV2"
+    }
+  },
+  "commands": []
+}

--- a/scripts/pd-generate.py
+++ b/scripts/pd-generate.py
@@ -3,6 +3,7 @@ import os
 import uuid
 import json
 import time
+from pathlib import Path
 
 # be sure to cd to Protocols repo top level
 
@@ -105,7 +106,6 @@ def create_pd_json(folder):
     for file in os.listdir(protobuilds_folder):
         if '.py.json' in file:
             protobuilds_file = protobuilds_folder + '/' + file
-            print(protobuilds_file)
             with open(protobuilds_file) as pb_file:
                 protobuilds_data = json.load(pb_file)
 
@@ -191,7 +191,6 @@ def create_pd_json(folder):
 def write_file_to_protocol_folder(folder):
     protocol_folder = 'protocols/' + folder
     if 'supplements' not in os.listdir(protocol_folder):
-        print('test')
         os.mkdir(protocol_folder + '/supplements')
     out_path = protocol_folder + '/supplements/pd.json'
     data = create_pd_json(folder)
@@ -200,5 +199,6 @@ def write_file_to_protocol_folder(folder):
 
 
 if __name__ == '__main__':
-    source_folder_path = sys.argv[1]
+    source_file_path = sys.argv[1]
+    source_folder_path = str(Path(source_file_path).parent).split('/')[-1]
     write_file_to_protocol_folder(source_folder_path)

--- a/scripts/pd-generate.py
+++ b/scripts/pd-generate.py
@@ -1,0 +1,204 @@
+import sys
+import os
+import uuid
+import json
+import time
+
+# be sure to cd to Protocols repo top level
+
+pd_json = {}
+
+
+def generate_uuid():
+    return str(uuid.uuid1())
+
+
+def get_now_ms():
+    return round(time.time()*1000)
+
+
+def get_category(folder):
+    readme_data_path = 'protoBuilds' + '/' + folder + '/README.json'
+    with open(readme_data_path) as readme_data_file:
+        readme_data = json.load(readme_data_file)
+        return(readme_data['categories'])
+
+
+def get_initial_setup():
+    pass
+
+
+def map_pipette_to_tiprack(pipette_type):
+    map = {
+        '10': '10',
+        '20': '20',
+        '50': '300',
+        '300': '300',
+        '1000': '1000'
+    }
+    pipette_capacity = pipette_type.split('_')[0][1:]
+    rack_name = f'opentrons/opentrons_96_tiprack_{map[pipette_capacity]}ul/1'
+    return(rack_name)
+
+
+def create_designer_application(pipettes, labware):
+    labware_location_update = {
+        id: labware[id]['slot']
+        for id in [key for key in labware.keys()]
+    }
+    pipette_location_update = {
+        id: pipettes[id]['mount']
+        for id in [key for key in pipettes.keys()]
+    }
+    pipette_tiprack_assignments = {
+        id: map_pipette_to_tiprack(pipettes[id]['name'])
+        for id in [key for key in pipettes.keys()]
+    }
+
+    designer_app = {
+        'name': 'opentrons/protocol-designer',
+        'version': '5.2.6',
+        'data': {
+            '_internalAppBuildDate': 'Mon, 26 Apr 2021 18:42:28 GMT',
+            'defaultValues': {
+                'aspirate_mmFromBottom': 1,
+                'dispense_mmFromBottom': 0.5,
+                'touchTip_mmFromTop': -1,
+                'blowout_mmFromTop': 0
+            },
+            'pipetteTiprackAssignments': pipette_tiprack_assignments,
+            'dismissedWarnings': {
+                'form': {},
+                'timeline': {}
+            },
+            'ingredients': {},
+            'ingredLocations': {},
+            'savedStepForms': {
+                '__INITIAL_DECK_SETUP_STEP__': {
+                    "stepType": "manualIntervention",
+                    "id": "__INITIAL_DECK_SETUP_STEP__",
+                    'labwareLocationUpdate': labware_location_update,
+                    'pipetteLocationUpdate': pipette_location_update,
+                    'moduleLocationUpdate': {}
+                }
+            },
+            'orderedStepIds': []
+        }
+    }
+    return designer_app
+
+
+def get_pipettes(protobuilds_data):
+    pipettes = {
+        generate_uuid(): pipette
+        for pipette in protobuilds_data['instruments']
+    }
+    return pipettes
+
+
+def get_labware(labware):
+    pass
+
+
+def create_pd_json(folder):
+    protobuilds_folder = 'protobuilds/' + folder
+    for file in os.listdir(protobuilds_folder):
+        if '.py.json' in file:
+            protobuilds_file = protobuilds_folder + '/' + file
+            print(protobuilds_file)
+            with open(protobuilds_file) as pb_file:
+                protobuilds_data = json.load(pb_file)
+
+    # labware
+    custom_labware = protobuilds_data['custom_labware_defs']
+    custom_loadnames = [lw['parameters']['loadName'] for lw in custom_labware]
+    standard_labware = []
+    opentrons_lw_path = 'ot2monorepoClone/shared-data/labware/definitions/2/'
+    for lw in protobuilds_data['labware']:
+        lw_loadname = lw['type']
+        if lw_loadname not in custom_loadnames:
+            standard_lw_path = opentrons_lw_path + lw_loadname + '/1.json'
+            with open(standard_lw_path) as lw_file:
+                lw_json = json.load(lw_file)
+                standard_labware.append(lw_json)
+
+    all_labware_defs = custom_labware + standard_labware
+    all_labware_dict = {}
+    for lw in all_labware_defs:
+        load_name = lw['parameters']['loadName']
+        full_labware_name = '/'.join([lw['namespace'], load_name, '1'])
+        if load_name == 'opentrons_1_trash_1100ml_fixed':
+            id = 'trashId'
+        else:
+            id = generate_uuid() + ':' + full_labware_name
+        all_labware_dict[load_name] = {
+                'fullname': full_labware_name,
+                'definition': lw,
+                'id': id,
+        }
+
+    labware = {}
+    for lw in protobuilds_data['labware']:
+        load_name = lw['type']
+        slot = lw['slot']
+        display_name = lw['name']
+
+        corr_id_lw = all_labware_dict[load_name]
+        labware[corr_id_lw['id']] = {
+            'slot': slot,
+            'displayName': display_name,
+            'definitionId': corr_id_lw['fullname']
+        }
+
+    labware_definitions = {}
+    for lw in all_labware_dict.values():
+        labware_definitions[lw['fullname']] = lw['definition']
+
+    protobuilds_metadata = protobuilds_data['metadata']
+    now = get_now_ms()
+    categories = get_category(folder)
+    category = [key for key in categories.keys()][0]
+    subcategory = categories[category][0]
+    metadata = {
+        'protocolName': protobuilds_metadata['protocolName'],
+        'author': protobuilds_metadata['author'],
+        'description': '',
+        'created': now,
+        'lastModified': now,
+        'category': category,
+        'subcategory': subcategory,
+        'tags': []
+    }
+
+    pipettes = get_pipettes(protobuilds_data)
+
+    designer_application = create_designer_application(pipettes, labware)
+    robot = {"model": "OT-2 Standard"}
+
+    pd_data = {
+        'metadata': metadata,
+        'designerApplication': designer_application,
+        'robot': robot,
+        'pipettes': pipettes,
+        'labware': labware,
+        'labwareDefinitions': labware_definitions,
+        'schemaVersion': 3,
+        'commands': []
+    }
+    return pd_data
+
+
+def write_file_to_protocol_folder(folder):
+    protocol_folder = 'protocols/' + folder
+    if 'supplements' not in os.listdir(protocol_folder):
+        print('test')
+        os.mkdir(protocol_folder + '/supplements')
+    out_path = protocol_folder + '/supplements/pd.json'
+    data = create_pd_json(folder)
+    with open(out_path, 'w') as out_file:
+        json.dump(data, out_file)
+
+
+if __name__ == '__main__':
+    source_folder_path = sys.argv[1]
+    write_file_to_protocol_folder(source_folder_path)


### PR DESCRIPTION
## overview

this PR adds a script that generates Protocol Designer-compatible .json files from the `protocols` + `protoBuilds` directories of this repo. To run directly:
1. change directory to the top level of the `protocols` repo
2. run `python scripts/pd-generate.py [protocol folder name]` in your terminal window
3. find the generated `pd.json` file in the `supplements` subfolder of your protocol folder. This file can be imported to PD 

Note that any new scripts will have this `supplements/pd.json` file created when `make parse-ot2` is run

## to do:
- [x] refactor script methods
- [x] add to  `makefile` for automatic builds of these PD .json files