### PR TITLE
fix(Makefile): Specify pipenv version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ venvs/ot2:
 	source venvs/ot2/bin/activate && \
 	pip install -e otcustomizers && \
 	pip install -r protolib/requirements.txt && \
-	pip install pipenv && \
+	pip install pipenv==2021.5.29 && \
 	pushd $(OT2_MONOREPO_DIR)/api/ && \
 	$(MAKE) setup && \
 	python setup.py install && \


### PR DESCRIPTION
### Overview
Today (Nov 8, 2021) `make setup` began to mysteriously fail. This prevents protocols from being uploaded since the build will fail during Travis check. This PR adds a specific version tag to pipenv (that matches that of the monorepo) to stem issues from updates.

### Changelog
- added `==2021.5.29` to `pip install pipenv`