### PR TITLE
fix(scripts/pd-generate.py): check for author field

### DIFF
--- a/scripts/pd-generate.py
+++ b/scripts/pd-generate.py
@@ -170,9 +170,14 @@ def create_pd_json(folder):
         name = protobuilds_metadata['title']
     else:
         name = ' '
+
+    if 'author' in protobuilds_metadata.keys():
+        author = protobuilds_metadata['author']
+    else:
+        author = ' '
     metadata = {
         'protocolName': name,
-        'author': protobuilds_metadata['author'],
+        'author': author,
         'description': '',
         'created': now,
         'lastModified': now,


### PR DESCRIPTION
## overview

remove exception from metadata parsing 

## changelog

#### 11/30/2021
- check for `author` field in protocol metadata