### PR TITLE
fix(protocols/69cf81): update tip logic for mix transfer

### DIFF
--- a/protocols/69cf81/pcr_prep.ot2.apiv2.py
+++ b/protocols/69cf81/pcr_prep.ot2.apiv2.py
@@ -59,10 +59,10 @@ with {num_primers} primers.')
 
     # transfer BigDye + water mix
     reagent_dests_multi = pcr_plate.rows()[0][:num_cols*num_primers]
+    m20.pick_up_tip()
     for d in reagent_dests_multi:
-        m20.pick_up_tip()
         m20.transfer(16, mm, d.bottom(0.5), new_tip='never')
-        m20.drop_tip()
+    m20.drop_tip()
 
     # transfer primers
     for primer, dest_set in zip(primer_sources, primer_dest_sets):

--- a/protocols/69cf81/pcr_prep.ot2.apiv2.py
+++ b/protocols/69cf81/pcr_prep.ot2.apiv2.py
@@ -64,16 +64,16 @@ with {num_primers} primers.')
         m20.transfer(16, mm, d.bottom(0.5), new_tip='never')
     m20.drop_tip()
 
-    # transfer primers
-    for primer, dest_set in zip(primer_sources, primer_dest_sets):
-        for d in dest_set:
-            p20.pick_up_tip()
-            p20.transfer(1, primer, d.bottom(0.5), new_tip='never')
-            p20.drop_tip()
-
     # transfer samples
     for s, d_set in zip(sample_sources, sample_dests_sets_m):
         for d in d_set:
             m20.pick_up_tip()
             m20.transfer(3, s, d.bottom(0.5), new_tip='never')
             m20.drop_tip()
+
+    # transfer primers
+    for primer, dest_set in zip(primer_sources, primer_dest_sets):
+        for d in dest_set:
+            p20.pick_up_tip()
+            p20.transfer(1, primer, d.bottom(0.5), new_tip='never')
+            p20.drop_tip()


### PR DESCRIPTION
## overview

fix tip use strategy for mastermix distribution for custom PCR prep protocol for 69cf81

## changelog

#### 12/13/2021
- use one set of tips for mmix transfer
- add samples before primers
- update protoBuilds