### PR TITLE
fix(protocol-supplements/121d15-2): rename tip tracking data variable

### DIFF
--- a/protocol-supplements/121d15-2/templates/aliquoting_15ml_2ml.ot2.apiv2.py
+++ b/protocol-supplements/121d15-2/templates/aliquoting_15ml_2ml.ot2.apiv2.py
@@ -64,10 +64,10 @@ def run(ctx):
     if tip_track and not ctx.is_simulating():
         if os.path.isfile(tip_file_path):
             with open(tip_file_path) as json_file:
-                data = json.load(json_file)
+                tip_data = json.load(json_file)
                 for pip in tip_log:
-                    if pip.name in data:
-                        tip_log[pip]['count'] = data[pip.name]
+                    if pip.name in tip_data:
+                        tip_log[pip]['count'] = tip_data[pip.name]
                     else:
                         tip_log[pip]['count'] = 0
         else:
@@ -192,6 +192,6 @@ resuming.')
     if not ctx.is_simulating():
         if not os.path.isdir(folder_path):
             os.mkdir(folder_path)
-        data = {pip.name: tip_log[pip]['count'] for pip in tip_log}
+        tip_data = {pip.name: tip_log[pip]['count'] for pip in tip_log}
         with open(tip_file_path, 'w') as outfile:
-            json.dump(data, outfile)
+            json.dump(tip_data, outfile)

--- a/protocol-supplements/121d15-2/templates/aliquoting_2ml_2ml.ot2.apiv2.py
+++ b/protocol-supplements/121d15-2/templates/aliquoting_2ml_2ml.ot2.apiv2.py
@@ -33,10 +33,10 @@ def run(ctx):
     if tip_track and not ctx.is_simulating():
         if os.path.isfile(tip_file_path):
             with open(tip_file_path) as json_file:
-                data = json.load(json_file)
+                tip_data = json.load(json_file)
                 for pip in tip_log:
-                    if pip.name in data:
-                        tip_log[pip]['count'] = data[pip.name]
+                    if pip.name in tip_data:
+                        tip_log[pip]['count'] = tip_data[pip.name]
                     else:
                         tip_log[pip]['count'] = 0
         else:
@@ -125,6 +125,6 @@ resuming.')
     if not ctx.is_simulating():
         if not os.path.isdir(folder_path):
             os.mkdir(folder_path)
-        data = {pip.name: tip_log[pip]['count'] for pip in tip_log}
+        tip_data = {pip.name: tip_log[pip]['count'] for pip in tip_log}
         with open(tip_file_path, 'w') as outfile:
-            json.dump(data, outfile)
+            json.dump(tip_data, outfile)

--- a/protocol-supplements/121d15-2/templates/greiner_1000_redoreplacementpicking.ot2.apiv2.py
+++ b/protocol-supplements/121d15-2/templates/greiner_1000_redoreplacementpicking.ot2.apiv2.py
@@ -42,10 +42,10 @@ def run(ctx):
     if tip_track and not ctx.is_simulating():
         if os.path.isfile(tip_file_path):
             with open(tip_file_path) as json_file:
-                data = json.load(json_file)
+                tip_data = json.load(json_file)
                 for pip in tip_log:
-                    if pip.name in data:
-                        tip_log[pip]['count'] = data[pip.name]
+                    if pip.name in tip_data:
+                        tip_log[pip]['count'] = tip_data[pip.name]
                     else:
                         tip_log[pip]['count'] = 0
         else:
@@ -176,6 +176,6 @@ resuming.')
     if not ctx.is_simulating():
         if not os.path.isdir(folder_path):
             os.mkdir(folder_path)
-        data = {pip.name: tip_log[pip]['count'] for pip in tip_log}
+        tip_data = {pip.name: tip_log[pip]['count'] for pip in tip_log}
         with open(tip_file_path, 'w') as outfile:
-            json.dump(data, outfile)
+            json.dump(tip_data, outfile)

--- a/protocol-supplements/121d15-2/templates/greiner_384_redoreplacementpicking.ot2.apiv2.py
+++ b/protocol-supplements/121d15-2/templates/greiner_384_redoreplacementpicking.ot2.apiv2.py
@@ -41,10 +41,10 @@ def run(ctx):
     if tip_track and not ctx.is_simulating():
         if os.path.isfile(tip_file_path):
             with open(tip_file_path) as json_file:
-                data = json.load(json_file)
+                tip_data = json.load(json_file)
                 for pip in tip_log:
-                    if pip.name in data:
-                        tip_log[pip]['count'] = data[pip.name]
+                    if pip.name in tip_data:
+                        tip_log[pip]['count'] = tip_data[pip.name]
                     else:
                         tip_log[pip]['count'] = 0
         else:
@@ -177,6 +177,6 @@ resuming.')
     if not ctx.is_simulating():
         if not os.path.isdir(folder_path):
             os.mkdir(folder_path)
-        data = {pip.name: tip_log[pip]['count'] for pip in tip_log}
+        tip_data = {pip.name: tip_log[pip]['count'] for pip in tip_log}
         with open(tip_file_path, 'w') as outfile:
-            json.dump(data, outfile)
+            json.dump(tip_data, outfile)

--- a/protocol-supplements/121d15-2/templates/greiner_500_redoreplacementpicking.ot2.apiv2.py
+++ b/protocol-supplements/121d15-2/templates/greiner_500_redoreplacementpicking.ot2.apiv2.py
@@ -41,10 +41,10 @@ def run(ctx):
     if tip_track and not ctx.is_simulating():
         if os.path.isfile(tip_file_path):
             with open(tip_file_path) as json_file:
-                data = json.load(json_file)
+                tip_data = json.load(json_file)
                 for pip in tip_log:
-                    if pip.name in data:
-                        tip_log[pip]['count'] = data[pip.name]
+                    if pip.name in tip_data:
+                        tip_log[pip]['count'] = tip_data[pip.name]
                     else:
                         tip_log[pip]['count'] = 0
         else:
@@ -177,6 +177,6 @@ resuming.')
     if not ctx.is_simulating():
         if not os.path.isdir(folder_path):
             os.mkdir(folder_path)
-        data = {pip.name: tip_log[pip]['count'] for pip in tip_log}
+        tip_data = {pip.name: tip_log[pip]['count'] for pip in tip_log}
         with open(tip_file_path, 'w') as outfile:
-            json.dump(data, outfile)
+            json.dump(tip_data, outfile)

--- a/protocol-supplements/121d15-2/templates/irish_2200_redoreplacementpicking.ot2.apiv2.py
+++ b/protocol-supplements/121d15-2/templates/irish_2200_redoreplacementpicking.ot2.apiv2.py
@@ -41,10 +41,10 @@ def run(ctx):
     if tip_track and not ctx.is_simulating():
         if os.path.isfile(tip_file_path):
             with open(tip_file_path) as json_file:
-                data = json.load(json_file)
+                tip_data = json.load(json_file)
                 for pip in tip_log:
-                    if pip.name in data:
-                        tip_log[pip]['count'] = data[pip.name]
+                    if pip.name in tip_data:
+                        tip_log[pip]['count'] = tip_data[pip.name]
                     else:
                         tip_log[pip]['count'] = 0
         else:
@@ -177,6 +177,6 @@ resuming.')
     if not ctx.is_simulating():
         if not os.path.isdir(folder_path):
             os.mkdir(folder_path)
-        data = {pip.name: tip_log[pip]['count'] for pip in tip_log}
+        tip_data = {pip.name: tip_log[pip]['count'] for pip in tip_log}
         with open(tip_file_path, 'w') as outfile:
-            json.dump(data, outfile)
+            json.dump(tip_data, outfile)

--- a/protocol-supplements/121d15-2/templates/pooling_2ml_15ml.ot2.apiv2.py
+++ b/protocol-supplements/121d15-2/templates/pooling_2ml_15ml.ot2.apiv2.py
@@ -65,10 +65,10 @@ def run(ctx):
     if tip_track and not ctx.is_simulating():
         if os.path.isfile(tip_file_path):
             with open(tip_file_path) as json_file:
-                data = json.load(json_file)
+                tip_data = json.load(json_file)
                 for pip in tip_log:
-                    if pip.name in data:
-                        tip_log[pip]['count'] = data[pip.name]
+                    if pip.name in tip_data:
+                        tip_log[pip]['count'] = tip_data[pip.name]
                     else:
                         tip_log[pip]['count'] = 0
         else:
@@ -168,6 +168,6 @@ resuming.')
     if not ctx.is_simulating():
         if not os.path.isdir(folder_path):
             os.mkdir(folder_path)
-        data = {pip.name: tip_log[pip]['count'] for pip in tip_log}
+        tip_data = {pip.name: tip_log[pip]['count'] for pip in tip_log}
         with open(tip_file_path, 'w') as outfile:
-            json.dump(data, outfile)
+            json.dump(tip_data, outfile)

--- a/protocol-supplements/121d15-2/templates/pooling_2ml_2ml.ot2.apiv2.py
+++ b/protocol-supplements/121d15-2/templates/pooling_2ml_2ml.ot2.apiv2.py
@@ -33,10 +33,10 @@ def run(ctx):
     if tip_track and not ctx.is_simulating():
         if os.path.isfile(tip_file_path):
             with open(tip_file_path) as json_file:
-                data = json.load(json_file)
+                tip_data = json.load(json_file)
                 for pip in tip_log:
-                    if pip.name in data:
-                        tip_log[pip]['count'] = data[pip.name]
+                    if pip.name in tip_data:
+                        tip_log[pip]['count'] = tip_data[pip.name]
                     else:
                         tip_log[pip]['count'] = 0
         else:
@@ -125,6 +125,6 @@ resuming.')
     if not ctx.is_simulating():
         if not os.path.isdir(folder_path):
             os.mkdir(folder_path)
-        data = {pip.name: tip_log[pip]['count'] for pip in tip_log}
+        tip_data = {pip.name: tip_log[pip]['count'] for pip in tip_log}
         with open(tip_file_path, 'w') as outfile:
-            json.dump(data, outfile)
+            json.dump(tip_data, outfile)


### PR DESCRIPTION
## overview

updates tip tracking data variable from `data` to `tip_data` due to other use of `data` variable in parsing csv contents