### PR TITLE
32207e

### DIFF
--- a/protoBuilds/32207e/32207e.ot2.apiv2.py.json
+++ b/protoBuilds/32207e/32207e.ot2.apiv2.py.json
@@ -1,0 +1,84 @@
+{
+    "content": "metadata = {\n    'protocolName': 'SuperScript III: qRT-PCR Prep with CSV File',\n    'author': 'Rami Farawi <rami.farawi@opentrons.com>',\n    'source': 'Custom Protocol Request',\n    'apiLevel': '2.11'\n}\n\n\ndef run(ctx):\n\n    [csv, dna_asp_rate, p300_mount] = get_values(  # noqa: F821\n        \"csv\", \"dna_asp_rate\", \"p300_mount\")\n\n    # load Labware\n    dna_plate = ctx.load_labware('nest_96_wellplate_200ul_flat', 1)\n    final_plate = ctx.load_labware('nest_96_wellplate_200ul_flat', 2)\n    tuberack = ctx.load_labware('opentrons_6_tuberack_falcon_50ml_conical', 3)\n    tipracks = [ctx.load_labware('opentrons_96_tiprack_300ul', slot)\n                for slot in [4, 5]]\n\n    # load instrument\n    p300 = ctx.load_instrument(\"p300_single_gen2\", p300_mount,\n                               tip_racks=tipracks)\n\n    # mapping and parsing\n    te = tuberack.wells()[0]\n    csv_rows = [[val.strip() for val in line.split(',')]\n                for line in csv.splitlines()\n                if line.split(',')[0].strip()][1:]\n\n    num_samp = 0\n    for row in csv_rows:\n\n        if len(row[4]) == 0:\n            break\n        else:\n            num_samp += 1\n    csv_rows = csv_rows[:num_samp]\n\n    for row in csv_rows:\n        if int(row[4]) >= 200:\n            raise Exception(\"Volume greater than 200ul TE in csv file\")\n    num_samp = len(csv_rows)\n\n    # transferring TE\n    ctx.comment('\\n\\n TRANSFERRING TE TO PLATE\\n')\n    p300.pick_up_tip()\n    for well, row in zip(final_plate.wells()[:num_samp], csv_rows):\n        te_vol = int(row[4])\n        if te_vol > 0:\n            p300.aspirate(te_vol, te)\n            p300.dispense(te_vol, well)\n        else:\n            continue\n    p300.drop_tip()\n\n    ctx.comment('\\n\\n TRANSFERRING DNA TO PLATE\\n')\n    for source_well, dest_well, row in zip(final_plate.wells()[:num_samp],\n                                           dna_plate.wells(),\n                                           csv_rows):\n        dna_vol = int(row[2])\n        te_vol = int(row[4])\n        total_vol = te_vol + dna_vol\n        p300.pick_up_tip()\n        p300.aspirate(dna_vol, source_well.bottom(z=3), rate=dna_asp_rate)\n        p300.dispense(dna_vol, dest_well)\n        p300.mix(3, total_vol*0.8, dest_well)\n        p300.drop_tip()\n",
+    "custom_labware_defs": [],
+    "fields": [
+        {
+            "default": "Well,initial conc (ng/\u03bcL),initial volume (\u03bcL),final conc (ng/\u03bcL),volume to add (\u03bcL),Name,Pipette\nA1,1385,10,100,129,R1125 LBCC 1035 mix,P200",
+            "label": ".CSV File",
+            "name": "csv",
+            "type": "textFile"
+        },
+        {
+            "default": 0.5,
+            "label": "DNA Aspiration Flow Rate",
+            "name": "dna_asp_rate",
+            "type": "float"
+        },
+        {
+            "label": "P300 Single-Channel Mount",
+            "name": "p300_mount",
+            "options": [
+                {
+                    "label": "Left",
+                    "value": "left"
+                },
+                {
+                    "label": "Right",
+                    "value": "right"
+                }
+            ],
+            "type": "dropDown"
+        }
+    ],
+    "instruments": [
+        {
+            "mount": "left",
+            "name": "p300_single_gen2"
+        }
+    ],
+    "labware": [
+        {
+            "name": "NEST 96 Well Plate 200 \u00b5L Flat on 1",
+            "share": false,
+            "slot": "1",
+            "type": "nest_96_wellplate_200ul_flat"
+        },
+        {
+            "name": "NEST 96 Well Plate 200 \u00b5L Flat on 2",
+            "share": false,
+            "slot": "2",
+            "type": "nest_96_wellplate_200ul_flat"
+        },
+        {
+            "name": "Opentrons 6 Tube Rack with Falcon 50 mL Conical on 3",
+            "share": false,
+            "slot": "3",
+            "type": "opentrons_6_tuberack_falcon_50ml_conical"
+        },
+        {
+            "name": "Opentrons 96 Tip Rack 300 \u00b5L on 4",
+            "share": false,
+            "slot": "4",
+            "type": "opentrons_96_tiprack_300ul"
+        },
+        {
+            "name": "Opentrons 96 Tip Rack 300 \u00b5L on 5",
+            "share": false,
+            "slot": "5",
+            "type": "opentrons_96_tiprack_300ul"
+        },
+        {
+            "name": "Opentrons Fixed Trash on 12",
+            "share": false,
+            "slot": "12",
+            "type": "opentrons_1_trash_1100ml_fixed"
+        }
+    ],
+    "metadata": {
+        "apiLevel": "2.11",
+        "author": "Rami Farawi <rami.farawi@opentrons.com>",
+        "protocolName": "SuperScript III: qRT-PCR Prep with CSV File",
+        "source": "Custom Protocol Request"
+    },
+    "modules": []
+}

--- a/protoBuilds/32207e/README.json
+++ b/protoBuilds/32207e/README.json
@@ -1,0 +1,30 @@
+{
+    "author": "Opentrons",
+    "categories": {
+        "Sample Prep": [
+            "Plate Filling"
+        ]
+    },
+    "deck-setup": "\n",
+    "description": "This protocol preps a 96 well plate with up to 96 samples of DNA, normalizing all DNA samples to the same concentration with TE. TE should not be filled more than 20mL in the 50mL falcon tube to prevent pipette plunging. One tip is used to load TE onto the plate, whereas one tip per sample is used for loading DNA samples to plate. After DNA is loaded, DNA and TE are mixed at 80% of the total well volume for 3 repetitions. If a volume greater than 200ul is passed in to the TE volume (greater than well volume), an error is thrown and the protocol will stop.  \nExplanation of complex parameters below:\n .csv file: Please upload your csv file in the following format, header included (no commas in header!).\n\n DNA Aspiration Rate: Specify the rate at which to aspirate DNA. A value of 1 is default, 0.5 being 50% of the default value, 1.2 being 20% faster than the default value, etc.\n* P300_mount: Specify which mount (left or right) to host the P300 single channel pipette.\n",
+    "internal": "32207e",
+    "labware": "\nOpentrons 4-in-1 Tube Rack with 50mL Falcon Tubes\nOpentrons 300ul Tips\nSarstedt PCR plate full skirt, 96 well, transparent, Low Profile, 100 \u00b5l\n",
+    "markdown": {
+        "author": "[Opentrons](https://opentrons.com/)\n\n",
+        "categories": "* Sample Prep\n\t* Plate Filling\n\n",
+        "deck-setup": "![deck layout]()\n\n---\n\n",
+        "description": "This protocol preps a 96 well plate with up to 96 samples of DNA, normalizing all DNA samples to the same concentration with TE. TE should not be filled more than 20mL in the 50mL falcon tube to prevent pipette plunging. One tip is used to load TE onto the plate, whereas one tip per sample is used for loading DNA samples to plate. After DNA is loaded, DNA and TE are mixed at 80% of the total well volume for 3 repetitions. If a volume greater than 200ul is passed in to the TE volume (greater than well volume), an error is thrown and the protocol will stop.  \n\nExplanation of complex parameters below:\n* `.csv file`: Please upload your csv file in the following format, header included (no commas in header!).\n![csv file](https://opentrons-protocol-library-website.s3.amazonaws.com/custom-README-images/32207e/Screen+Shot+2022-03-30+at+3.16.09+PM.png)\n* `DNA Aspiration Rate`: Specify the rate at which to aspirate DNA. A value of 1 is default, 0.5 being 50% of the default value, 1.2 being 20% faster than the default value, etc.\n* `P300_mount`: Specify which mount (left or right) to host the P300 single channel pipette.\n\n---\n\n",
+        "internal": "32207e\n",
+        "labware": "* [Opentrons 4-in-1 Tube Rack with 50mL Falcon Tubes](https://shop.opentrons.com/4-in-1-tube-rack-set/)\n* [Opentrons 300ul Tips](https://shop.opentrons.com/universal-filter-tips/)\n* [Sarstedt PCR plate full skirt, 96 well, transparent, Low Profile, 100 \u00b5l](https://www.sarstedt.com/en/products/laboratory/pcr-molecular-biology/pcr-plates/product/72.1980/)\n\n",
+        "notes": "If you have any questions about this protocol, please contact the Protocol Development Team by filling out the [Troubleshooting Survey](https://protocol-troubleshooting.paperform.co/).\n\n",
+        "pipettes": "* [Opentrons P300 Single Channel Pipette](https://shop.opentrons.com/single-channel-electronic-pipette-p20/)\n\n---\n\n",
+        "process": "1. Input your protocol parameters above.\n2. Download your protocol and unzip if needed.\n3. Upload your custom labware to the [OT App](https://opentrons.com/ot-app) by navigating to `More` > `Custom Labware` > `Add Labware`, and selecting your labware files (.json extensions) if needed.\n4. Upload your protocol file (.py extension) to the [OT App](https://opentrons.com/ot-app) in the `Protocol` tab.\n5. Set up your deck according to the deck map.\n6. Calibrate your labware, tiprack and pipette using the OT App. For calibration tips, check out our [support articles](https://support.opentrons.com/en/collections/1559720-guide-for-getting-started-with-the-ot-2).\n7. Hit 'Run'.\n\n",
+        "protocol-steps": "1. This section should consist of a numerical outline of the protocol steps, somewhat analogous to the steps outlined by the user in their custom protocol submission.\n2. example step: Samples are transferred from the source tuberacks on slots 1-2 to the PCR plate on slot 3, down columns and then across rows.\n3. example step: Waste is removed from each sample on the magnetic module, ensuring the bead pellets are not contacted by the pipette tips.\n\n",
+        "title": "Diluting DNA with TE, Using .csv File"
+    },
+    "notes": "If you have any questions about this protocol, please contact the Protocol Development Team by filling out the Troubleshooting Survey.",
+    "pipettes": "\nOpentrons P300 Single Channel Pipette\n\n",
+    "process": "\nInput your protocol parameters above.\nDownload your protocol and unzip if needed.\nUpload your custom labware to the OT App by navigating to More > Custom Labware > Add Labware, and selecting your labware files (.json extensions) if needed.\nUpload your protocol file (.py extension) to the OT App in the Protocol tab.\nSet up your deck according to the deck map.\nCalibrate your labware, tiprack and pipette using the OT App. For calibration tips, check out our support articles.\nHit 'Run'.\n",
+    "protocol-steps": "\nThis section should consist of a numerical outline of the protocol steps, somewhat analogous to the steps outlined by the user in their custom protocol submission.\nexample step: Samples are transferred from the source tuberacks on slots 1-2 to the PCR plate on slot 3, down columns and then across rows.\nexample step: Waste is removed from each sample on the magnetic module, ensuring the bead pellets are not contacted by the pipette tips.\n",
+    "title": "Diluting DNA with TE, Using .csv File"
+}

--- a/protoBuilds/32207e/metadata.json
+++ b/protoBuilds/32207e/metadata.json
@@ -1,0 +1,20 @@
+{
+    "files": {
+        "OT 1 protocol": [],
+        "OT 2 protocol": [
+            "32207e.ot2.apiv2.py"
+        ],
+        "description": [
+            "README.md"
+        ]
+    },
+    "flags": {
+        "embedded-app": false,
+        "feature": false,
+        "hide-from-search": false,
+        "skip-tests": false
+    },
+    "path": "protocols/32207e",
+    "slug": "32207e",
+    "status": "ok"
+}

--- a/protocols/32207e/32207e.ot2.apiv2.py
+++ b/protocols/32207e/32207e.ot2.apiv2.py
@@ -1,0 +1,68 @@
+metadata = {
+    'protocolName': 'SuperScript III: qRT-PCR Prep with CSV File',
+    'author': 'Rami Farawi <rami.farawi@opentrons.com>',
+    'source': 'Custom Protocol Request',
+    'apiLevel': '2.11'
+}
+
+
+def run(ctx):
+
+    [csv, dna_asp_rate, p300_mount] = get_values(  # noqa: F821
+        "csv", "dna_asp_rate", "p300_mount")
+
+    # load Labware
+    dna_plate = ctx.load_labware('nest_96_wellplate_200ul_flat', 1)
+    final_plate = ctx.load_labware('nest_96_wellplate_200ul_flat', 2)
+    tuberack = ctx.load_labware('opentrons_6_tuberack_falcon_50ml_conical', 3)
+    tipracks = [ctx.load_labware('opentrons_96_tiprack_300ul', slot)
+                for slot in [4, 5]]
+
+    # load instrument
+    p300 = ctx.load_instrument("p300_single_gen2", p300_mount,
+                               tip_racks=tipracks)
+
+    # mapping and parsing
+    te = tuberack.wells()[0]
+    csv_rows = [[val.strip() for val in line.split(',')]
+                for line in csv.splitlines()
+                if line.split(',')[0].strip()][1:]
+
+    num_samp = 0
+    for row in csv_rows:
+
+        if len(row[4]) == 0:
+            break
+        else:
+            num_samp += 1
+    csv_rows = csv_rows[:num_samp]
+
+    for row in csv_rows:
+        if int(row[4]) >= 200:
+            raise Exception("Volume greater than 200ul TE in csv file")
+    num_samp = len(csv_rows)
+
+    # transferring TE
+    ctx.comment('\n\n TRANSFERRING TE TO PLATE\n')
+    p300.pick_up_tip()
+    for well, row in zip(final_plate.wells()[:num_samp], csv_rows):
+        te_vol = int(row[4])
+        if te_vol > 0:
+            p300.aspirate(te_vol, te)
+            p300.dispense(te_vol, well)
+        else:
+            continue
+    p300.drop_tip()
+
+    ctx.comment('\n\n TRANSFERRING DNA TO PLATE\n')
+    for source_well, dest_well, row in zip(final_plate.wells()[:num_samp],
+                                           dna_plate.wells(),
+                                           csv_rows):
+        dna_vol = int(row[2])
+        te_vol = int(row[4])
+        total_vol = te_vol + dna_vol
+        p300.pick_up_tip()
+        p300.aspirate(dna_vol, source_well.bottom(z=3), rate=dna_asp_rate)
+        p300.dispense(dna_vol, dest_well)
+        p300.mix(3, total_vol*0.8, dest_well)
+        p300.drop_tip()

--- a/protocols/32207e/README.md
+++ b/protocols/32207e/README.md
@@ -1,0 +1,54 @@
+# Diluting DNA with TE, Using .csv File
+
+### Author
+[Opentrons](https://opentrons.com/)
+
+## Categories
+* Sample Prep
+	* Plate Filling
+
+## Description
+This protocol preps a 96 well plate with up to 96 samples of DNA, normalizing all DNA samples to the same concentration with TE. TE should not be filled more than 20mL in the 50mL falcon tube to prevent pipette plunging. One tip is used to load TE onto the plate, whereas one tip per sample is used for loading DNA samples to plate. After DNA is loaded, DNA and TE are mixed at 80% of the total well volume for 3 repetitions. If a volume greater than 200ul is passed in to the TE volume (greater than well volume), an error is thrown and the protocol will stop.  
+
+Explanation of complex parameters below:
+* `.csv file`: Please upload your csv file in the following format, header included (no commas in header!).
+![csv file](https://opentrons-protocol-library-website.s3.amazonaws.com/custom-README-images/32207e/Screen+Shot+2022-03-30+at+3.16.09+PM.png)
+* `DNA Aspiration Rate`: Specify the rate at which to aspirate DNA. A value of 1 is default, 0.5 being 50% of the default value, 1.2 being 20% faster than the default value, etc.
+* `P300_mount`: Specify which mount (left or right) to host the P300 single channel pipette.
+
+---
+
+### Labware
+* [Opentrons 4-in-1 Tube Rack with 50mL Falcon Tubes](https://shop.opentrons.com/4-in-1-tube-rack-set/)
+* [Opentrons 300ul Tips](https://shop.opentrons.com/universal-filter-tips/)
+* [Sarstedt PCR plate full skirt, 96 well, transparent, Low Profile, 100 µl](https://www.sarstedt.com/en/products/laboratory/pcr-molecular-biology/pcr-plates/product/72.1980/)
+
+### Pipettes
+* [Opentrons P300 Single Channel Pipette](https://shop.opentrons.com/single-channel-electronic-pipette-p20/)
+
+---
+
+### Deck Setup
+![deck layout]()
+
+---
+
+### Protocol Steps
+1. This section should consist of a numerical outline of the protocol steps, somewhat analogous to the steps outlined by the user in their custom protocol submission.
+2. example step: Samples are transferred from the source tuberacks on slots 1-2 to the PCR plate on slot 3, down columns and then across rows.
+3. example step: Waste is removed from each sample on the magnetic module, ensuring the bead pellets are not contacted by the pipette tips.
+
+### Process
+1. Input your protocol parameters above.
+2. Download your protocol and unzip if needed.
+3. Upload your custom labware to the [OT App](https://opentrons.com/ot-app) by navigating to `More` > `Custom Labware` > `Add Labware`, and selecting your labware files (.json extensions) if needed.
+4. Upload your protocol file (.py extension) to the [OT App](https://opentrons.com/ot-app) in the `Protocol` tab.
+5. Set up your deck according to the deck map.
+6. Calibrate your labware, tiprack and pipette using the OT App. For calibration tips, check out our [support articles](https://support.opentrons.com/en/collections/1559720-guide-for-getting-started-with-the-ot-2).
+7. Hit 'Run'.
+
+### Additional Notes
+If you have any questions about this protocol, please contact the Protocol Development Team by filling out the [Troubleshooting Survey](https://protocol-troubleshooting.paperform.co/).
+
+###### Internal
+32207e

--- a/protocols/32207e/fields.json
+++ b/protocols/32207e/fields.json
@@ -1,5 +1,3 @@
-FIELDS EXAMPLE
-
 [
   {
     "type": "textFile",

--- a/protocols/32207e/fields.json
+++ b/protocols/32207e/fields.json
@@ -1,0 +1,25 @@
+FIELDS EXAMPLE
+
+[
+  {
+    "type": "textFile",
+    "label": ".CSV File",
+    "name": "csv",
+    "default": "Well,initial conc (ng/μL),initial volume (μL),final conc (ng/μL),volume to add (μL),Name,Pipette\nA1,1385,10,100,129,R1125 LBCC 1035 mix,P200"
+  },
+  {
+    "type": "float",
+    "label": "DNA Aspiration Flow Rate",
+    "name": "dna_asp_rate",
+    "default": 0.5
+  },
+  {
+    "type": "dropDown",
+    "label": "P300 Single-Channel Mount",
+    "name": "p300_mount",
+    "options": [
+      {"label": "Left", "value": "left"},
+      {"label": "Right", "value": "right"}
+    ]
+  }
+]


### PR DESCRIPTION
This protocol preps a 96 well plate with up to 96 samples of DNA, normalizing all DNA samples to the same concentration with TE. TE should not be filled more than 20mL in the 50mL falcon tube to prevent pipette plunging. One tip is used to load TE onto the plate, whereas one tip per sample is used for loading DNA samples to plate. After DNA is loaded, DNA and TE are mixed at 80% of the total well volume for 3 repetitions. If a volume greater than 200ul is passed in to the TE volume (greater than well volume), an error is thrown and the protocol will stop.  