### PR TITLE
00f7b1_part5

### DIFF
--- a/data/data/fields.csv
+++ b/data/data/fields.csv
@@ -434,7 +434,7 @@ final_temp,3
 final_tubes,1
 final_vol,3
 first_media_x,1
-flash,23
+flash,24
 flow_rate_asp,1
 flow_rate_beads,6
 flow_rate_disp,1
@@ -646,7 +646,7 @@ lysis,1
 lysis_vol,1
 m10_mount,2
 m1k,1
-m20_mount,69
+m20_mount,68
 m300_mount,79
 m300_type,2
 m_mount,1
@@ -1468,7 +1468,7 @@ vol_peptide2,1
 vol_peptide3,1
 vol_pma_ca,1
 vol_reagent,1
-vol_sample,4
+vol_sample,3
 vol_sirna,1
 vol_source_bb_per_well,1
 vol_source_bead_mix_per_well,1

--- a/protoBuilds/00f7b1_part5/00f7b1_part5.ot2.apiv2.py.json
+++ b/protoBuilds/00f7b1_part5/00f7b1_part5.ot2.apiv2.py.json
@@ -1,0 +1,1312 @@
+{
+    "content": "# flake8: noqa\n\n\"\"\"OPENTRONS.\"\"\"\nfrom opentrons import protocol_api\nimport math\nimport threading\nfrom time import sleep\nfrom opentrons import types\n\nmetadata = {\n    'protocolName': 'NEBNext Ultra II Directional RNA Library Prep Kit for Illumina Part 5: DNA Purification',\n    'author': 'John C. Lynch <john.lynch@opentrons.com>',\n    'source': 'Custom Protocol Request',\n    'apiLevel': '2.11'   # CHECK IF YOUR API LEVEL HERE IS UP TO DATE\n                         # IN SECTION 5.2 OF THE APIV2 \"VERSIONING\"\n}\n\n# Definitions for deck light flashing\n\n\nclass CancellationToken:\n    \"\"\"FLASH SETUP.\"\"\"\n\n    def __init__(self):\n        \"\"\"FLASH SETUP.\"\"\"\n        self.is_continued = False\n\n    def set_true(self):\n        \"\"\"FLASH SETUP.\"\"\"\n        self.is_continued = True\n\n    def set_false(self):\n        \"\"\"FLASH SETUP.\"\"\"\n        self.is_continued = False\n\n\ndef turn_on_blinking_notification(hardware, pause):\n    \"\"\"FLASH SETUP.\"\"\"\n    while pause.is_continued:\n        hardware.set_lights(rails=True)\n        sleep(1)\n        hardware.set_lights(rails=False)\n        sleep(1)\n\n\ndef create_thread(ctx, cancel_token):\n    \"\"\"FLASH SETUP.\"\"\"\n    t1 = threading.Thread(target=turn_on_blinking_notification,\n                          args=(ctx._hw_manager.hardware, cancel_token))\n    t1.start()\n    return t1\n\n\ndef run(ctx: protocol_api.ProtocolContext):\n    \"\"\"PROTOCOLS.\"\"\"\n    [\n     num_samples,\n     m300_mount, flash\n    ] = get_values(  # noqa: F821 (<--- DO NOT REMOVE!)\n        \"num_samples\", \"m300_mount\", \"flash\")\n\n    'Global variables'\n    TEST_MODE = True\n    bead_delay_time = 10\n    wash_delay_time = 10\n    supernatant_headspeed_modulator = 10\n    mag_height = 3.5\n    air_dry_time = 5\n    ctx.max_speeds['Z'] = 125\n    ctx.max_speeds['A'] = 125\n    # Setup for flashing lights notification to empty trash\n    cancellationToken = CancellationToken()\n\n    # define all custom variables above here with descriptions:\n    num_columns = math.ceil(num_samples/8)\n    if m300_mount == 'right':\n        m20_mount = 'left'\n    else:\n        m20_mount = 'right'\n    # load modules\n    mag_deck = ctx.load_module('magnetic module gen2', '1')\n    temp_deck = ctx.load_module('temperature module gen2', '3')\n    print(num_columns)\n\n    # load labware\n    mag_plate = mag_deck.load_labware('nest_96_wellplate_2ml_deep')\n    temp_plate = temp_deck.load_labware('opentrons_96_aluminumblock_generic_'\n                                        'pcr_strip_200ul')\n    dwp = ctx.load_labware('nest_96_wellplate_2ml_deep', '4')\n    sample_plate = ctx.load_labware('thermofisher_96_wellplate_200ul', '5')\n    final_plate = ctx.load_labware('thermofisher_96_wellplate_200ul', '2')\n    trash = ctx.load_labware('nest_1_reservoir_195ml', '9').wells()[0].top()\n    # load tipracks\n\n    tips300 = [ctx.load_labware('opentrons_96_filtertiprack_200ul', slot)\n               for slot in ['7', '10']]\n    tips20 = [ctx.load_labware('opentrons_96_filtertiprack_20ul', slot)\n              for slot in ['11']]\n    # load instrument\n\n    m300 = ctx.load_instrument(\n        'p300_multi_gen2', m300_mount, tip_racks=tips300)\n\n    m20 = ctx.load_instrument('p20_multi_gen2', m20_mount, tip_racks=tips20)\n\n    # pipette functions   # INCLUDE ANY BINDING TO CLASS\n    # reagents\n    samples_start = sample_plate.rows()[0][:num_columns]\n    samples_mag = mag_plate.rows()[0][:num_columns]\n    beads = dwp.rows()[0][0]\n    etoh = dwp.rows()[0][2:2+math.ceil(num_columns/4)]*12\n    te_buff = temp_plate.rows()[0][:math.ceil(num_columns/3)]*12\n    final_dest = final_plate.rows()[0][:num_columns]\n\n    def pick_up(pip):\n        try:\n            pip.pick_up_tip()\n        except protocol_api.labware.OutOfTipsError:\n            if flash:\n                if not ctx._hw_manager.hardware.is_simulator:\n                    cancellationToken.set_true()\n                thread = create_thread(ctx, cancellationToken)\n            pip.home()\n            ctx.pause('\\n\\n~~~~~~~~~~~~~~PLEASE REPLACE TIPRACKS~~~~~~~~~~~~~~~\\n')  # noqa: E501\n            ctx.home()  # home before continuing with protocol\n            if flash:\n                cancellationToken.set_false()  # stop light flashing after home\n                thread.join()\n            ctx.set_rail_lights(True)\n            pip.reset_tipracks()\n            pick_up(pip)\n\n    tips_dropped = 0\n\n    def drop_tip(pip, home=True):\n        nonlocal tips_dropped\n        pip.drop_tip(home_after=home)\n        if pip == m300:\n            tips_dropped += 8\n        else:\n            tips_dropped += 1\n        if tips_dropped == 288:\n            if flash:\n                if not ctx._hw_manager.hardware.is_simulator:\n                    cancellationToken.set_true()\n                thread = create_thread(ctx, cancellationToken)\n            pip.home()\n            ctx.pause('\\n\\n~~~~~~~~~~~~~~PLEASE EMPTY TRASH~~~~~~~~~~~~~~~\\n')\n            ctx.home()  # home before continuing with protocol\n            if flash:\n                cancellationToken.set_false()  # stop light flashing after home\n                thread.join()\n            ctx.set_rail_lights(True)\n            tips_dropped = 0\n\n    def bead_mixing(well, pip, mvol, reps=10):\n        \"\"\"bead_mixing.\"\"\"\n        \"\"\"\n        'bead_mixing' will mix liquid that contains beads. This will be done by\n        aspirating from the middle of the well & dispensing from the bottom to\n        mix the beads with the other liquids as much as possible. Aspiration &\n        dispensing will also be reversed to ensure proper mixing.\n        param well: The current well that the mixing will occur in.\n        param pip: The pipet that is currently attached/ being used.\n        param mvol: The volume that is transferred before the mixing steps.\n        param reps: The number of mix repetitions that should occur. Note~\n        During each mix rep, there are 2 cycles of aspirating from bottom,\n        dispensing at the top and 2 cycles of aspirating from middle,\n        dispensing at the bottom\n        \"\"\"\n        vol = mvol * .9\n\n        pip.move_to(well.center())\n        for _ in range(reps):\n            pip.aspirate(vol, well.bottom(1), rate=2)\n            pip.dispense(vol, well.bottom(5), rate=2)\n\n    def remove_supernatant(vol, use_300=True, use_20=True):\n        for i, dest in enumerate(samples_mag):\n            side = -1 if i % 2 == 0 else 1\n            if use_300:\n                m300.move_to(dest.top())\n                ctx.max_speeds['Z'] /= supernatant_headspeed_modulator\n                ctx.max_speeds['A'] /= supernatant_headspeed_modulator\n                m300.aspirate(vol-20, dest.bottom().move(types.Point(x=side, y=0, z=1)),\n                              rate=0.1)\n                ctx.delay(seconds=1)\n                m300.move_to(dest.top())\n                m300.aspirate(10, dest.top())\n                ctx.max_speeds['Z'] *= supernatant_headspeed_modulator\n                ctx.max_speeds['A'] *= supernatant_headspeed_modulator\n                m300.dispense(m300.current_volume, trash)\n                m300.blow_out()\n                m300.air_gap(50)\n            if use_20:\n                if not m20.has_tip:\n                    pick_up(m20)\n                m20.move_to(dest.top())\n                ctx.max_speeds['Z'] /= supernatant_headspeed_modulator\n                ctx.max_speeds['A'] /= supernatant_headspeed_modulator\n                m20.aspirate(19, dest.bottom().move(types.Point(x=side, y=0, z=1)),\n                             rate=0.1)\n                ctx.delay(seconds=1)\n                m20.move_to(dest.top())\n                m20.aspirate(1, dest.top())\n                ctx.max_speeds['Z'] *= supernatant_headspeed_modulator\n                ctx.max_speeds['A'] *= supernatant_headspeed_modulator\n                m20.dispense(m20.current_volume, trash)\n                m20.blow_out()\n                m20.aspirate(10, trash)\n                ctx.comment('\\n')\n                if m20.has_tip:\n                    drop_tip(m20)\n\n    # protocol\n    ctx.comment('\\n~~~~~~~~~~~~~~ADDING SAMPLES TO MAG PLATE~~~~~~~~~~~~~~\\n')\n    for s, d in zip(samples_start, samples_mag):\n        pick_up(m300)\n        m300.aspirate(80, s)\n        m300.dispense(80, d)\n        drop_tip(m300)\n\n    ctx.comment('\\n~~~~~~~~~~~~~~ADDING BEADS TO SAMPLES~~~~~~~~~~~~~~\\n')\n    for i, dest in enumerate(samples_mag):\n        pick_up(m300)\n        if i % 3 == 0:\n            bead_mixing(beads, m300, 200)\n        m300.aspirate(144, beads, rate=0.5)\n        ctx.delay(seconds=1)\n        ctx.max_speeds['Z'] /= supernatant_headspeed_modulator\n        ctx.max_speeds['A'] /= supernatant_headspeed_modulator\n        m300.move_to(beads.top())\n        ctx.max_speeds['Z'] *= supernatant_headspeed_modulator\n        ctx.max_speeds['A'] *= supernatant_headspeed_modulator\n        m300.dispense(144, dest, rate=0.5)\n        bead_mixing(dest, m300, 200, reps=6)\n        m300.blow_out(dest.bottom(20))\n        drop_tip(m300)\n\n    ctx.comment('\\n~~~~~~~~~~~~~~INCUBATING SAMPLES WITH BEADS~~~~~~~~~~~~~\\n')\n    if TEST_MODE:\n        ctx.delay(seconds=bead_delay_time)\n    else:\n        ctx.delay(minute=bead_delay_time)\n\n    mag_deck.engage(height_from_base=mag_height)\n    ctx.comment('\\n~~~~~~~~~~~~~~SEPARATING BEADS~~~~~~~~~~~~~\\n')\n    if TEST_MODE:\n        ctx.delay(minutes=bead_delay_time)\n    else:\n        ctx.delay(minute=bead_delay_time)\n\n    ctx.comment('\\n~~~~~~~~~~~~~~REMOVING SUPERNATANT~~~~~~~~~~~~~\\n')\n    for i, dest in enumerate(samples_mag):\n        side = -1 if i % 2 == 0 else 1\n        pick_up(m300)\n        for _ in range(2):\n\n            m300.move_to(dest.top())\n            ctx.max_speeds['Z'] /= supernatant_headspeed_modulator\n            ctx.max_speeds['A'] /= supernatant_headspeed_modulator\n            m300.aspirate(105, dest.bottom().move(types.Point(x=side, y=0, z=1)),\n                          rate=0.1)\n            ctx.delay(seconds=1)\n            m300.move_to(dest.top())\n            m300.aspirate(10, dest.top())\n            ctx.max_speeds['Z'] *= supernatant_headspeed_modulator\n            ctx.max_speeds['A'] *= supernatant_headspeed_modulator\n            m300.dispense(m300.current_volume, trash)\n            m300.blow_out()\n            m300.air_gap(50)\n        drop_tip(m300)\n\n        pick_up(m20)\n        m20.move_to(dest.top())\n        ctx.max_speeds['Z'] /= supernatant_headspeed_modulator\n        ctx.max_speeds['A'] /= supernatant_headspeed_modulator\n        m20.aspirate(13, dest.bottom().move(types.Point(x=0, y=0, z=0.5)),\n                     rate=0.1)\n        ctx.delay(seconds=1)\n        m20.move_to(dest.top())\n        m20.aspirate(1, dest.top())\n        ctx.max_speeds['Z'] *= supernatant_headspeed_modulator\n        ctx.max_speeds['A'] *= supernatant_headspeed_modulator\n        m20.dispense(m20.current_volume, trash)\n        m20.blow_out()\n        m20.aspirate(10, trash)\n        drop_tip(m20)\n\n    ctx.comment('\\n~~~~~~~~~~~~~~WASHING TWICE WITH ETHANOL~~~~~~~~~~~~~\\n')\n    for _ in range(2):\n        pick_up(m300)\n        ctx.comment('\\n~~~~~~~~~~~~~~ADDING ETHANOL~~~~~~~~~~~~~\\n')\n        for eth, dest in zip(etoh, samples_mag):\n            m300.mix(1, 200, eth)\n            m300.aspirate(200, eth)\n            m300.dispense(190, dest.top())\n            m300.aspirate(20, dest.top())\n            m300.dispense(30, eth.top())\n\n        ctx.delay(seconds=30)\n        ctx.comment('\\n~~~~~~~~~~~~~~REMOVING ETHANOL~~~~~~~~~~~~~\\n')\n        for i, dest in enumerate(samples_mag):\n            if i > 0:\n                pick_up(m300)\n            m300.aspirate(200, dest.bottom().move(types.Point(x=-1, y=0, z=0.5)),\n                          rate=0.1)\n            m300.dispense(200, trash)\n            drop_tip(m300)\n            if _ == 1:\n                ctx.delay(minutes=1)\n                pick_up(m20)\n                m20.aspirate(10, dest.bottom(0.15), rate=.1)\n                m20.aspirate(2, dest.top())\n                m20.dispense(m20.current_volume, trash)\n                m20.aspirate(10, trash)\n                m20.drop_tip()\n\n    ctx.comment('\\n~~~~~~~~~~~~~~AIR DRY BEADS FOR 5 MINUTES~~~~~~~~~~~~~\\n')\n    if TEST_MODE:\n        ctx.delay(minutes=air_dry_time)\n    else:\n        ctx.delay(minutes=air_dry_time)\n\n    mag_deck.disengage()\n\n    ctx.comment('\\n~~~~~~~~~~~~~~ELUTING WITH TE BUFFER~~~~~~~~~~~~~\\n')\n    for te, dest in zip(te_buff, samples_mag):\n        pick_up(m300)\n        m300.aspirate(53, te)\n        m300.dispense(53, dest)\n        bead_mixing(dest, m300, 53)\n        m300.blow_out(dest.top())\n        m300.air_gap(20)\n        drop_tip(m300)\n\n    ctx.comment('\\n~~~~~~~~~~~~~~ELUTING FOR 2 MINUTES~~~~~~~~~~~~~\\n')\n    if TEST_MODE:\n        ctx.delay(seconds=2)\n    else:\n        ctx.delay(minutes=2)\n\n    ctx.comment('\\n~~~~~~~~~~~~~~SEPARATING BEADS~~~~~~~~~~~~~\\n')\n    mag_deck.engage(height_from_base=mag_height)\n    if TEST_MODE:\n        ctx.delay(minutes=bead_delay_time)\n    else:\n        ctx.delay(minute=bead_delay_time)\n\n    ctx.comment('\\n~~~~~~~~~~~~~~MOVING cDNA TO FINAL PLATE~~~~~~~~~~~~~\\n')\n    for i, (s, d) in enumerate(zip(samples_mag, final_dest)):\n        side = -1 if i % 2 == 0 else 1\n        pick_up(m300)\n        m300.aspirate(50, s.bottom().move(types.Point(x=side, y=0, z=1)),\n                      rate=0.1)\n        m300.dispense(50, d)\n        drop_tip(m300)\n\n    if flash:\n        if not ctx._hw_manager.hardware.is_simulator:\n            cancellationToken.set_true()\n        thread = create_thread(ctx, cancellationToken)\n    m300.home()\n    ctx.pause('\\n\\n~~~~~~~~~~~~~~PROTOCOL  COMPLETE~~~~~~~~~~~~~~~\\n')\n    ctx.home()  # home before continuing with protocol\n    if flash:\n        cancellationToken.set_false()  # stop light flashing after home\n        thread.join()\n    ctx.set_rail_lights(True)\n\n    for c in ctx.commands():\n        print(c)\n",
+    "custom_labware_defs": [
+        {
+            "brand": {
+                "brand": "thermo Fisher",
+                "brandId": [
+                    "AB-3396",
+                    "AB-2396"
+                ]
+            },
+            "cornerOffsetFromSlot": {
+                "x": 0,
+                "y": 0,
+                "z": 0
+            },
+            "dimensions": {
+                "xDimension": 127.76,
+                "yDimension": 85.48,
+                "zDimension": 16
+            },
+            "groups": [
+                {
+                    "metadata": {
+                        "wellBottomShape": "v"
+                    },
+                    "wells": [
+                        "A1",
+                        "B1",
+                        "C1",
+                        "D1",
+                        "E1",
+                        "F1",
+                        "G1",
+                        "H1",
+                        "A2",
+                        "B2",
+                        "C2",
+                        "D2",
+                        "E2",
+                        "F2",
+                        "G2",
+                        "H2",
+                        "A3",
+                        "B3",
+                        "C3",
+                        "D3",
+                        "E3",
+                        "F3",
+                        "G3",
+                        "H3",
+                        "A4",
+                        "B4",
+                        "C4",
+                        "D4",
+                        "E4",
+                        "F4",
+                        "G4",
+                        "H4",
+                        "A5",
+                        "B5",
+                        "C5",
+                        "D5",
+                        "E5",
+                        "F5",
+                        "G5",
+                        "H5",
+                        "A6",
+                        "B6",
+                        "C6",
+                        "D6",
+                        "E6",
+                        "F6",
+                        "G6",
+                        "H6",
+                        "A7",
+                        "B7",
+                        "C7",
+                        "D7",
+                        "E7",
+                        "F7",
+                        "G7",
+                        "H7",
+                        "A8",
+                        "B8",
+                        "C8",
+                        "D8",
+                        "E8",
+                        "F8",
+                        "G8",
+                        "H8",
+                        "A9",
+                        "B9",
+                        "C9",
+                        "D9",
+                        "E9",
+                        "F9",
+                        "G9",
+                        "H9",
+                        "A10",
+                        "B10",
+                        "C10",
+                        "D10",
+                        "E10",
+                        "F10",
+                        "G10",
+                        "H10",
+                        "A11",
+                        "B11",
+                        "C11",
+                        "D11",
+                        "E11",
+                        "F11",
+                        "G11",
+                        "H11",
+                        "A12",
+                        "B12",
+                        "C12",
+                        "D12",
+                        "E12",
+                        "F12",
+                        "G12",
+                        "H12"
+                    ]
+                }
+            ],
+            "metadata": {
+                "displayCategory": "wellPlate",
+                "displayName": "Thermo Fisher 96 Well Plate 200 \u00b5L",
+                "displayVolumeUnits": "\u00b5L",
+                "tags": []
+            },
+            "namespace": "custom_beta",
+            "ordering": [
+                [
+                    "A1",
+                    "B1",
+                    "C1",
+                    "D1",
+                    "E1",
+                    "F1",
+                    "G1",
+                    "H1"
+                ],
+                [
+                    "A2",
+                    "B2",
+                    "C2",
+                    "D2",
+                    "E2",
+                    "F2",
+                    "G2",
+                    "H2"
+                ],
+                [
+                    "A3",
+                    "B3",
+                    "C3",
+                    "D3",
+                    "E3",
+                    "F3",
+                    "G3",
+                    "H3"
+                ],
+                [
+                    "A4",
+                    "B4",
+                    "C4",
+                    "D4",
+                    "E4",
+                    "F4",
+                    "G4",
+                    "H4"
+                ],
+                [
+                    "A5",
+                    "B5",
+                    "C5",
+                    "D5",
+                    "E5",
+                    "F5",
+                    "G5",
+                    "H5"
+                ],
+                [
+                    "A6",
+                    "B6",
+                    "C6",
+                    "D6",
+                    "E6",
+                    "F6",
+                    "G6",
+                    "H6"
+                ],
+                [
+                    "A7",
+                    "B7",
+                    "C7",
+                    "D7",
+                    "E7",
+                    "F7",
+                    "G7",
+                    "H7"
+                ],
+                [
+                    "A8",
+                    "B8",
+                    "C8",
+                    "D8",
+                    "E8",
+                    "F8",
+                    "G8",
+                    "H8"
+                ],
+                [
+                    "A9",
+                    "B9",
+                    "C9",
+                    "D9",
+                    "E9",
+                    "F9",
+                    "G9",
+                    "H9"
+                ],
+                [
+                    "A10",
+                    "B10",
+                    "C10",
+                    "D10",
+                    "E10",
+                    "F10",
+                    "G10",
+                    "H10"
+                ],
+                [
+                    "A11",
+                    "B11",
+                    "C11",
+                    "D11",
+                    "E11",
+                    "F11",
+                    "G11",
+                    "H11"
+                ],
+                [
+                    "A12",
+                    "B12",
+                    "C12",
+                    "D12",
+                    "E12",
+                    "F12",
+                    "G12",
+                    "H12"
+                ]
+            ],
+            "parameters": {
+                "format": "irregular",
+                "isMagneticModuleCompatible": false,
+                "isTiprack": false,
+                "loadName": "thermofisher_96_wellplate_200ul",
+                "quirks": []
+            },
+            "schemaVersion": 2,
+            "version": 1,
+            "wells": {
+                "A1": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 14.38,
+                    "y": 74.24,
+                    "z": 1.05
+                },
+                "A10": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 95.38,
+                    "y": 74.24,
+                    "z": 1.05
+                },
+                "A11": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 104.38,
+                    "y": 74.24,
+                    "z": 1.05
+                },
+                "A12": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 113.38,
+                    "y": 74.24,
+                    "z": 1.05
+                },
+                "A2": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 23.38,
+                    "y": 74.24,
+                    "z": 1.05
+                },
+                "A3": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 32.38,
+                    "y": 74.24,
+                    "z": 1.05
+                },
+                "A4": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 41.38,
+                    "y": 74.24,
+                    "z": 1.05
+                },
+                "A5": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 50.38,
+                    "y": 74.24,
+                    "z": 1.05
+                },
+                "A6": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 59.38,
+                    "y": 74.24,
+                    "z": 1.05
+                },
+                "A7": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 68.38,
+                    "y": 74.24,
+                    "z": 1.05
+                },
+                "A8": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 77.38,
+                    "y": 74.24,
+                    "z": 1.05
+                },
+                "A9": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 86.38,
+                    "y": 74.24,
+                    "z": 1.05
+                },
+                "B1": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 14.38,
+                    "y": 65.24,
+                    "z": 1.05
+                },
+                "B10": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 95.38,
+                    "y": 65.24,
+                    "z": 1.05
+                },
+                "B11": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 104.38,
+                    "y": 65.24,
+                    "z": 1.05
+                },
+                "B12": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 113.38,
+                    "y": 65.24,
+                    "z": 1.05
+                },
+                "B2": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 23.38,
+                    "y": 65.24,
+                    "z": 1.05
+                },
+                "B3": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 32.38,
+                    "y": 65.24,
+                    "z": 1.05
+                },
+                "B4": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 41.38,
+                    "y": 65.24,
+                    "z": 1.05
+                },
+                "B5": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 50.38,
+                    "y": 65.24,
+                    "z": 1.05
+                },
+                "B6": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 59.38,
+                    "y": 65.24,
+                    "z": 1.05
+                },
+                "B7": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 68.38,
+                    "y": 65.24,
+                    "z": 1.05
+                },
+                "B8": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 77.38,
+                    "y": 65.24,
+                    "z": 1.05
+                },
+                "B9": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 86.38,
+                    "y": 65.24,
+                    "z": 1.05
+                },
+                "C1": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 14.38,
+                    "y": 56.24,
+                    "z": 1.05
+                },
+                "C10": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 95.38,
+                    "y": 56.24,
+                    "z": 1.05
+                },
+                "C11": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 104.38,
+                    "y": 56.24,
+                    "z": 1.05
+                },
+                "C12": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 113.38,
+                    "y": 56.24,
+                    "z": 1.05
+                },
+                "C2": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 23.38,
+                    "y": 56.24,
+                    "z": 1.05
+                },
+                "C3": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 32.38,
+                    "y": 56.24,
+                    "z": 1.05
+                },
+                "C4": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 41.38,
+                    "y": 56.24,
+                    "z": 1.05
+                },
+                "C5": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 50.38,
+                    "y": 56.24,
+                    "z": 1.05
+                },
+                "C6": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 59.38,
+                    "y": 56.24,
+                    "z": 1.05
+                },
+                "C7": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 68.38,
+                    "y": 56.24,
+                    "z": 1.05
+                },
+                "C8": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 77.38,
+                    "y": 56.24,
+                    "z": 1.05
+                },
+                "C9": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 86.38,
+                    "y": 56.24,
+                    "z": 1.05
+                },
+                "D1": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 14.38,
+                    "y": 47.24,
+                    "z": 1.05
+                },
+                "D10": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 95.38,
+                    "y": 47.24,
+                    "z": 1.05
+                },
+                "D11": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 104.38,
+                    "y": 47.24,
+                    "z": 1.05
+                },
+                "D12": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 113.38,
+                    "y": 47.24,
+                    "z": 1.05
+                },
+                "D2": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 23.38,
+                    "y": 47.24,
+                    "z": 1.05
+                },
+                "D3": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 32.38,
+                    "y": 47.24,
+                    "z": 1.05
+                },
+                "D4": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 41.38,
+                    "y": 47.24,
+                    "z": 1.05
+                },
+                "D5": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 50.38,
+                    "y": 47.24,
+                    "z": 1.05
+                },
+                "D6": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 59.38,
+                    "y": 47.24,
+                    "z": 1.05
+                },
+                "D7": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 68.38,
+                    "y": 47.24,
+                    "z": 1.05
+                },
+                "D8": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 77.38,
+                    "y": 47.24,
+                    "z": 1.05
+                },
+                "D9": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 86.38,
+                    "y": 47.24,
+                    "z": 1.05
+                },
+                "E1": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 14.38,
+                    "y": 38.24,
+                    "z": 1.05
+                },
+                "E10": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 95.38,
+                    "y": 38.24,
+                    "z": 1.05
+                },
+                "E11": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 104.38,
+                    "y": 38.24,
+                    "z": 1.05
+                },
+                "E12": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 113.38,
+                    "y": 38.24,
+                    "z": 1.05
+                },
+                "E2": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 23.38,
+                    "y": 38.24,
+                    "z": 1.05
+                },
+                "E3": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 32.38,
+                    "y": 38.24,
+                    "z": 1.05
+                },
+                "E4": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 41.38,
+                    "y": 38.24,
+                    "z": 1.05
+                },
+                "E5": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 50.38,
+                    "y": 38.24,
+                    "z": 1.05
+                },
+                "E6": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 59.38,
+                    "y": 38.24,
+                    "z": 1.05
+                },
+                "E7": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 68.38,
+                    "y": 38.24,
+                    "z": 1.05
+                },
+                "E8": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 77.38,
+                    "y": 38.24,
+                    "z": 1.05
+                },
+                "E9": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 86.38,
+                    "y": 38.24,
+                    "z": 1.05
+                },
+                "F1": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 14.38,
+                    "y": 29.24,
+                    "z": 1.05
+                },
+                "F10": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 95.38,
+                    "y": 29.24,
+                    "z": 1.05
+                },
+                "F11": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 104.38,
+                    "y": 29.24,
+                    "z": 1.05
+                },
+                "F12": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 113.38,
+                    "y": 29.24,
+                    "z": 1.05
+                },
+                "F2": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 23.38,
+                    "y": 29.24,
+                    "z": 1.05
+                },
+                "F3": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 32.38,
+                    "y": 29.24,
+                    "z": 1.05
+                },
+                "F4": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 41.38,
+                    "y": 29.24,
+                    "z": 1.05
+                },
+                "F5": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 50.38,
+                    "y": 29.24,
+                    "z": 1.05
+                },
+                "F6": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 59.38,
+                    "y": 29.24,
+                    "z": 1.05
+                },
+                "F7": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 68.38,
+                    "y": 29.24,
+                    "z": 1.05
+                },
+                "F8": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 77.38,
+                    "y": 29.24,
+                    "z": 1.05
+                },
+                "F9": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 86.38,
+                    "y": 29.24,
+                    "z": 1.05
+                },
+                "G1": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 14.38,
+                    "y": 20.24,
+                    "z": 1.05
+                },
+                "G10": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 95.38,
+                    "y": 20.24,
+                    "z": 1.05
+                },
+                "G11": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 104.38,
+                    "y": 20.24,
+                    "z": 1.05
+                },
+                "G12": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 113.38,
+                    "y": 20.24,
+                    "z": 1.05
+                },
+                "G2": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 23.38,
+                    "y": 20.24,
+                    "z": 1.05
+                },
+                "G3": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 32.38,
+                    "y": 20.24,
+                    "z": 1.05
+                },
+                "G4": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 41.38,
+                    "y": 20.24,
+                    "z": 1.05
+                },
+                "G5": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 50.38,
+                    "y": 20.24,
+                    "z": 1.05
+                },
+                "G6": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 59.38,
+                    "y": 20.24,
+                    "z": 1.05
+                },
+                "G7": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 68.38,
+                    "y": 20.24,
+                    "z": 1.05
+                },
+                "G8": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 77.38,
+                    "y": 20.24,
+                    "z": 1.05
+                },
+                "G9": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 86.38,
+                    "y": 20.24,
+                    "z": 1.05
+                },
+                "H1": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 14.38,
+                    "y": 11.24,
+                    "z": 1.05
+                },
+                "H10": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 95.38,
+                    "y": 11.24,
+                    "z": 1.05
+                },
+                "H11": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 104.38,
+                    "y": 11.24,
+                    "z": 1.05
+                },
+                "H12": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 113.38,
+                    "y": 11.24,
+                    "z": 1.05
+                },
+                "H2": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 23.38,
+                    "y": 11.24,
+                    "z": 1.05
+                },
+                "H3": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 32.38,
+                    "y": 11.24,
+                    "z": 1.05
+                },
+                "H4": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 41.38,
+                    "y": 11.24,
+                    "z": 1.05
+                },
+                "H5": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 50.38,
+                    "y": 11.24,
+                    "z": 1.05
+                },
+                "H6": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 59.38,
+                    "y": 11.24,
+                    "z": 1.05
+                },
+                "H7": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 68.38,
+                    "y": 11.24,
+                    "z": 1.05
+                },
+                "H8": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 77.38,
+                    "y": 11.24,
+                    "z": 1.05
+                },
+                "H9": {
+                    "depth": 14.95,
+                    "diameter": 5.5,
+                    "shape": "circular",
+                    "totalLiquidVolume": 200,
+                    "x": 86.38,
+                    "y": 11.24,
+                    "z": 1.05
+                }
+            }
+        }
+    ],
+    "fields": [
+        {
+            "label": "Number of samples",
+            "name": "num_samples",
+            "options": [
+                {
+                    "label": "8",
+                    "value": 8
+                },
+                {
+                    "label": "16",
+                    "value": 16
+                },
+                {
+                    "label": "24",
+                    "value": 24
+                },
+                {
+                    "label": "32",
+                    "value": 32
+                },
+                {
+                    "label": "40",
+                    "value": 40
+                },
+                {
+                    "label": "48",
+                    "value": 48
+                },
+                {
+                    "label": "56",
+                    "value": 56
+                },
+                {
+                    "label": "64",
+                    "value": 64
+                },
+                {
+                    "label": "72",
+                    "value": 72
+                },
+                {
+                    "label": "80",
+                    "value": 80
+                },
+                {
+                    "label": "88",
+                    "value": 88
+                },
+                {
+                    "label": "96",
+                    "value": 96
+                }
+            ],
+            "type": "dropDown"
+        },
+        {
+            "label": "P300 Multi-Channel Mount",
+            "name": "m300_mount",
+            "options": [
+                {
+                    "label": "Right",
+                    "value": "right"
+                },
+                {
+                    "label": "Left",
+                    "value": "left"
+                }
+            ],
+            "type": "dropDown"
+        },
+        {
+            "label": "Flash?",
+            "name": "flash",
+            "options": [
+                {
+                    "label": "Yes, flash",
+                    "value": true
+                },
+                {
+                    "label": "No, do not flash",
+                    "value": false
+                }
+            ],
+            "type": "dropDown"
+        }
+    ],
+    "instruments": [
+        {
+            "mount": "left",
+            "name": "p20_multi_gen2"
+        },
+        {
+            "mount": "right",
+            "name": "p300_multi_gen2"
+        }
+    ],
+    "labware": [
+        {
+            "name": "NEST 96 Deepwell Plate 2mL on Magnetic Module GEN2 on 1",
+            "share": false,
+            "slot": "1",
+            "type": "nest_96_wellplate_2ml_deep"
+        },
+        {
+            "name": "Thermo Fisher 96 Well Plate 200 \u00b5L on 2",
+            "share": false,
+            "slot": "2",
+            "type": "thermofisher_96_wellplate_200ul"
+        },
+        {
+            "name": "Opentrons 96 Well Aluminum Block with Generic PCR Strip 200 \u00b5L on Temperature Module GEN2 on 3",
+            "share": false,
+            "slot": "3",
+            "type": "opentrons_96_aluminumblock_generic_pcr_strip_200ul"
+        },
+        {
+            "name": "NEST 96 Deepwell Plate 2mL on 4",
+            "share": false,
+            "slot": "4",
+            "type": "nest_96_wellplate_2ml_deep"
+        },
+        {
+            "name": "Thermo Fisher 96 Well Plate 200 \u00b5L on 5",
+            "share": false,
+            "slot": "5",
+            "type": "thermofisher_96_wellplate_200ul"
+        },
+        {
+            "name": "Opentrons 96 Filter Tip Rack 200 \u00b5L on 7",
+            "share": false,
+            "slot": "7",
+            "type": "opentrons_96_filtertiprack_200ul"
+        },
+        {
+            "name": "NEST 1 Well Reservoir 195 mL on 9",
+            "share": false,
+            "slot": "9",
+            "type": "nest_1_reservoir_195ml"
+        },
+        {
+            "name": "Opentrons 96 Filter Tip Rack 200 \u00b5L on 10",
+            "share": false,
+            "slot": "10",
+            "type": "opentrons_96_filtertiprack_200ul"
+        },
+        {
+            "name": "Opentrons 96 Filter Tip Rack 20 \u00b5L on 11",
+            "share": false,
+            "slot": "11",
+            "type": "opentrons_96_filtertiprack_20ul"
+        },
+        {
+            "name": "Opentrons Fixed Trash on 12",
+            "share": false,
+            "slot": "12",
+            "type": "opentrons_1_trash_1100ml_fixed"
+        }
+    ],
+    "metadata": {
+        "apiLevel": "2.11",
+        "author": "John C. Lynch <john.lynch@opentrons.com>",
+        "protocolName": "NEBNext Ultra II Directional RNA Library Prep Kit for Illumina Part 5: DNA Purification",
+        "source": "Custom Protocol Request"
+    },
+    "modules": [
+        {
+            "name": "MagneticModuleContext at Magnetic Module GEN2 on 1 lw NEST 96 Deepwell Plate 2mL on Magnetic Module GEN2 on 1",
+            "share": false,
+            "slot": "1",
+            "type": "magdeck"
+        },
+        {
+            "name": "TemperatureModuleContext at Temperature Module GEN2 on 3 lw Opentrons 96 Well Aluminum Block with Generic PCR Strip 200 \u00b5L on Temperature Module GEN2 on 3",
+            "share": false,
+            "slot": "3",
+            "type": "tempdeck"
+        }
+    ]
+}

--- a/protoBuilds/00f7b1_part5/README.json
+++ b/protoBuilds/00f7b1_part5/README.json
@@ -1,0 +1,37 @@
+{
+    "author": "Opentrons",
+    "categories": {
+        "NGS LIBRARY PREP": [
+            "NEBNext\u00ae Ultra\u2122 II Directional RNA Library Prep"
+        ]
+    },
+    "deck-setup": "",
+    "description": "This protocol is part 5 of a 10 part series. Please look at deck map and liquid legend below. Note: the TE buffer can accommodate 3 columns of sample per column of wash. Each ethanol column can accommodate 4 columns of sample. If running more than one column of reagent, the volumes should be split equally among all columns.",
+    "internal": "00f7b1_part5",
+    "labware": "\nArmadillo 96 Well Plate 200 \u00b5L PCR Full Skirt\nNEST 96 Deepwell Plate 2mL #503001\nOpentrons 96 Well Aluminum Block with Generic PCR Strip 200 \u00b5L\nOpentrons 96 Filter Tip Rack 200 \u00b5L\nNEST 1 Well Reservoir 195 mL #360103\nOpentrons 96 Filter Tip Rack 20 \u00b5L\n",
+    "markdown": {
+        "author": "[Opentrons](https://opentrons.com/)\n\n\n",
+        "categories": "* NGS LIBRARY PREP\n\t* NEBNext\u00ae Ultra\u2122 II Directional RNA Library Prep\n\n\n",
+        "deck-setup": "![deck](https://opentrons-protocol-library-website.s3.amazonaws.com/custom-README-images/00f7b1/Part+5/Screen+Shot+2022-10-25+at+3.47.13+PM.png)\n\n\n",
+        "description": "This protocol is part 5 of a 10 part series. Please look at deck map and liquid legend below. Note: the TE buffer can accommodate 3 columns of sample per column of wash. Each ethanol column can accommodate 4 columns of sample. If running more than one column of reagent, the volumes should be split equally among all columns.\n\n\n",
+        "internal": "00f7b1_part5\n",
+        "labware": "* [Armadillo 96 Well Plate 200 \u00b5L PCR Full Skirt](https://labware.opentrons.com/armadillo_96_wellplate_200ul_pcr_full_skirt?category=wellPlate)\n* [NEST 96 Deepwell Plate 2mL #503001](http://www.cell-nest.com/page94?product_id=101&_l=en)\n* [Opentrons 96 Well Aluminum Block with Generic PCR Strip 200 \u00b5L](https://shop.opentrons.com/collections/hardware-modules/products/aluminum-block-set)\n* Opentrons 96 Filter Tip Rack 200 \u00b5L\n* [NEST 1 Well Reservoir 195 mL #360103](http://www.cell-nest.com/page94?_l=en&product_id=102)\n* Opentrons 96 Filter Tip Rack 20 \u00b5L\n\n\n",
+        "modules": "* [Opentrons Magnetic Module (GEN2)](https://shop.opentrons.com/magnetic-module-gen2/)\n* [Opentrons Temperature Module (GEN2)](https://shop.opentrons.com/temperature-module-gen2/)\n\n\n",
+        "notes": "If you have any questions about this protocol, please contact the Protocol Development Team by filling out the [Troubleshooting Survey](https://protocol-troubleshooting.paperform.co/).\n\n\n",
+        "pipettes": "* [Opentrons P20 8 Channel Electronic Pipette (GEN2)](https://shop.opentrons.com/8-channel-electronic-pipette/)\n* [Opentrons P300 8 Channel Electronic Pipette (GEN2)](https://shop.opentrons.com/8-channel-electronic-pipette/)\n\n\n",
+        "process": "1. Input your protocol parameters above.\n2. Download your protocol and unzip if needed.\n3. Upload your custom labware to the [OT App](https://opentrons.com/ot-app) by navigating to `More` > `Custom Labware` > `Add Labware`, and selecting your labware files (.json extensions) if needed.\n4. Upload your protocol file (.py extension) to the [OT App](https://opentrons.com/ot-app) in the `Protocol` tab.\n5. Set up your deck according to the deck map.\n6. Calibrate your labware, tiprack and pipette using the OT App. For calibration tips, check out our [support articles](https://support.opentrons.com/en/collections/1559720-guide-for-getting-started-with-the-ot-2).\n7. Hit \"Run\".\n\n\n",
+        "protocol-steps": "1. Samples added to mag plate\n2. Beads added to samples\n3. Incubate\n4. Remove supernatant\n5. Two ethanol washes\n6. Air dry beads\n7. Elute with TE\n8. Incubate\n9. Move cDNA to final plate\n\n\n",
+        "reagent-setup": "![reagents](https://opentrons-protocol-library-website.s3.amazonaws.com/custom-README-images/00f7b1/Part+5/Screen+Shot+2022-10-25+at+3.47.25+PM.png)\n\n\n",
+        "title": "NEBNext Ultra II Directional RNA Library Prep Kit for Illumina Part 5: DNA Purification"
+    },
+    "modules": [
+        "Opentrons Magnetic Module (GEN2)",
+        "Opentrons Temperature Module (GEN2)"
+    ],
+    "notes": "If you have any questions about this protocol, please contact the Protocol Development Team by filling out the Troubleshooting Survey.",
+    "pipettes": "\nOpentrons P20 8 Channel Electronic Pipette (GEN2)\nOpentrons P300 8 Channel Electronic Pipette (GEN2)\n",
+    "process": "\nInput your protocol parameters above.\nDownload your protocol and unzip if needed.\nUpload your custom labware to the OT App by navigating to More > Custom Labware > Add Labware, and selecting your labware files (.json extensions) if needed.\nUpload your protocol file (.py extension) to the OT App in the Protocol tab.\nSet up your deck according to the deck map.\nCalibrate your labware, tiprack and pipette using the OT App. For calibration tips, check out our support articles.\nHit \"Run\".\n",
+    "protocol-steps": "\nSamples added to mag plate\nBeads added to samples\nIncubate\nRemove supernatant\nTwo ethanol washes\nAir dry beads\nElute with TE\nIncubate\nMove cDNA to final plate\n",
+    "reagent-setup": "",
+    "title": "NEBNext Ultra II Directional RNA Library Prep Kit for Illumina Part 5: DNA Purification"
+}

--- a/protoBuilds/00f7b1_part5/metadata.json
+++ b/protoBuilds/00f7b1_part5/metadata.json
@@ -1,0 +1,20 @@
+{
+    "files": {
+        "OT 1 protocol": [],
+        "OT 2 protocol": [
+            "00f7b1_part5.ot2.apiv2.py"
+        ],
+        "description": [
+            "README.md"
+        ]
+    },
+    "flags": {
+        "embedded-app": false,
+        "feature": false,
+        "hide-from-search": false,
+        "skip-tests": false
+    },
+    "path": "protocols/00f7b1_part5",
+    "slug": "00f7b1_part5",
+    "status": "ok"
+}

--- a/protocols/00f7b1_part5/00f7b1_part5.ot2.apiv2.py
+++ b/protocols/00f7b1_part5/00f7b1_part5.ot2.apiv2.py
@@ -1,0 +1,372 @@
+# flake8: noqa
+
+"""OPENTRONS."""
+from opentrons import protocol_api
+import math
+import threading
+from time import sleep
+from opentrons import types
+
+metadata = {
+    'protocolName': 'NEBNext Ultra II Directional RNA Library Prep Kit for Illumina Part 5: DNA Purification',
+    'author': 'John C. Lynch <john.lynch@opentrons.com>',
+    'source': 'Custom Protocol Request',
+    'apiLevel': '2.11'   # CHECK IF YOUR API LEVEL HERE IS UP TO DATE
+                         # IN SECTION 5.2 OF THE APIV2 "VERSIONING"
+}
+
+# Definitions for deck light flashing
+
+
+class CancellationToken:
+    """FLASH SETUP."""
+
+    def __init__(self):
+        """FLASH SETUP."""
+        self.is_continued = False
+
+    def set_true(self):
+        """FLASH SETUP."""
+        self.is_continued = True
+
+    def set_false(self):
+        """FLASH SETUP."""
+        self.is_continued = False
+
+
+def turn_on_blinking_notification(hardware, pause):
+    """FLASH SETUP."""
+    while pause.is_continued:
+        hardware.set_lights(rails=True)
+        sleep(1)
+        hardware.set_lights(rails=False)
+        sleep(1)
+
+
+def create_thread(ctx, cancel_token):
+    """FLASH SETUP."""
+    t1 = threading.Thread(target=turn_on_blinking_notification,
+                          args=(ctx._hw_manager.hardware, cancel_token))
+    t1.start()
+    return t1
+
+
+def run(ctx: protocol_api.ProtocolContext):
+    """PROTOCOLS."""
+    [
+     num_samples,
+     m300_mount, flash
+    ] = get_values(  # noqa: F821 (<--- DO NOT REMOVE!)
+        "num_samples", "m300_mount", "flash")
+
+    'Global variables'
+    TEST_MODE = True
+    bead_delay_time = 10
+    wash_delay_time = 10
+    supernatant_headspeed_modulator = 10
+    mag_height = 3.5
+    air_dry_time = 5
+    ctx.max_speeds['Z'] = 125
+    ctx.max_speeds['A'] = 125
+    # Setup for flashing lights notification to empty trash
+    cancellationToken = CancellationToken()
+
+    # define all custom variables above here with descriptions:
+    num_columns = math.ceil(num_samples/8)
+    if m300_mount == 'right':
+        m20_mount = 'left'
+    else:
+        m20_mount = 'right'
+    # load modules
+    mag_deck = ctx.load_module('magnetic module gen2', '1')
+    temp_deck = ctx.load_module('temperature module gen2', '3')
+    print(num_columns)
+
+    # load labware
+    mag_plate = mag_deck.load_labware('nest_96_wellplate_2ml_deep')
+    temp_plate = temp_deck.load_labware('opentrons_96_aluminumblock_generic_'
+                                        'pcr_strip_200ul')
+    dwp = ctx.load_labware('nest_96_wellplate_2ml_deep', '4')
+    sample_plate = ctx.load_labware('thermofisher_96_wellplate_200ul', '5')
+    final_plate = ctx.load_labware('thermofisher_96_wellplate_200ul', '2')
+    trash = ctx.load_labware('nest_1_reservoir_195ml', '9').wells()[0].top()
+    # load tipracks
+
+    tips300 = [ctx.load_labware('opentrons_96_filtertiprack_200ul', slot)
+               for slot in ['7', '10']]
+    tips20 = [ctx.load_labware('opentrons_96_filtertiprack_20ul', slot)
+              for slot in ['11']]
+    # load instrument
+
+    m300 = ctx.load_instrument(
+        'p300_multi_gen2', m300_mount, tip_racks=tips300)
+
+    m20 = ctx.load_instrument('p20_multi_gen2', m20_mount, tip_racks=tips20)
+
+    # pipette functions   # INCLUDE ANY BINDING TO CLASS
+    # reagents
+    samples_start = sample_plate.rows()[0][:num_columns]
+    samples_mag = mag_plate.rows()[0][:num_columns]
+    beads = dwp.rows()[0][0]
+    etoh = dwp.rows()[0][2:2+math.ceil(num_columns/4)]*12
+    te_buff = temp_plate.rows()[0][:math.ceil(num_columns/3)]*12
+    final_dest = final_plate.rows()[0][:num_columns]
+
+    def pick_up(pip):
+        try:
+            pip.pick_up_tip()
+        except protocol_api.labware.OutOfTipsError:
+            if flash:
+                if not ctx._hw_manager.hardware.is_simulator:
+                    cancellationToken.set_true()
+                thread = create_thread(ctx, cancellationToken)
+            pip.home()
+            ctx.pause('\n\n~~~~~~~~~~~~~~PLEASE REPLACE TIPRACKS~~~~~~~~~~~~~~~\n')  # noqa: E501
+            ctx.home()  # home before continuing with protocol
+            if flash:
+                cancellationToken.set_false()  # stop light flashing after home
+                thread.join()
+            ctx.set_rail_lights(True)
+            pip.reset_tipracks()
+            pick_up(pip)
+
+    tips_dropped = 0
+
+    def drop_tip(pip, home=True):
+        nonlocal tips_dropped
+        pip.drop_tip(home_after=home)
+        if pip == m300:
+            tips_dropped += 8
+        else:
+            tips_dropped += 1
+        if tips_dropped == 288:
+            if flash:
+                if not ctx._hw_manager.hardware.is_simulator:
+                    cancellationToken.set_true()
+                thread = create_thread(ctx, cancellationToken)
+            pip.home()
+            ctx.pause('\n\n~~~~~~~~~~~~~~PLEASE EMPTY TRASH~~~~~~~~~~~~~~~\n')
+            ctx.home()  # home before continuing with protocol
+            if flash:
+                cancellationToken.set_false()  # stop light flashing after home
+                thread.join()
+            ctx.set_rail_lights(True)
+            tips_dropped = 0
+
+    def bead_mixing(well, pip, mvol, reps=10):
+        """bead_mixing."""
+        """
+        'bead_mixing' will mix liquid that contains beads. This will be done by
+        aspirating from the middle of the well & dispensing from the bottom to
+        mix the beads with the other liquids as much as possible. Aspiration &
+        dispensing will also be reversed to ensure proper mixing.
+        param well: The current well that the mixing will occur in.
+        param pip: The pipet that is currently attached/ being used.
+        param mvol: The volume that is transferred before the mixing steps.
+        param reps: The number of mix repetitions that should occur. Note~
+        During each mix rep, there are 2 cycles of aspirating from bottom,
+        dispensing at the top and 2 cycles of aspirating from middle,
+        dispensing at the bottom
+        """
+        vol = mvol * .9
+
+        pip.move_to(well.center())
+        for _ in range(reps):
+            pip.aspirate(vol, well.bottom(1), rate=2)
+            pip.dispense(vol, well.bottom(5), rate=2)
+
+    def remove_supernatant(vol, use_300=True, use_20=True):
+        for i, dest in enumerate(samples_mag):
+            side = -1 if i % 2 == 0 else 1
+            if use_300:
+                m300.move_to(dest.top())
+                ctx.max_speeds['Z'] /= supernatant_headspeed_modulator
+                ctx.max_speeds['A'] /= supernatant_headspeed_modulator
+                m300.aspirate(vol-20, dest.bottom().move(types.Point(x=side, y=0, z=1)),
+                              rate=0.1)
+                ctx.delay(seconds=1)
+                m300.move_to(dest.top())
+                m300.aspirate(10, dest.top())
+                ctx.max_speeds['Z'] *= supernatant_headspeed_modulator
+                ctx.max_speeds['A'] *= supernatant_headspeed_modulator
+                m300.dispense(m300.current_volume, trash)
+                m300.blow_out()
+                m300.air_gap(50)
+            if use_20:
+                if not m20.has_tip:
+                    pick_up(m20)
+                m20.move_to(dest.top())
+                ctx.max_speeds['Z'] /= supernatant_headspeed_modulator
+                ctx.max_speeds['A'] /= supernatant_headspeed_modulator
+                m20.aspirate(19, dest.bottom().move(types.Point(x=side, y=0, z=1)),
+                             rate=0.1)
+                ctx.delay(seconds=1)
+                m20.move_to(dest.top())
+                m20.aspirate(1, dest.top())
+                ctx.max_speeds['Z'] *= supernatant_headspeed_modulator
+                ctx.max_speeds['A'] *= supernatant_headspeed_modulator
+                m20.dispense(m20.current_volume, trash)
+                m20.blow_out()
+                m20.aspirate(10, trash)
+                ctx.comment('\n')
+                if m20.has_tip:
+                    drop_tip(m20)
+
+    # protocol
+    ctx.comment('\n~~~~~~~~~~~~~~ADDING SAMPLES TO MAG PLATE~~~~~~~~~~~~~~\n')
+    for s, d in zip(samples_start, samples_mag):
+        pick_up(m300)
+        m300.aspirate(80, s)
+        m300.dispense(80, d)
+        drop_tip(m300)
+
+    ctx.comment('\n~~~~~~~~~~~~~~ADDING BEADS TO SAMPLES~~~~~~~~~~~~~~\n')
+    for i, dest in enumerate(samples_mag):
+        pick_up(m300)
+        if i % 3 == 0:
+            bead_mixing(beads, m300, 200)
+        m300.aspirate(144, beads, rate=0.5)
+        ctx.delay(seconds=1)
+        ctx.max_speeds['Z'] /= supernatant_headspeed_modulator
+        ctx.max_speeds['A'] /= supernatant_headspeed_modulator
+        m300.move_to(beads.top())
+        ctx.max_speeds['Z'] *= supernatant_headspeed_modulator
+        ctx.max_speeds['A'] *= supernatant_headspeed_modulator
+        m300.dispense(144, dest, rate=0.5)
+        bead_mixing(dest, m300, 200, reps=6)
+        m300.blow_out(dest.bottom(20))
+        drop_tip(m300)
+
+    ctx.comment('\n~~~~~~~~~~~~~~INCUBATING SAMPLES WITH BEADS~~~~~~~~~~~~~\n')
+    if TEST_MODE:
+        ctx.delay(seconds=bead_delay_time)
+    else:
+        ctx.delay(minute=bead_delay_time)
+
+    mag_deck.engage(height_from_base=mag_height)
+    ctx.comment('\n~~~~~~~~~~~~~~SEPARATING BEADS~~~~~~~~~~~~~\n')
+    if TEST_MODE:
+        ctx.delay(minutes=bead_delay_time)
+    else:
+        ctx.delay(minute=bead_delay_time)
+
+    ctx.comment('\n~~~~~~~~~~~~~~REMOVING SUPERNATANT~~~~~~~~~~~~~\n')
+    for i, dest in enumerate(samples_mag):
+        side = -1 if i % 2 == 0 else 1
+        pick_up(m300)
+        for _ in range(2):
+
+            m300.move_to(dest.top())
+            ctx.max_speeds['Z'] /= supernatant_headspeed_modulator
+            ctx.max_speeds['A'] /= supernatant_headspeed_modulator
+            m300.aspirate(105, dest.bottom().move(types.Point(x=side, y=0, z=1)),
+                          rate=0.1)
+            ctx.delay(seconds=1)
+            m300.move_to(dest.top())
+            m300.aspirate(10, dest.top())
+            ctx.max_speeds['Z'] *= supernatant_headspeed_modulator
+            ctx.max_speeds['A'] *= supernatant_headspeed_modulator
+            m300.dispense(m300.current_volume, trash)
+            m300.blow_out()
+            m300.air_gap(50)
+        drop_tip(m300)
+
+        pick_up(m20)
+        m20.move_to(dest.top())
+        ctx.max_speeds['Z'] /= supernatant_headspeed_modulator
+        ctx.max_speeds['A'] /= supernatant_headspeed_modulator
+        m20.aspirate(13, dest.bottom().move(types.Point(x=0, y=0, z=0.5)),
+                     rate=0.1)
+        ctx.delay(seconds=1)
+        m20.move_to(dest.top())
+        m20.aspirate(1, dest.top())
+        ctx.max_speeds['Z'] *= supernatant_headspeed_modulator
+        ctx.max_speeds['A'] *= supernatant_headspeed_modulator
+        m20.dispense(m20.current_volume, trash)
+        m20.blow_out()
+        m20.aspirate(10, trash)
+        drop_tip(m20)
+
+    ctx.comment('\n~~~~~~~~~~~~~~WASHING TWICE WITH ETHANOL~~~~~~~~~~~~~\n')
+    for _ in range(2):
+        pick_up(m300)
+        ctx.comment('\n~~~~~~~~~~~~~~ADDING ETHANOL~~~~~~~~~~~~~\n')
+        for eth, dest in zip(etoh, samples_mag):
+            m300.mix(1, 200, eth)
+            m300.aspirate(200, eth)
+            m300.dispense(190, dest.top())
+            m300.aspirate(20, dest.top())
+            m300.dispense(30, eth.top())
+
+        ctx.delay(seconds=30)
+        ctx.comment('\n~~~~~~~~~~~~~~REMOVING ETHANOL~~~~~~~~~~~~~\n')
+        for i, dest in enumerate(samples_mag):
+            if i > 0:
+                pick_up(m300)
+            m300.aspirate(200, dest.bottom().move(types.Point(x=-1, y=0, z=0.5)),
+                          rate=0.1)
+            m300.dispense(200, trash)
+            drop_tip(m300)
+            if _ == 1:
+                ctx.delay(minutes=1)
+                pick_up(m20)
+                m20.aspirate(10, dest.bottom(0.15), rate=.1)
+                m20.aspirate(2, dest.top())
+                m20.dispense(m20.current_volume, trash)
+                m20.aspirate(10, trash)
+                m20.drop_tip()
+
+    ctx.comment('\n~~~~~~~~~~~~~~AIR DRY BEADS FOR 5 MINUTES~~~~~~~~~~~~~\n')
+    if TEST_MODE:
+        ctx.delay(minutes=air_dry_time)
+    else:
+        ctx.delay(minutes=air_dry_time)
+
+    mag_deck.disengage()
+
+    ctx.comment('\n~~~~~~~~~~~~~~ELUTING WITH TE BUFFER~~~~~~~~~~~~~\n')
+    for te, dest in zip(te_buff, samples_mag):
+        pick_up(m300)
+        m300.aspirate(53, te)
+        m300.dispense(53, dest)
+        bead_mixing(dest, m300, 53)
+        m300.blow_out(dest.top())
+        m300.air_gap(20)
+        drop_tip(m300)
+
+    ctx.comment('\n~~~~~~~~~~~~~~ELUTING FOR 2 MINUTES~~~~~~~~~~~~~\n')
+    if TEST_MODE:
+        ctx.delay(seconds=2)
+    else:
+        ctx.delay(minutes=2)
+
+    ctx.comment('\n~~~~~~~~~~~~~~SEPARATING BEADS~~~~~~~~~~~~~\n')
+    mag_deck.engage(height_from_base=mag_height)
+    if TEST_MODE:
+        ctx.delay(minutes=bead_delay_time)
+    else:
+        ctx.delay(minute=bead_delay_time)
+
+    ctx.comment('\n~~~~~~~~~~~~~~MOVING cDNA TO FINAL PLATE~~~~~~~~~~~~~\n')
+    for i, (s, d) in enumerate(zip(samples_mag, final_dest)):
+        side = -1 if i % 2 == 0 else 1
+        pick_up(m300)
+        m300.aspirate(50, s.bottom().move(types.Point(x=side, y=0, z=1)),
+                      rate=0.1)
+        m300.dispense(50, d)
+        drop_tip(m300)
+
+    if flash:
+        if not ctx._hw_manager.hardware.is_simulator:
+            cancellationToken.set_true()
+        thread = create_thread(ctx, cancellationToken)
+    m300.home()
+    ctx.pause('\n\n~~~~~~~~~~~~~~PROTOCOL  COMPLETE~~~~~~~~~~~~~~~\n')
+    ctx.home()  # home before continuing with protocol
+    if flash:
+        cancellationToken.set_false()  # stop light flashing after home
+        thread.join()
+    ctx.set_rail_lights(True)
+
+    for c in ctx.commands():
+        print(c)

--- a/protocols/00f7b1_part5/README.md
+++ b/protocols/00f7b1_part5/README.md
@@ -1,0 +1,71 @@
+# NEBNext Ultra II Directional RNA Library Prep Kit for Illumina Part 5: DNA Purification
+
+
+### Author
+[Opentrons](https://opentrons.com/)
+
+
+## Categories
+* NGS LIBRARY PREP
+	* NEBNext® Ultra™ II Directional RNA Library Prep
+
+
+## Description
+This protocol is part 5 of a 10 part series. Please look at deck map and liquid legend below. Note: the TE buffer can accommodate 3 columns of sample per column of wash. Each ethanol column can accommodate 4 columns of sample. If running more than one column of reagent, the volumes should be split equally among all columns.
+
+
+### Modules
+* [Opentrons Magnetic Module (GEN2)](https://shop.opentrons.com/magnetic-module-gen2/)
+* [Opentrons Temperature Module (GEN2)](https://shop.opentrons.com/temperature-module-gen2/)
+
+
+### Labware
+* [Armadillo 96 Well Plate 200 µL PCR Full Skirt](https://labware.opentrons.com/armadillo_96_wellplate_200ul_pcr_full_skirt?category=wellPlate)
+* [NEST 96 Deepwell Plate 2mL #503001](http://www.cell-nest.com/page94?product_id=101&_l=en)
+* [Opentrons 96 Well Aluminum Block with Generic PCR Strip 200 µL](https://shop.opentrons.com/collections/hardware-modules/products/aluminum-block-set)
+* Opentrons 96 Filter Tip Rack 200 µL
+* [NEST 1 Well Reservoir 195 mL #360103](http://www.cell-nest.com/page94?_l=en&product_id=102)
+* Opentrons 96 Filter Tip Rack 20 µL
+
+
+### Pipettes
+* [Opentrons P20 8 Channel Electronic Pipette (GEN2)](https://shop.opentrons.com/8-channel-electronic-pipette/)
+* [Opentrons P300 8 Channel Electronic Pipette (GEN2)](https://shop.opentrons.com/8-channel-electronic-pipette/)
+
+
+### Deck Setup
+![deck](https://opentrons-protocol-library-website.s3.amazonaws.com/custom-README-images/00f7b1/Part+5/Screen+Shot+2022-10-25+at+3.47.13+PM.png)
+
+
+### Reagent Setup
+![reagents](https://opentrons-protocol-library-website.s3.amazonaws.com/custom-README-images/00f7b1/Part+5/Screen+Shot+2022-10-25+at+3.47.25+PM.png)
+
+
+### Protocol Steps
+1. Samples added to mag plate
+2. Beads added to samples
+3. Incubate
+4. Remove supernatant
+5. Two ethanol washes
+6. Air dry beads
+7. Elute with TE
+8. Incubate
+9. Move cDNA to final plate
+
+
+### Process
+1. Input your protocol parameters above.
+2. Download your protocol and unzip if needed.
+3. Upload your custom labware to the [OT App](https://opentrons.com/ot-app) by navigating to `More` > `Custom Labware` > `Add Labware`, and selecting your labware files (.json extensions) if needed.
+4. Upload your protocol file (.py extension) to the [OT App](https://opentrons.com/ot-app) in the `Protocol` tab.
+5. Set up your deck according to the deck map.
+6. Calibrate your labware, tiprack and pipette using the OT App. For calibration tips, check out our [support articles](https://support.opentrons.com/en/collections/1559720-guide-for-getting-started-with-the-ot-2).
+7. Hit "Run".
+
+
+### Additional Notes
+If you have any questions about this protocol, please contact the Protocol Development Team by filling out the [Troubleshooting Survey](https://protocol-troubleshooting.paperform.co/).
+
+
+###### Internal
+00f7b1_part5

--- a/protocols/00f7b1_part5/fields.json
+++ b/protocols/00f7b1_part5/fields.json
@@ -1,0 +1,40 @@
+[
+
+  {
+    "type": "dropDown",
+    "label": "Number of samples",
+    "name": "num_samples",
+    "options": [
+      {"label": "8", "value": 8},
+      {"label": "16", "value": 16},
+      {"label": "24", "value": 24},
+      {"label": "32", "value": 32},
+      {"label": "40", "value": 40},
+      {"label": "48", "value": 48},
+      {"label": "56", "value": 56},
+      {"label": "64", "value": 64},
+      {"label": "72", "value": 72},
+      {"label": "80", "value": 80},
+      {"label": "88", "value": 88},
+      {"label": "96", "value": 96}
+    ]
+  },
+  {
+    "type": "dropDown",
+    "label": "P300 Multi-Channel Mount",
+    "name": "m300_mount",
+    "options": [
+      {"label": "Right", "value": "right"},
+      {"label": "Left", "value": "left"}
+    ]
+  },
+  {
+    "type": "dropDown",
+    "label": "Flash?",
+    "name": "flash",
+    "options": [
+      {"label": "Yes, flash", "value": true},
+      {"label": "No, do not flash", "value": false}
+    ]
+  }
+]

--- a/protocols/00f7b1_part5/labware/thermofisher_96_wellplate_200ul.json
+++ b/protocols/00f7b1_part5/labware/thermofisher_96_wellplate_200ul.json
@@ -1,0 +1,1128 @@
+{
+    "ordering": [
+        [
+            "A1",
+            "B1",
+            "C1",
+            "D1",
+            "E1",
+            "F1",
+            "G1",
+            "H1"
+        ],
+        [
+            "A2",
+            "B2",
+            "C2",
+            "D2",
+            "E2",
+            "F2",
+            "G2",
+            "H2"
+        ],
+        [
+            "A3",
+            "B3",
+            "C3",
+            "D3",
+            "E3",
+            "F3",
+            "G3",
+            "H3"
+        ],
+        [
+            "A4",
+            "B4",
+            "C4",
+            "D4",
+            "E4",
+            "F4",
+            "G4",
+            "H4"
+        ],
+        [
+            "A5",
+            "B5",
+            "C5",
+            "D5",
+            "E5",
+            "F5",
+            "G5",
+            "H5"
+        ],
+        [
+            "A6",
+            "B6",
+            "C6",
+            "D6",
+            "E6",
+            "F6",
+            "G6",
+            "H6"
+        ],
+        [
+            "A7",
+            "B7",
+            "C7",
+            "D7",
+            "E7",
+            "F7",
+            "G7",
+            "H7"
+        ],
+        [
+            "A8",
+            "B8",
+            "C8",
+            "D8",
+            "E8",
+            "F8",
+            "G8",
+            "H8"
+        ],
+        [
+            "A9",
+            "B9",
+            "C9",
+            "D9",
+            "E9",
+            "F9",
+            "G9",
+            "H9"
+        ],
+        [
+            "A10",
+            "B10",
+            "C10",
+            "D10",
+            "E10",
+            "F10",
+            "G10",
+            "H10"
+        ],
+        [
+            "A11",
+            "B11",
+            "C11",
+            "D11",
+            "E11",
+            "F11",
+            "G11",
+            "H11"
+        ],
+        [
+            "A12",
+            "B12",
+            "C12",
+            "D12",
+            "E12",
+            "F12",
+            "G12",
+            "H12"
+        ]
+    ],
+    "brand": {
+        "brand": "thermo Fisher",
+        "brandId": [
+            "AB-3396",
+            "AB-2396"
+        ]
+    },
+    "metadata": {
+        "displayName": "Thermo Fisher 96 Well Plate 200 µL",
+        "displayCategory": "wellPlate",
+        "displayVolumeUnits": "µL",
+        "tags": []
+    },
+    "dimensions": {
+        "xDimension": 127.76,
+        "yDimension": 85.48,
+        "zDimension": 16
+    },
+    "wells": {
+        "A1": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 14.38,
+            "y": 74.24,
+            "z": 1.05
+        },
+        "B1": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 14.38,
+            "y": 65.24,
+            "z": 1.05
+        },
+        "C1": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 14.38,
+            "y": 56.24,
+            "z": 1.05
+        },
+        "D1": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 14.38,
+            "y": 47.24,
+            "z": 1.05
+        },
+        "E1": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 14.38,
+            "y": 38.24,
+            "z": 1.05
+        },
+        "F1": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 14.38,
+            "y": 29.24,
+            "z": 1.05
+        },
+        "G1": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 14.38,
+            "y": 20.24,
+            "z": 1.05
+        },
+        "H1": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 14.38,
+            "y": 11.24,
+            "z": 1.05
+        },
+        "A2": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 23.38,
+            "y": 74.24,
+            "z": 1.05
+        },
+        "B2": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 23.38,
+            "y": 65.24,
+            "z": 1.05
+        },
+        "C2": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 23.38,
+            "y": 56.24,
+            "z": 1.05
+        },
+        "D2": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 23.38,
+            "y": 47.24,
+            "z": 1.05
+        },
+        "E2": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 23.38,
+            "y": 38.24,
+            "z": 1.05
+        },
+        "F2": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 23.38,
+            "y": 29.24,
+            "z": 1.05
+        },
+        "G2": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 23.38,
+            "y": 20.24,
+            "z": 1.05
+        },
+        "H2": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 23.38,
+            "y": 11.24,
+            "z": 1.05
+        },
+        "A3": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 32.38,
+            "y": 74.24,
+            "z": 1.05
+        },
+        "B3": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 32.38,
+            "y": 65.24,
+            "z": 1.05
+        },
+        "C3": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 32.38,
+            "y": 56.24,
+            "z": 1.05
+        },
+        "D3": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 32.38,
+            "y": 47.24,
+            "z": 1.05
+        },
+        "E3": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 32.38,
+            "y": 38.24,
+            "z": 1.05
+        },
+        "F3": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 32.38,
+            "y": 29.24,
+            "z": 1.05
+        },
+        "G3": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 32.38,
+            "y": 20.24,
+            "z": 1.05
+        },
+        "H3": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 32.38,
+            "y": 11.24,
+            "z": 1.05
+        },
+        "A4": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 41.38,
+            "y": 74.24,
+            "z": 1.05
+        },
+        "B4": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 41.38,
+            "y": 65.24,
+            "z": 1.05
+        },
+        "C4": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 41.38,
+            "y": 56.24,
+            "z": 1.05
+        },
+        "D4": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 41.38,
+            "y": 47.24,
+            "z": 1.05
+        },
+        "E4": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 41.38,
+            "y": 38.24,
+            "z": 1.05
+        },
+        "F4": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 41.38,
+            "y": 29.24,
+            "z": 1.05
+        },
+        "G4": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 41.38,
+            "y": 20.24,
+            "z": 1.05
+        },
+        "H4": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 41.38,
+            "y": 11.24,
+            "z": 1.05
+        },
+        "A5": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 50.38,
+            "y": 74.24,
+            "z": 1.05
+        },
+        "B5": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 50.38,
+            "y": 65.24,
+            "z": 1.05
+        },
+        "C5": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 50.38,
+            "y": 56.24,
+            "z": 1.05
+        },
+        "D5": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 50.38,
+            "y": 47.24,
+            "z": 1.05
+        },
+        "E5": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 50.38,
+            "y": 38.24,
+            "z": 1.05
+        },
+        "F5": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 50.38,
+            "y": 29.24,
+            "z": 1.05
+        },
+        "G5": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 50.38,
+            "y": 20.24,
+            "z": 1.05
+        },
+        "H5": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 50.38,
+            "y": 11.24,
+            "z": 1.05
+        },
+        "A6": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 59.38,
+            "y": 74.24,
+            "z": 1.05
+        },
+        "B6": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 59.38,
+            "y": 65.24,
+            "z": 1.05
+        },
+        "C6": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 59.38,
+            "y": 56.24,
+            "z": 1.05
+        },
+        "D6": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 59.38,
+            "y": 47.24,
+            "z": 1.05
+        },
+        "E6": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 59.38,
+            "y": 38.24,
+            "z": 1.05
+        },
+        "F6": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 59.38,
+            "y": 29.24,
+            "z": 1.05
+        },
+        "G6": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 59.38,
+            "y": 20.24,
+            "z": 1.05
+        },
+        "H6": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 59.38,
+            "y": 11.24,
+            "z": 1.05
+        },
+        "A7": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 68.38,
+            "y": 74.24,
+            "z": 1.05
+        },
+        "B7": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 68.38,
+            "y": 65.24,
+            "z": 1.05
+        },
+        "C7": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 68.38,
+            "y": 56.24,
+            "z": 1.05
+        },
+        "D7": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 68.38,
+            "y": 47.24,
+            "z": 1.05
+        },
+        "E7": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 68.38,
+            "y": 38.24,
+            "z": 1.05
+        },
+        "F7": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 68.38,
+            "y": 29.24,
+            "z": 1.05
+        },
+        "G7": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 68.38,
+            "y": 20.24,
+            "z": 1.05
+        },
+        "H7": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 68.38,
+            "y": 11.24,
+            "z": 1.05
+        },
+        "A8": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 77.38,
+            "y": 74.24,
+            "z": 1.05
+        },
+        "B8": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 77.38,
+            "y": 65.24,
+            "z": 1.05
+        },
+        "C8": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 77.38,
+            "y": 56.24,
+            "z": 1.05
+        },
+        "D8": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 77.38,
+            "y": 47.24,
+            "z": 1.05
+        },
+        "E8": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 77.38,
+            "y": 38.24,
+            "z": 1.05
+        },
+        "F8": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 77.38,
+            "y": 29.24,
+            "z": 1.05
+        },
+        "G8": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 77.38,
+            "y": 20.24,
+            "z": 1.05
+        },
+        "H8": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 77.38,
+            "y": 11.24,
+            "z": 1.05
+        },
+        "A9": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 86.38,
+            "y": 74.24,
+            "z": 1.05
+        },
+        "B9": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 86.38,
+            "y": 65.24,
+            "z": 1.05
+        },
+        "C9": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 86.38,
+            "y": 56.24,
+            "z": 1.05
+        },
+        "D9": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 86.38,
+            "y": 47.24,
+            "z": 1.05
+        },
+        "E9": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 86.38,
+            "y": 38.24,
+            "z": 1.05
+        },
+        "F9": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 86.38,
+            "y": 29.24,
+            "z": 1.05
+        },
+        "G9": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 86.38,
+            "y": 20.24,
+            "z": 1.05
+        },
+        "H9": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 86.38,
+            "y": 11.24,
+            "z": 1.05
+        },
+        "A10": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 95.38,
+            "y": 74.24,
+            "z": 1.05
+        },
+        "B10": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 95.38,
+            "y": 65.24,
+            "z": 1.05
+        },
+        "C10": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 95.38,
+            "y": 56.24,
+            "z": 1.05
+        },
+        "D10": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 95.38,
+            "y": 47.24,
+            "z": 1.05
+        },
+        "E10": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 95.38,
+            "y": 38.24,
+            "z": 1.05
+        },
+        "F10": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 95.38,
+            "y": 29.24,
+            "z": 1.05
+        },
+        "G10": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 95.38,
+            "y": 20.24,
+            "z": 1.05
+        },
+        "H10": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 95.38,
+            "y": 11.24,
+            "z": 1.05
+        },
+        "A11": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 104.38,
+            "y": 74.24,
+            "z": 1.05
+        },
+        "B11": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 104.38,
+            "y": 65.24,
+            "z": 1.05
+        },
+        "C11": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 104.38,
+            "y": 56.24,
+            "z": 1.05
+        },
+        "D11": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 104.38,
+            "y": 47.24,
+            "z": 1.05
+        },
+        "E11": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 104.38,
+            "y": 38.24,
+            "z": 1.05
+        },
+        "F11": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 104.38,
+            "y": 29.24,
+            "z": 1.05
+        },
+        "G11": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 104.38,
+            "y": 20.24,
+            "z": 1.05
+        },
+        "H11": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 104.38,
+            "y": 11.24,
+            "z": 1.05
+        },
+        "A12": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 113.38,
+            "y": 74.24,
+            "z": 1.05
+        },
+        "B12": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 113.38,
+            "y": 65.24,
+            "z": 1.05
+        },
+        "C12": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 113.38,
+            "y": 56.24,
+            "z": 1.05
+        },
+        "D12": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 113.38,
+            "y": 47.24,
+            "z": 1.05
+        },
+        "E12": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 113.38,
+            "y": 38.24,
+            "z": 1.05
+        },
+        "F12": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 113.38,
+            "y": 29.24,
+            "z": 1.05
+        },
+        "G12": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 113.38,
+            "y": 20.24,
+            "z": 1.05
+        },
+        "H12": {
+            "depth": 14.95,
+            "totalLiquidVolume": 200,
+            "shape": "circular",
+            "diameter": 5.5,
+            "x": 113.38,
+            "y": 11.24,
+            "z": 1.05
+        }
+    },
+    "groups": [
+        {
+            "metadata": {
+                "wellBottomShape": "v"
+            },
+            "wells": [
+                "A1",
+                "B1",
+                "C1",
+                "D1",
+                "E1",
+                "F1",
+                "G1",
+                "H1",
+                "A2",
+                "B2",
+                "C2",
+                "D2",
+                "E2",
+                "F2",
+                "G2",
+                "H2",
+                "A3",
+                "B3",
+                "C3",
+                "D3",
+                "E3",
+                "F3",
+                "G3",
+                "H3",
+                "A4",
+                "B4",
+                "C4",
+                "D4",
+                "E4",
+                "F4",
+                "G4",
+                "H4",
+                "A5",
+                "B5",
+                "C5",
+                "D5",
+                "E5",
+                "F5",
+                "G5",
+                "H5",
+                "A6",
+                "B6",
+                "C6",
+                "D6",
+                "E6",
+                "F6",
+                "G6",
+                "H6",
+                "A7",
+                "B7",
+                "C7",
+                "D7",
+                "E7",
+                "F7",
+                "G7",
+                "H7",
+                "A8",
+                "B8",
+                "C8",
+                "D8",
+                "E8",
+                "F8",
+                "G8",
+                "H8",
+                "A9",
+                "B9",
+                "C9",
+                "D9",
+                "E9",
+                "F9",
+                "G9",
+                "H9",
+                "A10",
+                "B10",
+                "C10",
+                "D10",
+                "E10",
+                "F10",
+                "G10",
+                "H10",
+                "A11",
+                "B11",
+                "C11",
+                "D11",
+                "E11",
+                "F11",
+                "G11",
+                "H11",
+                "A12",
+                "B12",
+                "C12",
+                "D12",
+                "E12",
+                "F12",
+                "G12",
+                "H12"
+            ]
+        }
+    ],
+    "parameters": {
+        "format": "irregular",
+        "quirks": [],
+        "isTiprack": false,
+        "isMagneticModuleCompatible": false,
+        "loadName": "thermofisher_96_wellplate_200ul"
+    },
+    "namespace": "custom_beta",
+    "version": 1,
+    "schemaVersion": 2,
+    "cornerOffsetFromSlot": {
+        "x": 0,
+        "y": 0,
+        "z": 0
+    }
+}


### PR DESCRIPTION
This protocol is part 5 of a 10 part series. Please look at deck map and liquid legend below. Note: the TE buffer can accommodate 3 columns of sample per column of wash. Each ethanol column can accommodate 4 columns of sample. If running more than one column of reagent, the volumes should be split equally among all columns.