### PR TITLE
fix(protocols/00f7b1): deck layout and readme adjustments, mixing adjustments

### DIFF
--- a/protoBuilds/00f7b1_part10/README.json
+++ b/protoBuilds/00f7b1_part10/README.json
@@ -1,7 +1,7 @@
 {
     "author": "Opentrons",
     "categories": {
-        "NGS LIBRARY PREP": [
+        "NGS Library Prep": [
             "NEBNext\u00ae Ultra\u2122 II Directional RNA Library Prep"
         ]
     },
@@ -11,7 +11,7 @@
     "labware": "\nArmadillo 96 Well Plate 200 \u00b5L PCR Full Skirt\nNEST 96 Deepwell Plate 2mL #503001\nOpentrons 96 Well Aluminum Block with Generic PCR Strip 200 \u00b5L\nOpentrons 96 Filter Tip Rack 200 \u00b5L\nNEST 1 Well Reservoir 195 mL #360103\nOpentrons 96 Filter Tip Rack 20 \u00b5L\n",
     "markdown": {
         "author": "[Opentrons](https://opentrons.com/)\n\n\n",
-        "categories": "* NGS LIBRARY PREP\n\t* NEBNext\u00ae Ultra\u2122 II Directional RNA Library Prep\n\n\n",
+        "categories": "* NGS Library Prep\n\t* NEBNext\u00ae Ultra\u2122 II Directional RNA Library Prep\n\n\n",
         "deck-setup": "![deck](https://opentrons-protocol-library-website.s3.amazonaws.com/custom-README-images/00f7b1/Part+10/deck.png)\n\n\n",
         "description": "This protocol is part 10 of a 10 part series. Please look at deck map and liquid legend below. Note: the TE buffer can accommodate 3 columns of sample per column of wash. Each ethanol column can accommodate 4 columns of sample. If running more than one column of reagent, the volumes should be split equally among all columns.\n\n\n",
         "internal": "00f7b1_part10\n",

--- a/protoBuilds/00f7b1_part2/README.json
+++ b/protoBuilds/00f7b1_part2/README.json
@@ -1,7 +1,7 @@
 {
     "author": "Opentrons",
     "categories": {
-        "NGS LIBRARY PREP": [
+        "NGS Library Prep": [
             "NEBNext\u00ae Ultra\u2122 II Directional RNA Library Prep"
         ]
     },
@@ -11,8 +11,8 @@
     "labware": "\nArmadillo 96 Well Plate 200 \u00b5L PCR Full Skirt\nNEST 96 Deepwell Plate 2mL #503001\nOpentrons 96 Well Aluminum Block with Generic PCR Strip 200 \u00b5L\nOpentrons 96 Filter Tip Rack 200 \u00b5L\nNEST 1 Well Reservoir 195 mL #360103\nOpentrons 96 Filter Tip Rack 20 \u00b5L\n",
     "markdown": {
         "author": "[Opentrons](https://opentrons.com/)\n\n\n",
-        "categories": "* NGS LIBRARY PREP\n\t* NEBNext\u00ae Ultra\u2122 II Directional RNA Library Prep\n\n\n",
-        "deck-setup": "![deck](https://opentrons-protocol-library-website.s3.amazonaws.com/custom-README-images/00f7b1/Part+2/Screen+Shot+2022-10-25+at+10.39.41+AM.png)\n\n\n",
+        "categories": "* NGS Library Prep\n\t* NEBNext\u00ae Ultra\u2122 II Directional RNA Library Prep\n\n\n",
+        "deck-setup": "![deck](https://opentrons-protocol-library-website.s3.amazonaws.com/custom-README-images/00f7b1/Part+2/new+deck.png)\n\n\n",
         "description": "This protocol is part 2 of a 10 part series. Please look at deck map and liquid legend below. Note: bead strip tubes can accommodate 2 columns of sample by volume (i.e. 6 columns of beads for a full plate of samples). The RNA wash can accommodate 3 columns of sample per column of wash. There only needs to be one column of strand primer mix per run for all sample numbers. An overage of at least 10% should be used each run.\n\n\n",
         "internal": "00f7b1_part2\n",
         "labware": "* [Armadillo 96 Well Plate 200 \u00b5L PCR Full Skirt](https://labware.opentrons.com/armadillo_96_wellplate_200ul_pcr_full_skirt?category=wellPlate)\n* [NEST 96 Deepwell Plate 2mL #503001](http://www.cell-nest.com/page94?product_id=101&_l=en)\n* [Opentrons 96 Well Aluminum Block with Generic PCR Strip 200 \u00b5L](https://shop.opentrons.com/collections/hardware-modules/products/aluminum-block-set)\n* Opentrons 96 Filter Tip Rack 200 \u00b5L\n* [NEST 1 Well Reservoir 195 mL #360103](http://www.cell-nest.com/page94?_l=en&product_id=102)\n* Opentrons 96 Filter Tip Rack 20 \u00b5L\n\n\n",

--- a/protoBuilds/00f7b1_part5/README.json
+++ b/protoBuilds/00f7b1_part5/README.json
@@ -1,7 +1,7 @@
 {
     "author": "Opentrons",
     "categories": {
-        "NGS LIBRARY PREP": [
+        "NGS Library Prep": [
             "NEBNext\u00ae Ultra\u2122 II Directional RNA Library Prep"
         ]
     },
@@ -11,8 +11,8 @@
     "labware": "\nArmadillo 96 Well Plate 200 \u00b5L PCR Full Skirt\nNEST 96 Deepwell Plate 2mL #503001\nOpentrons 96 Well Aluminum Block with Generic PCR Strip 200 \u00b5L\nOpentrons 96 Filter Tip Rack 200 \u00b5L\nNEST 1 Well Reservoir 195 mL #360103\nOpentrons 96 Filter Tip Rack 20 \u00b5L\n",
     "markdown": {
         "author": "[Opentrons](https://opentrons.com/)\n\n\n",
-        "categories": "* NGS LIBRARY PREP\n\t* NEBNext\u00ae Ultra\u2122 II Directional RNA Library Prep\n\n\n",
-        "deck-setup": "![deck](https://opentrons-protocol-library-website.s3.amazonaws.com/custom-README-images/00f7b1/Part+5/Screen+Shot+2022-10-25+at+3.47.13+PM.png)\n\n\n",
+        "categories": "* NGS Library Prep\n\t* NEBNext\u00ae Ultra\u2122 II Directional RNA Library Prep\n\n\n",
+        "deck-setup": "![deck](https://opentrons-protocol-library-website.s3.amazonaws.com/custom-README-images/00f7b1/Part+5/Screen+Shot+2022-10-27+at+10.48.22+AM.png)\n\n\n",
         "description": "This protocol is part 5 of a 10 part series. Please look at deck map and liquid legend below. Note: the TE buffer can accommodate 3 columns of sample per column of wash. Each ethanol column can accommodate 4 columns of sample. If running more than one column of reagent, the volumes should be split equally among all columns.\n\n\n",
         "internal": "00f7b1_part5\n",
         "labware": "* [Armadillo 96 Well Plate 200 \u00b5L PCR Full Skirt](https://labware.opentrons.com/armadillo_96_wellplate_200ul_pcr_full_skirt?category=wellPlate)\n* [NEST 96 Deepwell Plate 2mL #503001](http://www.cell-nest.com/page94?product_id=101&_l=en)\n* [Opentrons 96 Well Aluminum Block with Generic PCR Strip 200 \u00b5L](https://shop.opentrons.com/collections/hardware-modules/products/aluminum-block-set)\n* Opentrons 96 Filter Tip Rack 200 \u00b5L\n* [NEST 1 Well Reservoir 195 mL #360103](http://www.cell-nest.com/page94?_l=en&product_id=102)\n* Opentrons 96 Filter Tip Rack 20 \u00b5L\n\n\n",

--- a/protoBuilds/00f7b1_part8/README.json
+++ b/protoBuilds/00f7b1_part8/README.json
@@ -1,7 +1,7 @@
 {
     "author": "Opentrons",
     "categories": {
-        "NGS LIBRARY PREP": [
+        "NGS Library Prep": [
             "NEBNext\u00ae Ultra\u2122 II Directional RNA Library Prep"
         ]
     },
@@ -11,7 +11,7 @@
     "labware": "\nArmadillo 96 Well Plate 200 \u00b5L PCR Full Skirt\nNEST 96 Deepwell Plate 2mL #503001\nOpentrons 96 Well Aluminum Block with Generic PCR Strip 200 \u00b5L\nOpentrons 96 Filter Tip Rack 200 \u00b5L\nNEST 1 Well Reservoir 195 mL #360103\nOpentrons 96 Filter Tip Rack 20 \u00b5L\n",
     "markdown": {
         "author": "[Opentrons](https://opentrons.com/)\n\n\n",
-        "categories": "* NGS LIBRARY PREP\n\t* NEBNext\u00ae Ultra\u2122 II Directional RNA Library Prep\n\n\n",
+        "categories": "* NGS Library Prep\n\t* NEBNext\u00ae Ultra\u2122 II Directional RNA Library Prep\n\n\n",
         "deck-setup": "![deck](https://opentrons-protocol-library-website.s3.amazonaws.com/custom-README-images/00f7b1/Part+10/deck.png)\n\n\n",
         "description": "This protocol is part 8 of a 10 part series. Please look at deck map and liquid legend below. Note: the TE buffer can accommodate 3 columns of sample per column of wash. Each ethanol column can accommodate 4 columns of sample. If running more than one column of reagent, the volumes should be split equally among all columns.\n\n\n",
         "internal": "00f7b1_part10\n",

--- a/protocols/00f7b1_part10/00f7b1_part10.ot2.apiv2.py
+++ b/protocols/00f7b1_part10/00f7b1_part10.ot2.apiv2.py
@@ -92,9 +92,9 @@ def run(ctx: protocol_api.ProtocolContext):
     # load tipracks
 
     tips300 = [ctx.load_labware('opentrons_96_filtertiprack_200ul', slot)
-               for slot in ['7', '10']]
+               for slot in ['10', '7', '6']]
     tips20 = [ctx.load_labware('opentrons_96_filtertiprack_20ul', slot)
-              for slot in ['11']]
+              for slot in ['11', '8']]
     # load instrument
 
     m300 = ctx.load_instrument(

--- a/protocols/00f7b1_part10/README.md
+++ b/protocols/00f7b1_part10/README.md
@@ -6,7 +6,7 @@
 
 
 ## Categories
-* NGS LIBRARY PREP
+* NGS Library Prep
 	* NEBNext® Ultra™ II Directional RNA Library Prep
 
 

--- a/protocols/00f7b1_part2/README.md
+++ b/protocols/00f7b1_part2/README.md
@@ -6,7 +6,7 @@
 
 
 ## Categories
-* NGS LIBRARY PREP
+* NGS Library Prep
 	* NEBNext® Ultra™ II Directional RNA Library Prep
 
 
@@ -34,7 +34,7 @@ This protocol is part 2 of a 10 part series. Please look at deck map and liquid 
 
 
 ### Deck Setup
-![deck](https://opentrons-protocol-library-website.s3.amazonaws.com/custom-README-images/00f7b1/Part+2/Screen+Shot+2022-10-25+at+10.39.41+AM.png)
+![deck](https://opentrons-protocol-library-website.s3.amazonaws.com/custom-README-images/00f7b1/Part+2/new+deck.png)
 
 
 ### Reagent Setup

--- a/protocols/00f7b1_part5/00f7b1_part5.ot2.apiv2.py
+++ b/protocols/00f7b1_part5/00f7b1_part5.ot2.apiv2.py
@@ -16,8 +16,6 @@ metadata = {
 }
 
 # Definitions for deck light flashing
-
-
 class CancellationToken:
     """FLASH SETUP."""
 
@@ -80,7 +78,6 @@ def run(ctx: protocol_api.ProtocolContext):
     # load modules
     mag_deck = ctx.load_module('magnetic module gen2', '1')
     temp_deck = ctx.load_module('temperature module gen2', '3')
-    print(num_columns)
 
     # load labware
     mag_plate = mag_deck.load_labware('nest_96_wellplate_2ml_deep')
@@ -90,12 +87,12 @@ def run(ctx: protocol_api.ProtocolContext):
     sample_plate = ctx.load_labware('thermofisher_96_wellplate_200ul', '5')
     final_plate = ctx.load_labware('thermofisher_96_wellplate_200ul', '2')
     trash = ctx.load_labware('nest_1_reservoir_195ml', '9').wells()[0].top()
-    # load tipracks
 
+    # load tipracks
     tips300 = [ctx.load_labware('opentrons_96_filtertiprack_200ul', slot)
-               for slot in ['7', '10']]
+               for slot in ['10', '7', '6']]
     tips20 = [ctx.load_labware('opentrons_96_filtertiprack_20ul', slot)
-              for slot in ['11']]
+              for slot in ['11', '8']]
     # load instrument
 
     m300 = ctx.load_instrument(
@@ -103,7 +100,6 @@ def run(ctx: protocol_api.ProtocolContext):
 
     m20 = ctx.load_instrument('p20_multi_gen2', m20_mount, tip_racks=tips20)
 
-    # pipette functions   # INCLUDE ANY BINDING TO CLASS
     # reagents
     samples_start = sample_plate.rows()[0][:num_columns]
     samples_mag = mag_plate.rows()[0][:num_columns]

--- a/protocols/00f7b1_part5/README.md
+++ b/protocols/00f7b1_part5/README.md
@@ -6,7 +6,7 @@
 
 
 ## Categories
-* NGS LIBRARY PREP
+* NGS Library Prep
 	* NEBNext® Ultra™ II Directional RNA Library Prep
 
 
@@ -34,7 +34,7 @@ This protocol is part 5 of a 10 part series. Please look at deck map and liquid 
 
 
 ### Deck Setup
-![deck](https://opentrons-protocol-library-website.s3.amazonaws.com/custom-README-images/00f7b1/Part+5/Screen+Shot+2022-10-25+at+3.47.13+PM.png)
+![deck](https://opentrons-protocol-library-website.s3.amazonaws.com/custom-README-images/00f7b1/Part+5/Screen+Shot+2022-10-27+at+10.48.22+AM.png)
 
 
 ### Reagent Setup

--- a/protocols/00f7b1_part8/00f7b1_part8.ot2.apiv2.py
+++ b/protocols/00f7b1_part8/00f7b1_part8.ot2.apiv2.py
@@ -97,9 +97,9 @@ def run(ctx: protocol_api.ProtocolContext):
     # load tipracks
 
     tips300 = [ctx.load_labware('opentrons_96_filtertiprack_200ul', slot)
-               for slot in ['7', '10']]
+               for slot in ['10', '7', '6']]
     tips20 = [ctx.load_labware('opentrons_96_filtertiprack_20ul', slot)
-              for slot in ['11']]
+              for slot in ['11', '8']]
     # load instrument
 
     m300 = ctx.load_instrument(

--- a/protocols/00f7b1_part8/README.md
+++ b/protocols/00f7b1_part8/README.md
@@ -6,7 +6,7 @@
 
 
 ## Categories
-* NGS LIBRARY PREP
+* NGS Library Prep
 	* NEBNext® Ultra™ II Directional RNA Library Prep
 
 


### PR DESCRIPTION
## overview

this PR adjusts multiple optimizations for the extraction sections of the NEBNEXT protocols. See below. 

## changelog

#### mm/dd/yyyy
- add tip boxes to all protocols
- change readme category
- change order of bead mixing so that all aspirations and dispenses happen first, then mixes
- change order of remove supernatant so that all aspirations and dispenses happen first with m300, then all aspirations with m20, instead of m300-m20 repeat

