### PR TITLE
0f7910

### DIFF
--- a/data/data/fields.csv
+++ b/data/data/fields.csv
@@ -254,7 +254,7 @@ csv_file_1,1
 csv_file_2,1
 csv_input,3
 csv_oil,1
-csv_samp,9
+csv_samp,10
 csv_samp1,1
 csv_samp2,1
 csv_samp3,1
@@ -290,6 +290,7 @@ denat_anneal_cycles,1
 desired_conc,2
 dest_flow_rate_mmx,1
 dest_flow_rate_sample,1
+dest_format,1
 dest_labware,1
 dest_lw,1
 dest_lw_def,1
@@ -896,7 +897,7 @@ p1kmnt,1
 p1n,1
 p1num,1
 p20_blowout_height,1
-p20_mount,111
+p20_mount,112
 p20_multi_mount,3
 p20_rate,2
 p20_reservoir_height,1
@@ -913,7 +914,7 @@ p2num,1
 p300_gen,1
 p300_mixing_height,1
 p300_mnt,3
-p300_mount,133
+p300_mount,134
 p300_mount_1,1
 p300_multi_mount,7
 p300_rate,1
@@ -1230,6 +1231,7 @@ source_csv_slot3,1
 source_csv_slot7,1
 source_csv_slot8,1
 source_csv_slot9,1
+source_format,1
 source_lw,1
 source_plate,2
 source_plate_type,1
@@ -1266,6 +1268,7 @@ starting_conc,2
 starting_diluent_vol,1
 starting_plasma_vol,1
 starting_position,1
+starting_tip,1
 starting_tip_col,2
 starting_tip_position,1
 starting_tip_well,1
@@ -1405,7 +1408,7 @@ transfer2,1
 transfer_csv,20
 transfer_scheme,2
 transfer_to_storage,1
-transfer_vol,9
+transfer_vol,10
 transfer_volume,3
 transfercsv,2
 transfervol,1

--- a/protoBuilds/0f7910/0f7910.ot2.apiv2.py.json
+++ b/protoBuilds/0f7910/0f7910.ot2.apiv2.py.json
@@ -1,0 +1,159 @@
+{
+    "content": "from opentrons import protocol_api\n\nmetadata = {\n    'protocolName': 'Plate Filling with CSV Import',\n    'author': 'Rami Farawi <rami.farawi@opentrons.com>',\n    'source': 'Custom Protocol Request',\n    'apiLevel': '2.11'\n}\n\n\ndef run(ctx):\n\n    [csv_samp,\n     source_format,\n     dest_format,\n     transfer_vol,\n     starting_tip,\n     p300_mount,\n     p20_mount] = get_values(  # noqa: F821\n        \"csv_samp\",\n        \"source_format\",\n        \"dest_format\",\n        \"transfer_vol\",\n        \"starting_tip\",\n        \"p300_mount\",\n        \"p20_mount\")\n\n    starting_tip -= starting_tip\n\n    # labware\n    source_plates = [ctx.load_labware(\n                     'corning_96_wellplate_360ul_flat'\n                     if source_format == \"384\"\n                     else \"corning_384_wellplate_112ul_flat\", slot)\n                     for slot in [3, 4, 5, 6, 7, 8, 9]]\n    source_plates = source_plates\n\n    dest_plate = ctx.load_labware(\n                     'corning_96_wellplate_360ul_flat'\n                     if dest_format == \"384\"\n                     else \"corning_384_wellplate_112ul_flat\", 1\n                     if dest_format == \"384\"\n                     else 2)\n\n    if transfer_vol > 20:\n        tips300 = [ctx.load_labware('opentrons_96_tiprack_300ul', slot)\n                   for slot in [10]]\n    else:\n        tips20 = [ctx.load_labware('opentrons_96_tiprack_20ul', slot)\n                  for slot in [11]]\n\n    # pipettes\n    if transfer_vol > 20:\n        p300 = ctx.load_instrument('p300_single_gen2', p300_mount,\n                                   tip_racks=tips300)\n\n    else:\n        p20 = ctx.load_instrument('p20_single_gen2', p20_mount,\n                                  tip_racks=tips20)\n\n    def pick_up(pip):\n        try:\n            pip.pick_up_tip()\n        except protocol_api.labware.OutOfTipsError:\n            ctx.pause(\"Replace empty tip racks.\")\n            pip.reset_tipracks()\n            pick_up(pip)\n\n    # mapping\n    csv_lines = [[val.strip() for val in line.split(',')]\n                 for line in csv_samp.splitlines()\n                 if line.split(',')[0].strip()][1:]\n\n    # protocol\n    pip = p20 if transfer_vol <= 20 else p300\n    pip.flow_rate.aspirate = 1\n    pip.flow_rate.dispense = 2\n    if transfer_vol > 20:\n        pip.starting_tip = tips300[0].wells()[starting_tip]\n    else:\n        pip.starting_tip = tips20[0].wells()[starting_tip]\n    for row in csv_lines:\n        source_plate_slot = int(row[1])\n        source_well_name = row[2]\n        dest_well_name = row[4]\n\n        source = ctx.loaded_labwares[source_plate_slot].wells_by_name()[source_well_name]  # noqa: E501\n        dest = dest_plate.wells_by_name()[dest_well_name]\n\n        pick_up(pip)\n        pip.transfer(transfer_vol, source.bottom(z=0.2), dest, new_tip='never',\n                     blow_out=True, blowout_location='destination well')\n        pip.drop_tip()\n",
+    "custom_labware_defs": [],
+    "fields": [
+        {
+            "default": "Source plate Barcode,Source plate location,Source well,Destination plate Barcode,Destination well\nDDDD,3,C1,ABCD,A1\nEEEE,3,A1,BBBD,B1",
+            "label": ".CSV File",
+            "name": "csv_samp",
+            "type": "textFile"
+        },
+        {
+            "label": "Source Plate Format",
+            "name": "source_format",
+            "options": [
+                {
+                    "label": "96",
+                    "value": "96"
+                },
+                {
+                    "label": "384",
+                    "value": "384"
+                }
+            ],
+            "type": "dropDown"
+        },
+        {
+            "label": "Destination Plate Format",
+            "name": "dest_format",
+            "options": [
+                {
+                    "label": "96",
+                    "value": "96"
+                },
+                {
+                    "label": "384",
+                    "value": "384"
+                }
+            ],
+            "type": "dropDown"
+        },
+        {
+            "default": 12,
+            "label": "Transfer Volume",
+            "name": "transfer_vol",
+            "type": "int"
+        },
+        {
+            "default": 1,
+            "label": "Starting Tip in Tip Rack (1-96, by column)",
+            "name": "starting_tip",
+            "type": "int"
+        },
+        {
+            "label": "P20 Single-Channel Mount",
+            "name": "p20_mount",
+            "options": [
+                {
+                    "label": "Left",
+                    "value": "left"
+                },
+                {
+                    "label": "Right",
+                    "value": "right"
+                }
+            ],
+            "type": "dropDown"
+        },
+        {
+            "label": "P300 Single-Channel Mount",
+            "name": "p300_mount",
+            "options": [
+                {
+                    "label": "Right",
+                    "value": "right"
+                },
+                {
+                    "label": "Left",
+                    "value": "left"
+                }
+            ],
+            "type": "dropDown"
+        }
+    ],
+    "instruments": [
+        {
+            "mount": "left",
+            "name": "p20_single_gen2"
+        }
+    ],
+    "labware": [
+        {
+            "name": "Corning 384 Well Plate 112 \u00b5L Flat on 2",
+            "share": false,
+            "slot": "2",
+            "type": "corning_384_wellplate_112ul_flat"
+        },
+        {
+            "name": "Corning 384 Well Plate 112 \u00b5L Flat on 3",
+            "share": false,
+            "slot": "3",
+            "type": "corning_384_wellplate_112ul_flat"
+        },
+        {
+            "name": "Corning 384 Well Plate 112 \u00b5L Flat on 4",
+            "share": false,
+            "slot": "4",
+            "type": "corning_384_wellplate_112ul_flat"
+        },
+        {
+            "name": "Corning 384 Well Plate 112 \u00b5L Flat on 5",
+            "share": false,
+            "slot": "5",
+            "type": "corning_384_wellplate_112ul_flat"
+        },
+        {
+            "name": "Corning 384 Well Plate 112 \u00b5L Flat on 6",
+            "share": false,
+            "slot": "6",
+            "type": "corning_384_wellplate_112ul_flat"
+        },
+        {
+            "name": "Corning 384 Well Plate 112 \u00b5L Flat on 7",
+            "share": false,
+            "slot": "7",
+            "type": "corning_384_wellplate_112ul_flat"
+        },
+        {
+            "name": "Corning 384 Well Plate 112 \u00b5L Flat on 8",
+            "share": false,
+            "slot": "8",
+            "type": "corning_384_wellplate_112ul_flat"
+        },
+        {
+            "name": "Corning 384 Well Plate 112 \u00b5L Flat on 9",
+            "share": false,
+            "slot": "9",
+            "type": "corning_384_wellplate_112ul_flat"
+        },
+        {
+            "name": "Opentrons 96 Tip Rack 20 \u00b5L on 11",
+            "share": false,
+            "slot": "11",
+            "type": "opentrons_96_tiprack_20ul"
+        },
+        {
+            "name": "Opentrons Fixed Trash on 12",
+            "share": false,
+            "slot": "12",
+            "type": "opentrons_1_trash_1100ml_fixed"
+        }
+    ],
+    "metadata": {
+        "apiLevel": "2.11",
+        "author": "Rami Farawi <rami.farawi@opentrons.com>",
+        "protocolName": "Plate Filling with CSV Import",
+        "source": "Custom Protocol Request"
+    },
+    "modules": []
+}

--- a/protoBuilds/0f7910/README.json
+++ b/protoBuilds/0f7910/README.json
@@ -1,32 +1,30 @@
 {
     "author": "Opentrons",
     "categories": {
-        "Broad Category": [
-            "Specific Category"
+        "Sample Prep": [
+            "Plate Filling"
         ]
     },
     "deck-setup": "",
-    "description": "This protocol does stuff!",
+    "description": "Select the format for the source and destination plates. See diagram below. If a 384 plate is selected for destination plate, it should always be in slot 2. If a 96 plate is selected for destination, it should always be in slot 1. Source plates always start from slot 3 to 9, and tip racks are always the same. You can select which tip the protocol will start on in the fields below. If the global transfer volume is over 20ul, then the P300 will be used. If the transfer volume is 20 or less, the P20 will be used. A value of \"8\" for the starting position of the tip would mean to start H1 of the tip rack, and a value of 10 would mean to start at B2 of the tip rack, since it iterates down by column. The csv should be formatted as such in the header:\nSource plate barcode, Source plate slot (3-9), Source well (A1, B1, etc.), Destination plate barcode, Destination well",
     "internal": "0f7910",
-    "labware": "\nCorning 384 Well Plate 112 \u00b5L Flat #3640\nOpentrons 96 Tip Rack 20 \u00b5L\n",
+    "labware": "\nCorning 384 Well Plate 112 \u00b5L Flat\nCorning 96 Well Plate 360 \u00b5L\nOpentrons 96 Tip Rack 20 \u00b5L\nOpentrons 96 Tip Rack 300 \u00b5L\n",
     "markdown": {
         "author": "[Opentrons](https://opentrons.com/)\n\n\n",
-        "categories": "* Broad Category\n\t* Specific Category\n\n\n",
-        "deck-setup": "![deck](https://opentrons-protocol-library-website.s3.amazonaws.com/custom-README-images/0f7910/deck.png)\n\n\n",
-        "description": "This protocol does stuff!\n\n\n",
+        "categories": "* Sample Prep\n\t* Plate Filling\n\n\n",
+        "deck-setup": "![deck](https://opentrons-protocol-library-website.s3.amazonaws.com/custom-README-images/0f7910/Screen+Shot+2022-12-13+at+4.21.58+PM.png)\n\n\n",
+        "description": "Select the format for the source and destination plates. See diagram below. If a 384 plate is selected for destination plate, it should always be in slot 2. If a 96 plate is selected for destination, it should always be in slot 1. Source plates always start from slot 3 to 9, and tip racks are always the same. You can select which tip the protocol will start on in the fields below. If the global transfer volume is over 20ul, then the P300 will be used. If the transfer volume is 20 or less, the P20 will be used. A value of \"8\" for the starting position of the tip would mean to start H1 of the tip rack, and a value of 10 would mean to start at B2 of the tip rack, since it iterates down by column. The csv should be formatted as such in the header:\n\n```\nSource plate barcode, Source plate slot (3-9), Source well (A1, B1, etc.), Destination plate barcode, Destination well\n```\n\n\n",
         "internal": "0f7910\n",
-        "labware": "* [Corning 384 Well Plate 112 \u00b5L Flat #3640](https://ecatalog.corning.com/life-sciences/b2c/US/en/Microplates/Assay-Microplates/384-Well-Microplates/Corning%C2%AE-384-well-Clear-Polystyrene-Microplates/p/corning384WellClearPolystyreneMicroplates)\n* [Opentrons 96 Tip Rack 20 \u00b5L](https://shop.opentrons.com/collections/opentrons-tips/products/opentrons-10ul-tips)\n\n\n",
+        "labware": "* Corning 384 Well Plate 112 \u00b5L Flat\n* Corning 96 Well Plate 360 \u00b5L\n* [Opentrons 96 Tip Rack 20 \u00b5L](https://shop.opentrons.com/collections/opentrons-tips/products/opentrons-10ul-tips)\n* [Opentrons 96 Tip Rack 300 \u00b5L](https://shop.opentrons.com/collections/opentrons-tips/products/opentrons-10ul-tips)\n\n\n",
         "notes": "If you have any questions about this protocol, please contact the Protocol Development Team by filling out the [Troubleshooting Survey](https://protocol-troubleshooting.paperform.co/).\n\n\n",
-        "pipettes": "* [Opentrons P20 Single Channel Electronic Pipette (GEN2)](https://shop.opentrons.com/single-channel-electronic-pipette-p20/)\n\n\n",
+        "pipettes": "* [Opentrons P20 Single Channel Electronic Pipette (GEN2)](https://shop.opentrons.com/single-channel-electronic-pipette-p20/)\n* [Opentrons P300 Single Channel Electronic Pipette (GEN2)](https://shop.opentrons.com/single-channel-electronic-pipette-p20/)\n\n\n",
         "process": "1. Input your protocol parameters above.\n2. Download your protocol and unzip if needed.\n3. Upload your custom labware to the [OT App](https://opentrons.com/ot-app) by navigating to `More` > `Custom Labware` > `Add Labware`, and selecting your labware files (.json extensions) if needed.\n4. Upload your protocol file (.py extension) to the [OT App](https://opentrons.com/ot-app) in the `Protocol` tab.\n5. Set up your deck according to the deck map.\n6. Calibrate your labware, tiprack and pipette using the OT App. For calibration tips, check out our [support articles](https://support.opentrons.com/en/collections/1559720-guide-for-getting-started-with-the-ot-2).\n7. Hit \"Run\".\n\n\n",
-        "protocol-steps": "1. Step 1...\n\n\n",
-        "reagent-setup": "![reagents](https://opentrons-protocol-library-website.s3.amazonaws.com/custom-README-images/0f7910/reagents.png)\n\n\n",
+        "protocol-steps": "1. Protocol will input the global transfer volume from source plates to destination plates according to the csv.\n\n\n",
         "title": "Plate Filling with CSV Import"
     },
     "notes": "If you have any questions about this protocol, please contact the Protocol Development Team by filling out the Troubleshooting Survey.",
-    "pipettes": "\nOpentrons P20 Single Channel Electronic Pipette (GEN2)\n",
+    "pipettes": "\nOpentrons P20 Single Channel Electronic Pipette (GEN2)\nOpentrons P300 Single Channel Electronic Pipette (GEN2)\n",
     "process": "\nInput your protocol parameters above.\nDownload your protocol and unzip if needed.\nUpload your custom labware to the OT App by navigating to More > Custom Labware > Add Labware, and selecting your labware files (.json extensions) if needed.\nUpload your protocol file (.py extension) to the OT App in the Protocol tab.\nSet up your deck according to the deck map.\nCalibrate your labware, tiprack and pipette using the OT App. For calibration tips, check out our support articles.\nHit \"Run\".\n",
-    "protocol-steps": "\nStep 1...\n",
-    "reagent-setup": "",
+    "protocol-steps": "\nProtocol will input the global transfer volume from source plates to destination plates according to the csv.\n",
     "title": "Plate Filling with CSV Import"
 }

--- a/protoBuilds/0f7910/README.json
+++ b/protoBuilds/0f7910/README.json
@@ -1,0 +1,32 @@
+{
+    "author": "Opentrons",
+    "categories": {
+        "Broad Category": [
+            "Specific Category"
+        ]
+    },
+    "deck-setup": "",
+    "description": "This protocol does stuff!",
+    "internal": "0f7910",
+    "labware": "\nCorning 384 Well Plate 112 \u00b5L Flat #3640\nOpentrons 96 Tip Rack 20 \u00b5L\n",
+    "markdown": {
+        "author": "[Opentrons](https://opentrons.com/)\n\n\n",
+        "categories": "* Broad Category\n\t* Specific Category\n\n\n",
+        "deck-setup": "![deck](https://opentrons-protocol-library-website.s3.amazonaws.com/custom-README-images/0f7910/deck.png)\n\n\n",
+        "description": "This protocol does stuff!\n\n\n",
+        "internal": "0f7910\n",
+        "labware": "* [Corning 384 Well Plate 112 \u00b5L Flat #3640](https://ecatalog.corning.com/life-sciences/b2c/US/en/Microplates/Assay-Microplates/384-Well-Microplates/Corning%C2%AE-384-well-Clear-Polystyrene-Microplates/p/corning384WellClearPolystyreneMicroplates)\n* [Opentrons 96 Tip Rack 20 \u00b5L](https://shop.opentrons.com/collections/opentrons-tips/products/opentrons-10ul-tips)\n\n\n",
+        "notes": "If you have any questions about this protocol, please contact the Protocol Development Team by filling out the [Troubleshooting Survey](https://protocol-troubleshooting.paperform.co/).\n\n\n",
+        "pipettes": "* [Opentrons P20 Single Channel Electronic Pipette (GEN2)](https://shop.opentrons.com/single-channel-electronic-pipette-p20/)\n\n\n",
+        "process": "1. Input your protocol parameters above.\n2. Download your protocol and unzip if needed.\n3. Upload your custom labware to the [OT App](https://opentrons.com/ot-app) by navigating to `More` > `Custom Labware` > `Add Labware`, and selecting your labware files (.json extensions) if needed.\n4. Upload your protocol file (.py extension) to the [OT App](https://opentrons.com/ot-app) in the `Protocol` tab.\n5. Set up your deck according to the deck map.\n6. Calibrate your labware, tiprack and pipette using the OT App. For calibration tips, check out our [support articles](https://support.opentrons.com/en/collections/1559720-guide-for-getting-started-with-the-ot-2).\n7. Hit \"Run\".\n\n\n",
+        "protocol-steps": "1. Step 1...\n\n\n",
+        "reagent-setup": "![reagents](https://opentrons-protocol-library-website.s3.amazonaws.com/custom-README-images/0f7910/reagents.png)\n\n\n",
+        "title": "Plate Filling with CSV Import"
+    },
+    "notes": "If you have any questions about this protocol, please contact the Protocol Development Team by filling out the Troubleshooting Survey.",
+    "pipettes": "\nOpentrons P20 Single Channel Electronic Pipette (GEN2)\n",
+    "process": "\nInput your protocol parameters above.\nDownload your protocol and unzip if needed.\nUpload your custom labware to the OT App by navigating to More > Custom Labware > Add Labware, and selecting your labware files (.json extensions) if needed.\nUpload your protocol file (.py extension) to the OT App in the Protocol tab.\nSet up your deck according to the deck map.\nCalibrate your labware, tiprack and pipette using the OT App. For calibration tips, check out our support articles.\nHit \"Run\".\n",
+    "protocol-steps": "\nStep 1...\n",
+    "reagent-setup": "",
+    "title": "Plate Filling with CSV Import"
+}

--- a/protoBuilds/0f7910/metadata.json
+++ b/protoBuilds/0f7910/metadata.json
@@ -1,0 +1,20 @@
+{
+    "files": {
+        "OT 1 protocol": [],
+        "OT 2 protocol": [
+            "0f7910.ot2.apiv2.py"
+        ],
+        "description": [
+            "README.md"
+        ]
+    },
+    "flags": {
+        "embedded-app": false,
+        "feature": false,
+        "hide-from-search": false,
+        "skip-tests": false
+    },
+    "path": "protocols/0f7910",
+    "slug": "0f7910",
+    "status": "ok"
+}

--- a/protocols/0f7910/0f7910.ot2.apiv2.py
+++ b/protocols/0f7910/0f7910.ot2.apiv2.py
@@ -1,0 +1,93 @@
+from opentrons import protocol_api
+
+metadata = {
+    'protocolName': 'Plate Filling with CSV Import',
+    'author': 'Rami Farawi <rami.farawi@opentrons.com>',
+    'source': 'Custom Protocol Request',
+    'apiLevel': '2.11'
+}
+
+
+def run(ctx):
+
+    [csv_samp,
+     source_format,
+     dest_format,
+     transfer_vol,
+     starting_tip,
+     p300_mount,
+     p20_mount] = get_values(  # noqa: F821
+        "csv_samp",
+        "source_format",
+        "dest_format",
+        "transfer_vol",
+        "starting_tip",
+        "p300_mount",
+        "p20_mount")
+
+    starting_tip -= starting_tip
+
+    # labware
+    source_plates = [ctx.load_labware(
+                     'corning_96_wellplate_360ul_flat'
+                     if source_format == "384"
+                     else "corning_384_wellplate_112ul_flat", slot)
+                     for slot in [3, 4, 5, 6, 7, 8, 9]]
+    source_plates = source_plates
+
+    dest_plate = ctx.load_labware(
+                     'corning_96_wellplate_360ul_flat'
+                     if dest_format == "384"
+                     else "corning_384_wellplate_112ul_flat", 1
+                     if dest_format == "384"
+                     else 2)
+
+    if transfer_vol > 20:
+        tips300 = [ctx.load_labware('opentrons_96_tiprack_300ul', slot)
+                   for slot in [10]]
+    else:
+        tips20 = [ctx.load_labware('opentrons_96_tiprack_20ul', slot)
+                  for slot in [11]]
+
+    # pipettes
+    if transfer_vol > 20:
+        p300 = ctx.load_instrument('p300_single_gen2', p300_mount,
+                                   tip_racks=tips300)
+
+    else:
+        p20 = ctx.load_instrument('p20_single_gen2', p20_mount,
+                                  tip_racks=tips20)
+
+    def pick_up(pip):
+        try:
+            pip.pick_up_tip()
+        except protocol_api.labware.OutOfTipsError:
+            ctx.pause("Replace empty tip racks.")
+            pip.reset_tipracks()
+            pick_up(pip)
+
+    # mapping
+    csv_lines = [[val.strip() for val in line.split(',')]
+                 for line in csv_samp.splitlines()
+                 if line.split(',')[0].strip()][1:]
+
+    # protocol
+    pip = p20 if transfer_vol <= 20 else p300
+    pip.flow_rate.aspirate = 1
+    pip.flow_rate.dispense = 2
+    if transfer_vol > 20:
+        pip.starting_tip = tips300[0].wells()[starting_tip]
+    else:
+        pip.starting_tip = tips20[0].wells()[starting_tip]
+    for row in csv_lines:
+        source_plate_slot = int(row[1])
+        source_well_name = row[2]
+        dest_well_name = row[4]
+
+        source = ctx.loaded_labwares[source_plate_slot].wells_by_name()[source_well_name]  # noqa: E501
+        dest = dest_plate.wells_by_name()[dest_well_name]
+
+        pick_up(pip)
+        pip.transfer(transfer_vol, source.bottom(z=0.2), dest, new_tip='never',
+                     blow_out=True, blowout_location='destination well')
+        pip.drop_tip()

--- a/protocols/0f7910/README.md
+++ b/protocols/0f7910/README.md
@@ -1,0 +1,53 @@
+# Plate Filling with CSV Import
+
+
+### Author
+[Opentrons](https://opentrons.com/)
+
+
+## Categories
+* Broad Category
+	* Specific Category
+
+
+## Description
+This protocol does stuff!
+
+
+### Labware
+* [Corning 384 Well Plate 112 µL Flat #3640](https://ecatalog.corning.com/life-sciences/b2c/US/en/Microplates/Assay-Microplates/384-Well-Microplates/Corning%C2%AE-384-well-Clear-Polystyrene-Microplates/p/corning384WellClearPolystyreneMicroplates)
+* [Opentrons 96 Tip Rack 20 µL](https://shop.opentrons.com/collections/opentrons-tips/products/opentrons-10ul-tips)
+
+
+### Pipettes
+* [Opentrons P20 Single Channel Electronic Pipette (GEN2)](https://shop.opentrons.com/single-channel-electronic-pipette-p20/)
+
+
+### Deck Setup
+![deck](https://opentrons-protocol-library-website.s3.amazonaws.com/custom-README-images/0f7910/deck.png)
+
+
+### Reagent Setup
+![reagents](https://opentrons-protocol-library-website.s3.amazonaws.com/custom-README-images/0f7910/reagents.png)
+
+
+### Protocol Steps
+1. Step 1...
+
+
+### Process
+1. Input your protocol parameters above.
+2. Download your protocol and unzip if needed.
+3. Upload your custom labware to the [OT App](https://opentrons.com/ot-app) by navigating to `More` > `Custom Labware` > `Add Labware`, and selecting your labware files (.json extensions) if needed.
+4. Upload your protocol file (.py extension) to the [OT App](https://opentrons.com/ot-app) in the `Protocol` tab.
+5. Set up your deck according to the deck map.
+6. Calibrate your labware, tiprack and pipette using the OT App. For calibration tips, check out our [support articles](https://support.opentrons.com/en/collections/1559720-guide-for-getting-started-with-the-ot-2).
+7. Hit "Run".
+
+
+### Additional Notes
+If you have any questions about this protocol, please contact the Protocol Development Team by filling out the [Troubleshooting Survey](https://protocol-troubleshooting.paperform.co/).
+
+
+###### Internal
+0f7910

--- a/protocols/0f7910/README.md
+++ b/protocols/0f7910/README.md
@@ -6,33 +6,36 @@
 
 
 ## Categories
-* Broad Category
-	* Specific Category
+* Sample Prep
+	* Plate Filling
 
 
 ## Description
-This protocol does stuff!
+Select the format for the source and destination plates. See diagram below. If a 384 plate is selected for destination plate, it should always be in slot 2. If a 96 plate is selected for destination, it should always be in slot 1. Source plates always start from slot 3 to 9, and tip racks are always the same. You can select which tip the protocol will start on in the fields below. If the global transfer volume is over 20ul, then the P300 will be used. If the transfer volume is 20 or less, the P20 will be used. A value of "8" for the starting position of the tip would mean to start H1 of the tip rack, and a value of 10 would mean to start at B2 of the tip rack, since it iterates down by column. The csv should be formatted as such in the header:
+
+```
+Source plate barcode, Source plate slot (3-9), Source well (A1, B1, etc.), Destination plate barcode, Destination well
+```
 
 
 ### Labware
-* [Corning 384 Well Plate 112 µL Flat #3640](https://ecatalog.corning.com/life-sciences/b2c/US/en/Microplates/Assay-Microplates/384-Well-Microplates/Corning%C2%AE-384-well-Clear-Polystyrene-Microplates/p/corning384WellClearPolystyreneMicroplates)
+* Corning 384 Well Plate 112 µL Flat
+* Corning 96 Well Plate 360 µL
 * [Opentrons 96 Tip Rack 20 µL](https://shop.opentrons.com/collections/opentrons-tips/products/opentrons-10ul-tips)
+* [Opentrons 96 Tip Rack 300 µL](https://shop.opentrons.com/collections/opentrons-tips/products/opentrons-10ul-tips)
 
 
 ### Pipettes
 * [Opentrons P20 Single Channel Electronic Pipette (GEN2)](https://shop.opentrons.com/single-channel-electronic-pipette-p20/)
+* [Opentrons P300 Single Channel Electronic Pipette (GEN2)](https://shop.opentrons.com/single-channel-electronic-pipette-p20/)
 
 
 ### Deck Setup
-![deck](https://opentrons-protocol-library-website.s3.amazonaws.com/custom-README-images/0f7910/deck.png)
-
-
-### Reagent Setup
-![reagents](https://opentrons-protocol-library-website.s3.amazonaws.com/custom-README-images/0f7910/reagents.png)
+![deck](https://opentrons-protocol-library-website.s3.amazonaws.com/custom-README-images/0f7910/Screen+Shot+2022-12-13+at+4.21.58+PM.png)
 
 
 ### Protocol Steps
-1. Step 1...
+1. Protocol will input the global transfer volume from source plates to destination plates according to the csv.
 
 
 ### Process

--- a/protocols/0f7910/fields.json
+++ b/protocols/0f7910/fields.json
@@ -1,0 +1,56 @@
+[
+  {
+    "type": "textFile",
+    "label": ".CSV File",
+    "name": "csv_samp",
+    "default": "Source plate Barcode,Source plate location,Source well,Destination plate Barcode,Destination well\nDDDD,3,C1,ABCD,A1\nEEEE,3,A1,BBBD,B1"
+  },
+  {
+    "type": "dropDown",
+    "label": "Source Plate Format",
+    "name": "source_format",
+    "options": [
+      {"label": "96", "value": "96"},
+      {"label": "384", "value": "384"}
+    ]
+  },
+  {
+    "type": "dropDown",
+    "label": "Destination Plate Format",
+    "name": "dest_format",
+    "options": [
+      {"label": "96", "value": "96"},
+      {"label": "384", "value": "384"}
+    ]
+  },
+  {
+    "type": "int",
+    "label": "Transfer Volume",
+    "name": "transfer_vol",
+    "default": 12
+  },
+  {
+    "type": "int",
+    "label": "Starting Tip in Tip Rack (1-96, by column)",
+    "name": "starting_tip",
+    "default": 1
+  },
+  {
+    "type": "dropDown",
+    "label": "P20 Single-Channel Mount",
+    "name": "p20_mount",
+    "options": [
+      {"label": "Left", "value": "left"},
+      {"label": "Right", "value": "right"}
+    ]
+  },
+  {
+    "type": "dropDown",
+    "label": "P300 Single-Channel Mount",
+    "name": "p300_mount",
+    "options": [
+      {"label": "Right", "value": "right"},
+      {"label": "Left", "value": "left"}
+    ]
+  }
+]


### PR DESCRIPTION
Select the format for the source and destination plates. See diagram below. If a 384 plate is selected for destination plate, it should always be in slot 2. If a 96 plate is selected for destination, it should always be in slot 1. Source plates always start from slot 3 to 9, and tip racks are always the same. You can select which tip the protocol will start on in the fields below. If the global transfer volume is over 20ul, then the P300 will be used. If the transfer volume is 20 or less, the P20 will be used. A value of "8" for the starting position of the tip would mean to start H1 of the tip rack, and a value of 10 would mean to start at B2 of the tip rack, since it iterates down by column. The csv should be formatted as such in the header: