### PR TITLE
fix(protocols/0fdc01): change mastermix strategy, expose mix reps

### DIFF
--- a/data/data/fields.csv
+++ b/data/data/fields.csv
@@ -1156,7 +1156,7 @@ reduced_speed_limit,1
 relative_height,1
 remove_empty_racks,1
 replenish_tips_manually,1
-reps_mix,1
+reps_mix,2
 res,2
 res12_type,1
 res1_type,1

--- a/protoBuilds/0fdc01/pcr.ot2.apiv2.py.json
+++ b/protoBuilds/0fdc01/pcr.ot2.apiv2.py.json
@@ -1,11 +1,17 @@
 {
-    "content": "import math\n\nmetadata = {\n    'protocolName': 'PCR Prep',\n    'author': 'Krishna <krishna.soma@opentrons.com>',\n    'apiLevel': '2.13'\n}\n\n\ndef run(ctx):\n\n    [num_plates] = get_values(  # noqa: F821\n        'num_plates')\n\n    # modules\n    tempdeck = ctx.load_module('temperature module gen2', '1')\n    tempdeck.set_temperature(4)\n\n    # labware\n    reservoir = tempdeck.load_labware('nest_12_reservoir_15ml')\n    plate_slots = ['5', '6']\n    pcr_plates = [\n        ctx.load_labware('opentrons_96_aluminumblock_generic_pcr_strip_200ul',\n                         slot)\n        for slot in plate_slots]\n    sample_plate = ctx.load_labware(\n        'opentrons_96_aluminumblock_generic_pcr_strip_200ul', '3',\n        'sample plate')\n\n    tiprack300 = [ctx.load_labware('opentrons_96_tiprack_300ul', '2')]\n    tiprack20 = [ctx.load_labware('opentrons_96_tiprack_20ul', '4')]\n\n    # pipettes\n    m300 = ctx.load_instrument(\n         'p300_multi_gen2', 'left', tip_racks=tiprack300)\n    m20 = ctx.load_instrument(\n         'p20_multi_gen2', 'right', tip_racks=tiprack20)\n\n    # variables\n    vol_mm = 23.0\n    vol_sample = 2.0\n\n    mm = reservoir.wells()[0]\n    sample_sources = sample_plate.rows()[0]\n\n    def slow_withdraw(well, delay_seconds=2.0, pip=m300):\n        pip.default_speed /= 16\n        if delay_seconds > 0:\n            ctx.delay(seconds=delay_seconds)\n        pip.move_to(well.top())\n        pip.default_speed *= 16\n\n    for n in range(num_plates):\n        pcr_plate = pcr_plates[n//2]\n        pcr_destinations = pcr_plate.rows()[0]\n\n        # add mastermix with the same tip\n        tip_vol_ref = m300.tip_racks[0].wells()[0].max_volume\n        num_asp = math.ceil(vol_mm*len(pcr_destinations)/tip_vol_ref)\n        max_dests_per_asp = int(math.floor(tip_vol_ref/vol_mm))\n        mm_dest_sets = [\n            pcr_destinations[i*max_dests_per_asp:(i+1)*max_dests_per_asp]\n            if i < num_asp - 1\n            else pcr_destinations[i*max_dests_per_asp:]\n            for i in range(num_asp)]\n        m300.pick_up_tip()\n        for d_set in mm_dest_sets:\n            m300.aspirate(vol_mm*len(d_set), mm.bottom(2))\n            slow_withdraw(mm)\n            for d in d_set:\n                m300.dispense(vol_mm, d.bottom(-2))\n                slow_withdraw(d)\n        m300.drop_tip()\n\n        # add sample with fresh tips each time, and mix (2x)\n        for s, d in zip(sample_sources, pcr_destinations):\n            m20.pick_up_tip()\n            m20.aspirate(vol_sample, s.bottom(-2))\n            slow_withdraw(s, pip=m20)\n            m20.dispense(vol_sample, d.bottom(-2))\n            m20.mix(2, 10, d.bottom(-1))\n            slow_withdraw(d, pip=m20)\n            m20.drop_tip()\n\n        m20.reset_tipracks()\n\n        if n < num_plates - 1:\n            ctx.pause(f'Replace 20ul tiprack. Refill mastermix. Replace \\\nEnsure clean PCR plate on slot {pcr_plates[(n+1)//2].parent} before resuming.')\n",
+    "content": "import math\n\nmetadata = {\n    'protocolName': 'PCR Prep',\n    'author': 'Krishna <krishna.soma@opentrons.com>',\n    'apiLevel': '2.13'\n}\n\n\ndef run(ctx):\n\n    [num_plates, reps_mix] = get_values(  # noqa: F821\n        'num_plates', 'reps_mix')\n\n    # modules\n    tempdeck = ctx.load_module('temperature module gen2', '1')\n    tempdeck.set_temperature(4)\n\n    # labware\n    reservoir = tempdeck.load_labware('nest_12_reservoir_15ml')\n    plate_slots = ['5', '6']\n    pcr_plates = [\n        ctx.load_labware('opentrons_96_aluminumblock_generic_pcr_strip_200ul',\n                         slot)\n        for slot in plate_slots]\n    sample_plate = ctx.load_labware(\n        'opentrons_96_aluminumblock_generic_pcr_strip_200ul', '3',\n        'sample plate')\n\n    tiprack300 = [ctx.load_labware('opentrons_96_filtertiprack_200ul', '2')]\n    tiprack20 = [ctx.load_labware('opentrons_96_filtertiprack_20ul', '4')]\n\n    # pipettes\n    m300 = ctx.load_instrument(\n         'p300_multi_gen2', 'left', tip_racks=tiprack300)\n    m20 = ctx.load_instrument(\n         'p20_multi_gen2', 'right', tip_racks=tiprack20)\n\n    # variables\n    vol_mm = 23.0\n    vol_sample = 2.0\n\n    mm = reservoir.wells()[:num_plates]\n    sample_sources = sample_plate.rows()[0]\n\n    def slow_withdraw(well, delay_seconds=1.0, pip=m300):\n        pip.default_speed /= 16\n        if delay_seconds > 0:\n            ctx.delay(seconds=delay_seconds)\n        pip.move_to(well.top())\n        pip.default_speed *= 16\n\n    for n in range(num_plates):\n        pcr_plate = pcr_plates[n//2]\n        pcr_destinations = pcr_plate.rows()[0]\n\n        # add mastermix with the same tip\n        tip_vol_ref = m300.tip_racks[0].wells()[0].max_volume\n        num_asp = math.ceil(vol_mm*len(pcr_destinations)/tip_vol_ref)\n        max_dests_per_asp = int(math.floor(tip_vol_ref/vol_mm))\n        mm_dest_sets = [\n            pcr_destinations[i*max_dests_per_asp:(i+1)*max_dests_per_asp]\n            if i < num_asp - 1\n            else pcr_destinations[i*max_dests_per_asp:]\n            for i in range(num_asp)]\n        m300.pick_up_tip()\n        for d_set in mm_dest_sets:\n            m300.aspirate(vol_mm*len(d_set), mm[n//2].bottom(2))\n            slow_withdraw(mm[n//2])\n            for d in d_set:\n                m300.dispense(vol_mm, d.bottom(-2))\n                slow_withdraw(d)\n        m300.drop_tip()\n\n        # add sample with fresh tips each time, and mix (2x)\n        for s, d in zip(sample_sources, pcr_destinations):\n            m20.pick_up_tip()\n            m20.aspirate(vol_sample, s.bottom(-2))\n            slow_withdraw(s, pip=m20)\n            m20.dispense(vol_sample, d.bottom(-2))\n            m20.mix(reps_mix, 10, d.bottom(-1))\n            slow_withdraw(d, pip=m20)\n            m20.drop_tip()\n\n        m20.reset_tipracks()\n\n        if n < num_plates - 1:\n            ctx.pause(f'Replace 20ul tiprack. Refill mastermix. \\\nEnsure clean PCR plate on slot {pcr_plates[(n+1)//2].parent} before resuming.')\n",
     "custom_labware_defs": [],
     "fields": [
         {
             "default": 4,
             "label": "number of PCR plates to prep",
             "name": "num_plates",
+            "type": "int"
+        },
+        {
+            "default": 3,
+            "label": "mixing repetitions",
+            "name": "reps_mix",
             "type": "int"
         }
     ],
@@ -27,10 +33,10 @@
             "type": "nest_12_reservoir_15ml"
         },
         {
-            "name": "Opentrons 96 Tip Rack 300 \u00b5L on 2",
+            "name": "Opentrons 96 Filter Tip Rack 200 \u00b5L on 2",
             "share": false,
             "slot": "2",
-            "type": "opentrons_96_tiprack_300ul"
+            "type": "opentrons_96_filtertiprack_200ul"
         },
         {
             "name": "sample plate on 3",
@@ -39,10 +45,10 @@
             "type": "opentrons_96_aluminumblock_generic_pcr_strip_200ul"
         },
         {
-            "name": "Opentrons 96 Tip Rack 20 \u00b5L on 4",
+            "name": "Opentrons 96 Filter Tip Rack 20 \u00b5L on 4",
             "share": false,
             "slot": "4",
-            "type": "opentrons_96_tiprack_20ul"
+            "type": "opentrons_96_filtertiprack_20ul"
         },
         {
             "name": "Opentrons 96 Well Aluminum Block with Generic PCR Strip 200 \u00b5L on 5",

--- a/protocols/0fdc01/fields.json
+++ b/protocols/0fdc01/fields.json
@@ -4,5 +4,11 @@
         "label": "number of PCR plates to prep",
         "name": "num_plates",
         "default": 4
+    },
+    {
+        "type": "int",
+        "label": "mixing repetitions",
+        "name": "reps_mix",
+        "default": 3
     }
 ]


### PR DESCRIPTION
## overview

this PR adds featrues/fixes to PCR prep protocol for 0fdc01

## changelog

#### 07/21/2023
- move reservoir channel periodically (1 channel / every 2 plates)
- expose mix reps parameter and set to 3x by default
- update protoBuilds