### PR TITLE
Fix if volume > 0, lower asp height for samples

### DIFF
--- a/protocols/08207f/08207f.ot2.apiv2.py
+++ b/protocols/08207f/08207f.ot2.apiv2.py
@@ -80,17 +80,18 @@ def run(ctx):
         dest_well = dest_plate.wells_by_name()[well]
         volume = float(row[7])
 
-        if volume > 20:
-            if not p300.has_tip:
-                p300.pick_up_tip()
-            p300.aspirate(volume, buffer.bottom(h_buff))
-            p300.dispense(volume, dest_well)
+        if volume > 0:
+            if volume > 20:
+                if not p300.has_tip:
+                    p300.pick_up_tip()
+                p300.aspirate(volume, buffer.bottom(h_buff))
+                p300.dispense(volume, dest_well)
 
-        else:
-            if not p20.has_tip:
-                p20.pick_up_tip()
-            p20.aspirate(volume, buffer.bottom(h_buff))
-            p20.dispense(volume, dest_well)
+            else:
+                if not p20.has_tip:
+                    p20.pick_up_tip()
+                p20.aspirate(volume, buffer.bottom(h_buff))
+                p20.dispense(volume, dest_well)
 
         adjust_height(volume)
 
@@ -108,19 +109,21 @@ def run(ctx):
 
         volume = float(row[6])
         mix_reps = 2
+        tip_height = 0.5
 
-        if volume > 20:
-            p300.pick_up_tip()
-            p300.aspirate(volume, source_well)
-            p300.dispense(volume, dest_well)
-            p300.mix(mix_reps, 20)
-            p300.blow_out()
-            p300.drop_tip()
+        if volume > 0:
+            if volume > 20:
+                p300.pick_up_tip()
+                p300.aspirate(volume, source_well.bottom(tip_height))
+                p300.dispense(volume, dest_well)
+                p300.mix(mix_reps, 20)
+                p300.blow_out()
+                p300.drop_tip()
 
-        else:
-            p20.pick_up_tip()
-            p20.aspirate(volume, source_well)
-            p20.dispense(volume, dest_well)
-            p20.mix(mix_reps, 10)
-            p20.blow_out()
-            p20.drop_tip()
+            else:
+                p20.pick_up_tip()
+                p20.aspirate(volume, source_well.bottom(tip_height))
+                p20.dispense(volume, dest_well)
+                p20.mix(mix_reps, 10)
+                p20.blow_out()
+                p20.drop_tip()


### PR DESCRIPTION
## overview

this PR does something in reference to protocol 08207f. closes #YYYY

## changelog

#### 09/21/2023
- Add code for "if volume >0:" so pipette max volume is not transferred for 0 value
- lower aspirate height from default to 0.5 mm from bottom of sample plate
- update protoBuilds
