### PR TITLE
Update 6d901d.ot2.apiv2.py

### DIFF
--- a/protocols/6d901d/6d901d.ot2.apiv2.py
+++ b/protocols/6d901d/6d901d.ot2.apiv2.py
@@ -1,4 +1,5 @@
 from opentrons import protocol_api
+from opentrons import types
 
 metadata = {
     'protocolName': 'Normalization with a multi-channel pipette \
@@ -69,9 +70,11 @@ def run(ctx: protocol_api.ProtocolContext):
     m300 = ctx.load_instrument('p300_multi_gen2', p300_mount)
     m20 = ctx.load_instrument('p20_multi_gen2', p20_mount)
 
+    mounted_on = {"left": types.Mount.LEFT, "right":types.Mount.RIGHT}
+
     pick_up_current = 0.15  # 150 mA for single tip
     ctx._hw_manager.hardware._attached_instruments[
-      m20._implementation.get_mount()].update_config_item(
+      mounted_on[m20.mount]].update_config_item(
       'pick_up_current', pick_up_current)
 
     tip300ctr = 95

--- a/protocols/6d901d/6d901d.ot2.apiv2.py
+++ b/protocols/6d901d/6d901d.ot2.apiv2.py
@@ -70,7 +70,7 @@ def run(ctx: protocol_api.ProtocolContext):
     m300 = ctx.load_instrument('p300_multi_gen2', p300_mount)
     m20 = ctx.load_instrument('p20_multi_gen2', p20_mount)
 
-    mounted_on = {"left": types.Mount.LEFT, "right":types.Mount.RIGHT}
+    mounted_on = {"left" : types.Mount.LEFT, "right" : types.Mount.RIGHT}
 
     pick_up_current = 0.15  # 150 mA for single tip
     ctx._hw_manager.hardware._attached_instruments[


### PR DESCRIPTION
fix deprecated function  hardware._implementation to find the correct mount type.

## overview

this PR does something in reference to protocol XXXXXX. closes #YYYY

## changelog

#### mm/dd/yyyy
- change 1
- change 2
- update protoBuilds
